### PR TITLE
fix: links from star badge to github

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -29,5 +29,5 @@ Feature/Capability Key:
 
 [bpl-tanstack-form]: https://bundlephobia.com/result?p=@tanstack/react-form
 [bp-tanstack-form]: https://badgen.net/bundlephobia/minzip/@tanstack/react-form?label=💾
-[gh-tanstack-form]: https://github.com/tannerlinsley/@tanstack/form
-[stars-tanstack-form]: https://img.shields.io/github/stars/@tanstack/form?label=%F0%9F%8C%9F
+[gh-tanstack-form]: https://github.com/TanStack/form
+[stars-tanstack-form]: https://img.shields.io/github/stars/TanStack/form?label=%F0%9F%8C%9F


### PR DESCRIPTION
When browsing the [Comparision page](https://tanstack.com/form/latest/docs/comparison) I noticed the badge link to GitHub and the image URL were incorrect:

<img width="825" alt="Screenshot 2023-04-28 at 22 13 50" src="https://user-images.githubusercontent.com/12116098/235255636-d9f229fa-e5f3-42fd-ba25-f3517d25b4bf.png">

This PR fixes it by changing `tannerlinsley/@tanstack` and `@tanstack` to `TanStack`.