### PR TITLE
fix: maximum depth exceeded should no longer occur on validation

### DIFF
--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -125,10 +125,6 @@ export class FieldApi<TData, TFormData> {
             ? state.meta.error
             : undefined
 
-          if (state.value !== this.prevState.value) {
-            this.validate('change', state.value as never)
-          }
-
           this.prevState = state
           this.state = state
         },
@@ -206,17 +202,13 @@ export class FieldApi<TData, TFormData> {
   getValue = (): typeof this._tdata => {
     return this.form.getFieldValue(this.name)
   }
+
   setValue = (
     updater: Updater<typeof this._tdata>,
     options?: { touch?: boolean; notify?: boolean },
   ) => {
-    this.form.setFieldValue(this.name, updater as any, options)
-    this.store.setState((prev) => {
-      return {
-        ...prev,
-        value: updater as any,
-      }
-    })
+    this.form.setFieldValue(this.name, updater as never, options)
+    this.validate('change', this.state.value)
   }
 
   getMeta = (): FieldMeta => this.form.getFieldMeta(this.name)
@@ -250,7 +242,7 @@ export class FieldApi<TData, TFormData> {
       form: this.form,
     })
 
-  validateSync = async (value = this.state.value, cause: ValidationCause) => {
+  validateSync = (value = this.state.value, cause: ValidationCause) => {
     const { onChange, onBlur } = this.options
     const validate =
       cause === 'submit' ? undefined : cause === 'change' ? onChange : onBlur


### PR DESCRIPTION
When running validation, there were some errors about maximum depth being exceeded. I fixed this by moving the validation check out of the stores' `onUpdate` and into the `setValue` function itself. It's not perfect, but I think this might honestly just be the way to go to sidestep this issue.

At very least it solves the issue in the short term so we can keep writing tests and stabilizing the API

Closes #406 