### PR TITLE
fix several type  and build errors and fix example type inference

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -30,10 +30,15 @@ module.exports = {
         ].replace(/^[^0-9]*/, ''),
       },
     ],
+    ['@babel/plugin-proposal-class-properties', { loose: false }],
   ].filter(Boolean),
   overrides: [
     {
-      exclude: ['./packages/solid-form/**', './packages/svelte-form/**', './packages/vue-form/**'],
+      exclude: [
+        './packages/solid-form/**',
+        './packages/svelte-form/**',
+        './packages/vue-form/**',
+      ],
       presets: ['@babel/react'],
     },
     {

--- a/docs/reference/fieldApi.md
+++ b/docs/reference/fieldApi.md
@@ -205,7 +205,7 @@ An object type representing the state of a field.
 An object type representing the change and blur event handlers for a field.
 
 - ```tsx
-  onChange?: (updater: Updater<TData>) => void
+  onChange?: (value: TData) => void
   ```
   - An optional function to further handle the change event.
 - ```tsx
@@ -235,7 +235,7 @@ An object type representing the change and blur event handlers for a field.
   ```
   - The current value of the field.
 - ```tsx
-  onChange: (updater: Updater<TData>) => void
+  onChange: (value: TData) => void
   ```
   - A function to handle the change event.
 - ```tsx

--- a/examples/react/simple/src/index.tsx
+++ b/examples/react/simple/src/index.tsx
@@ -181,12 +181,16 @@ export default function App() {
             />
           </div> */}
           <form.Subscribe
-            selector={(state) => [state.canSubmit, state.isSubmitting]}
-            children={([canSubmit, isSubmitting]) => (
-              <button type="submit" disabled={!canSubmit}>
-                {isSubmitting ? "..." : "Submit"}
-              </button>
-            )}
+            {...{
+              // TS bug - inference isn't working with props, so use object
+              selector: (state) =>
+                [state.canSubmit, state.isSubmitting] as const,
+              children: ([canSubmit, isSubmitting]) => (
+                <button type="submit" disabled={!canSubmit}>
+                  {isSubmitting ? "..." : "Submit"}
+                </button>
+              ),
+            }}
           />
         </form>
       </form.Provider>

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -58,7 +58,7 @@ export type UserInputProps = {
 
 export type ChangeProps<TData> = {
   value: TData
-  onChange: (updater: Updater<TData>) => void
+  onChange: (value: TData) => void
   onBlur: (event: any) => void
 }
 

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -209,7 +209,7 @@ export class FormApi<TFormData> {
     return Promise.all(fieldValidationPromises)
   }
 
-  validateForm = async () => {}
+  // validateForm = async () => {}
 
   handleSubmit = async (e: FormSubmitEvent) => {
     e.preventDefault()
@@ -248,7 +248,7 @@ export class FormApi<TFormData> {
     }
 
     // Run validation for the form
-    await this.validateForm()
+    // await this.validateForm()
 
     if (!this.state.isValid) {
       done()

--- a/packages/react-form/src/useField.tsx
+++ b/packages/react-form/src/useField.tsx
@@ -57,7 +57,7 @@ export function useField<TData, TFormData>(
   fieldApi.update({ ...opts, form: formApi })
 
   useStore(
-    fieldApi.store,
+    fieldApi.store as any,
     opts.mode === 'array'
       ? (state: any) => {
           return [state.meta, Object.keys(state.value || []).length]

--- a/packages/react-form/src/useForm.tsx
+++ b/packages/react-form/src/useForm.tsx
@@ -57,7 +57,7 @@ export function useForm<TData>(opts?: FormOptions<TData>): FormApi<TData> {
       selector,
     ) => {
       // eslint-disable-next-line react-hooks/rules-of-hooks
-      return useStore(api.store, selector) as any
+      return useStore(api.store as any, selector as any) as any
     }
     api.Subscribe = (
       // @ts-ignore
@@ -66,7 +66,7 @@ export function useForm<TData>(opts?: FormOptions<TData>): FormApi<TData> {
       return functionalUpdate(
         props.children,
         // eslint-disable-next-line react-hooks/rules-of-hooks
-        useStore(api.store, props.selector),
+        useStore(api.store as any, props.selector as any),
       ) as any
     }
 


### PR DESCRIPTION
- Fix type of `ChangeProps.onChange`
- Fix basic react example `<form.Subscribe>` to get type inference working
- Fix build error by removing unused `validateForm()` method
- Fix the build by adding a few `as any` on react-store errors that I don't understand
- Fix the below `pnpm test:build` error by adding `['@babel/plugin-proposal-class-properties', { loose: false }]` to the babel config
```
[!] Error: Private field '#prevState' must be declared in an enclosing class (Note that you need plugins to import files that are not JavaScript)
packages/form-core/src/FieldApi.ts (116:35)
114:             : undefined
115: 
116:           if (state.value !== this.#prevState.value) {
                                        ^
117:             this.validate('change', state.value)
118:           }
Error: Private field '#prevState' must be declared in an enclosing class (Note that you need plugins to import files that are not JavaScript)
    at error (/home/runner/work/form/form/node_modules/.pnpm/rollup@2.[78](https://github.com/TanStack/form/actions/runs/5260366012/jobs/9507176611?pr=399#step:6:79).1/node_modules/rollup/dist/shared/rollup.js:198:30)
    at Module.error (/home/runner/work/form/form/node_modules/.pnpm/rollup@2.78.1/node_modules/rollup/dist/shared/rollup.js:12560:16)
    at Module.tryParse (/home/runner/work/form/form/node_modules/.pnpm/rollup@2.78.1/node_modules/rollup/dist/shared/rollup.js:12937:25)
    at Module.setSource (/home/runner/work/form/form/node_modules/.pnpm/rollup@2.78.1/node_modules/rollup/dist/shared/rollup.js:12[84](https://github.com/TanStack/form/actions/runs/5260366012/jobs/9507176611?pr=399#step:6:85)2:24)
    at ModuleLoader.addModuleSource (/home/runner/work/form/form/node_modules/.pnpm/rollup@2.78.1/node_modules/rollup/dist/shared/rollup.js:22284:20)
```