### PR TITLE
docs: remove form.Form in docs

### DIFF
--- a/docs/framework/react/quick-start.md
+++ b/docs/framework/react/quick-start.md
@@ -27,17 +27,19 @@ export default function App() {
 
   return (
     <div>
-      <form {...form.getFormProps()}>
-        <div>
-          <form.Field
-            name="fullName"
-            children={(field) => (
-              <input name={field.name} {...field.getInputProps()} />
-            )}
-          />
-        </div>
-        <button type="submit">Submit</button>
-      </form>
+      <form.Provider>
+        <form {...form.getFormProps()}>
+          <div>
+            <form.Field
+              name="fullName"
+              children={(field) => (
+                <input name={field.name} {...field.getInputProps()} />
+              )}
+            />
+          </div>
+          <button type="submit">Submit</button>
+        </form>
+      <form.Provider>
     </div>
   )
 }

--- a/docs/framework/react/quick-start.md
+++ b/docs/framework/react/quick-start.md
@@ -27,7 +27,7 @@ export default function App() {
 
   return (
     <div>
-      <form.Form>
+      <form {...form.getFormProps()}>
         <div>
           <form.Field
             name="fullName"
@@ -37,7 +37,7 @@ export default function App() {
           />
         </div>
         <button type="submit">Submit</button>
-      </form.Form>
+      </form>
     </div>
   )
 }


### PR DESCRIPTION
Change `form.Form` in quickstart guide to `{...form.getFormProps()}` after the [latest release](https://github.com/TanStack/form/releases/tag/v0.0.10).