### PR TITLE
Changing 'touched' state to reflect the common notion of 'touched'

### DIFF
--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -279,6 +279,11 @@ export default function useForm({
             ? updater(old.__fieldMeta[fieldID])
             : { ...old.__fieldMeta[fieldID], ...updater }
 
+        // If field has been blured, update form touched status
+        if (newFieldMeta.isTouched) {
+          apiRef.current.setMeta({ isTouched: true })
+        }
+
         return {
           ...old,
           // Any errors in fields should visually stop
@@ -297,11 +302,11 @@ export default function useForm({
         }
       })
     },
-    [setState]
+    [setState, apiRef]
   )
 
   const setFieldValue = React.useCallback(
-    (field, updater, { isTouched = true } = {}) => {
+    (field, updater, { isTouched = false } = {}) => {
       const fieldInstances = apiRef.current.__getFieldInstances(field)
 
       setState(old => {


### PR DESCRIPTION
@tannerlinsley want to get your thoughts on this. Generally, `touched` in other frameworks, libraries, etc. represents a field that has been focused/blurred. The `touched` state in `react-form` seems to represent `dirty`, but without the `touched` state, it's difficult to have a UX that needs to show validation on blur. Currently, with `touched` representing `dirty`, validation messaging will immediately populate as soon as a user types one character. For things like email fields this isn't great, as the user likely hasn't finished typing. I understand there is a concept of `debounce`, but I feel like that is solving something different.