### PR TITLE
Fix minor FormApi bugs and add initial form API tests

### DIFF
--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -164,23 +164,27 @@ export class FormApi<TFormData> {
     if (!options) return
 
     this.store.batch(() => {
-      if (
-        options.defaultState &&
+      const shouldUpdateValues =
+        options.defaultValues &&
+        options.defaultValues !== this.options.defaultValues
+
+      const shouldUpdateState =
         options.defaultState !== this.options.defaultState
-      ) {
-        this.store.setState((prev) => ({
-          ...prev,
-          ...options.defaultState,
-        }))
+
+      if (!shouldUpdateValues || !shouldUpdateValues) {
+        return
       }
 
-      if (options.defaultValues !== this.options.defaultValues) {
-        this.store.setState(() =>
-          getDefaultFormState({
-            values: options.defaultValues,
-          }),
-        )
-      }
+      this.store.setState(() =>
+        getDefaultFormState({
+          ...(shouldUpdateState ? options.defaultState : {}),
+          ...(shouldUpdateValues
+            ? {
+                values: options.defaultValues,
+              }
+            : {}),
+        }),
+      )
     })
 
     this.options = options

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -344,7 +344,7 @@ export class FormApi<TFormData> {
 
   pushFieldValue = <TField extends DeepKeys<TFormData>>(
     field: TField,
-    value: DeepValue<TFormData, TField>,
+    value: DeepValue<TFormData, TField>[number],
     opts?: { touch?: boolean },
   ) => {
     return this.setFieldValue(
@@ -357,7 +357,7 @@ export class FormApi<TFormData> {
   insertFieldValue = <TField extends DeepKeys<TFormData>>(
     field: TField,
     index: number,
-    value: DeepValue<TFormData, TField>,
+    value: DeepValue<TFormData, TField>[number],
     opts?: { touch?: boolean },
   ) => {
     this.setFieldValue(

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -175,7 +175,11 @@ export class FormApi<TFormData> {
       }
 
       if (options.defaultValues !== this.options.defaultValues) {
-        this.store.setState(() => getDefaultFormState(options.defaultValues!))
+        this.store.setState(() =>
+          getDefaultFormState({
+            values: options.defaultValues,
+          }),
+        )
       }
     })
 

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -194,7 +194,13 @@ export class FormApi<TFormData> {
   }
 
   reset = () =>
-    this.store.setState(() => getDefaultFormState(this.options.defaultValues!))
+    this.store.setState(() =>
+      getDefaultFormState({
+        ...this.options?.defaultState,
+        values:
+          this.options?.defaultValues ?? this.options?.defaultState?.values,
+      }),
+    )
 
   validateAllFields = async (cause: ValidationCause) => {
     const fieldValidationPromises: Promise<ValidationError>[] = [] as any

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -395,7 +395,7 @@ export class FormApi<TFormData> {
     this.setFieldValue(field, (prev: any) => {
       const prev1 = prev[index1]!
       const prev2 = prev[index2]!
-      return setBy(setBy(prev, [index1], prev2), [index2], prev1)
+      return setBy(setBy(prev, `${index1}`, prev2), `${index2}`, prev1)
     })
   }
 }

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -176,14 +176,17 @@ export class FormApi<TFormData> {
       }
 
       this.store.setState(() =>
-        getDefaultFormState({
-          ...(shouldUpdateState ? options.defaultState : {}),
-          ...(shouldUpdateValues
-            ? {
-                values: options.defaultValues,
-              }
-            : {}),
-        }),
+        getDefaultFormState(
+          Object.assign(
+            {},
+            shouldUpdateState ? options.defaultState : {},
+            shouldUpdateValues
+              ? {
+                  values: options.defaultValues,
+                }
+              : {},
+          ),
+        ),
       )
     })
 

--- a/packages/form-core/src/tests/FormApi.spec.tsx
+++ b/packages/form-core/src/tests/FormApi.spec.tsx
@@ -54,7 +54,7 @@ describe('form api', () => {
   it('should get default form state when default state is passed', () => {
     const form = new FormApi({
       defaultState: {
-        submissionAttempts: 30
+        submissionAttempts: 30,
       },
     })
 
@@ -72,6 +72,42 @@ describe('form api', () => {
       isValid: true,
       isValidating: false,
       submissionAttempts: 30,
+      formValidationCount: 0,
+    })
+  })
+
+  it('should handle updating form state', () => {
+    const form = new FormApi({
+      defaultValues: {
+        name: 'test',
+      },
+    })
+
+    form.update({
+      defaultValues: {
+        name: 'other',
+      },
+      defaultState: {
+        submissionAttempts: 300,
+      },
+    })
+
+    expect(form.state).toEqual({
+      values: {
+        name: 'other',
+      },
+      fieldMeta: {},
+      canSubmit: true,
+      isFieldsValid: true,
+      isFieldsValidating: false,
+      isFormValid: true,
+      isFormValidating: false,
+      isSubmitted: false,
+      isSubmitting: false,
+      isTouched: false,
+      isValid: true,
+      isValidating: false,
+      submissionAttempts: 300,
       formValidationCount: 0,
     })
   })

--- a/packages/form-core/src/tests/FormApi.spec.tsx
+++ b/packages/form-core/src/tests/FormApi.spec.tsx
@@ -189,4 +189,28 @@ describe('form api', () => {
 
     expect(form.getFieldValue('names')).toStrictEqual(['one', 'other', 'three'])
   })
+
+  it("should remove an array field's value", () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ['one', 'two', 'three'],
+      },
+    })
+
+    form.removeFieldValue('names', 1)
+
+    expect(form.getFieldValue('names')).toStrictEqual(['one', 'three'])
+  })
+
+  it("should swap an array field's value", () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ['one', 'two', 'three'],
+      },
+    })
+
+    form.swapFieldValues('names', 1, 2)
+
+    expect(form.getFieldValue('names')).toStrictEqual(['one', 'three', 'two'])
+  })
 })

--- a/packages/form-core/src/tests/FormApi.spec.tsx
+++ b/packages/form-core/src/tests/FormApi.spec.tsx
@@ -112,7 +112,6 @@ describe('form api', () => {
     })
   })
 
-
   it('should reset the form state properly', () => {
     const form = new FormApi({
       defaultValues: {
@@ -120,10 +119,10 @@ describe('form api', () => {
       },
     })
 
-    form.pushFieldValue('name', 'other');
-    form.state.submissionAttempts = 300;
+    form.pushFieldValue('name', 'other')
+    form.state.submissionAttempts = 300
 
-    form.reset();
+    form.reset()
 
     expect(form.state).toEqual({
       values: {
@@ -143,5 +142,51 @@ describe('form api', () => {
       submissionAttempts: 0,
       formValidationCount: 0,
     })
+  })
+
+  it("should get a field's value", () => {
+    const form = new FormApi({
+      defaultValues: {
+        name: 'test',
+      },
+    })
+
+    expect(form.getFieldValue('name')).toEqual('test')
+  })
+
+  it("should set a field's value", () => {
+    const form = new FormApi({
+      defaultValues: {
+        name: 'test',
+      },
+    })
+
+    form.setFieldValue('name', 'other')
+
+    expect(form.getFieldValue('name')).toEqual('other')
+  })
+
+  it("should push an array field's value", () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ['test'],
+      },
+    })
+
+    form.pushFieldValue('names', 'other')
+
+    expect(form.getFieldValue('names')).toStrictEqual(['test', 'other'])
+  })
+
+  it("should insert an array field's value", () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ['one', 'two', 'three'],
+      },
+    })
+
+    form.insertFieldValue('names', 1, 'other')
+
+    expect(form.getFieldValue('names')).toStrictEqual(['one', 'other', 'three'])
   })
 })

--- a/packages/form-core/src/tests/FormApi.spec.tsx
+++ b/packages/form-core/src/tests/FormApi.spec.tsx
@@ -111,4 +111,37 @@ describe('form api', () => {
       formValidationCount: 0,
     })
   })
+
+
+  it('should reset the form state properly', () => {
+    const form = new FormApi({
+      defaultValues: {
+        name: 'test',
+      },
+    })
+
+    form.pushFieldValue('name', 'other');
+    form.state.submissionAttempts = 300;
+
+    form.reset();
+
+    expect(form.state).toEqual({
+      values: {
+        name: 'test',
+      },
+      fieldMeta: {},
+      canSubmit: true,
+      isFieldsValid: true,
+      isFieldsValidating: false,
+      isFormValid: true,
+      isFormValidating: false,
+      isSubmitted: false,
+      isSubmitting: false,
+      isTouched: false,
+      isValid: true,
+      isValidating: false,
+      submissionAttempts: 0,
+      formValidationCount: 0,
+    })
+  })
 })

--- a/packages/form-core/src/tests/FormApi.spec.tsx
+++ b/packages/form-core/src/tests/FormApi.spec.tsx
@@ -1,0 +1,78 @@
+import { expect } from 'vitest'
+
+import { FormApi } from '../FormApi'
+
+describe('form api', () => {
+  it('should get default form state', () => {
+    const form = new FormApi()
+
+    expect(form.state).toEqual({
+      values: undefined,
+      fieldMeta: {},
+      canSubmit: true,
+      isFieldsValid: true,
+      isFieldsValidating: false,
+      isFormValid: true,
+      isFormValidating: false,
+      isSubmitted: false,
+      isSubmitting: false,
+      isTouched: false,
+      isValid: true,
+      isValidating: false,
+      submissionAttempts: 0,
+      formValidationCount: 0,
+    })
+  })
+
+  it('should get default form state when default values are passed', () => {
+    const form = new FormApi({
+      defaultValues: {
+        name: 'test',
+      },
+    })
+
+    expect(form.state).toEqual({
+      values: {
+        name: 'test',
+      },
+      fieldMeta: {},
+      canSubmit: true,
+      isFieldsValid: true,
+      isFieldsValidating: false,
+      isFormValid: true,
+      isFormValidating: false,
+      isSubmitted: false,
+      isSubmitting: false,
+      isTouched: false,
+      isValid: true,
+      isValidating: false,
+      submissionAttempts: 0,
+      formValidationCount: 0,
+    })
+  })
+
+  it('should get default form state when default state is passed', () => {
+    const form = new FormApi({
+      defaultState: {
+        submissionAttempts: 30
+      },
+    })
+
+    expect(form.state).toEqual({
+      values: undefined,
+      fieldMeta: {},
+      canSubmit: true,
+      isFieldsValid: true,
+      isFieldsValidating: false,
+      isFormValid: true,
+      isFormValidating: false,
+      isSubmitted: false,
+      isSubmitting: false,
+      isTouched: false,
+      isValid: true,
+      isValidating: false,
+      submissionAttempts: 30,
+      formValidationCount: 0,
+    })
+  })
+})

--- a/packages/form-core/src/tests/test.test.tsx
+++ b/packages/form-core/src/tests/test.test.tsx
@@ -1,5 +1,0 @@
-describe('tests', () => {
-  it('should test', () => {
-    expect(true).toBe(true)
-  })
-})

--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -13,6 +13,9 @@ export function functionalUpdate<TInput, TOutput = TInput>(
     : updater
 }
 
+/**
+ * Get a value from an object using a path, including dot notation.
+ */
 export function getBy(obj: any, path: any) {
   const pathArray = makePathArray(path)
   const pathObj = pathArray
@@ -24,6 +27,9 @@ export function getBy(obj: any, path: any) {
   }, obj)
 }
 
+/**
+ * Set a value on an object using a path, including dot notation.
+ */
 export function setBy(obj: any, _path: any, updater: Updater<any>) {
   const path = makePathArray(_path)
 
@@ -75,7 +81,7 @@ const intReplace = `${intPrefix}$1`
 
 function makePathArray(str: string) {
   if (typeof str !== 'string') {
-    throw new Error()
+    throw new Error('Path must be a string.')
   }
 
   return str


### PR DESCRIPTION
This PR:

- [x] Fixes formApi.update to behave as I would expect it to
- [x] Fixes typings for `pushFieldValue` and `insertFieldValue` helpers
- [x] Prevents throwing an error on `swapFieldValues`
- [x] Adds initial tests for form API
- [x] Fixes formApi.reset to include form values