### PR TITLE
chore: attempt to fix test build CI command

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -93,6 +93,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
       - uses: pnpm/action-setup@v2.2.4
         with:
           version: 7
@@ -102,6 +106,10 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm --filter "./packages/**" --filter form --prefer-offline install --no-frozen-lockfile
+      - name: Get appropriate base and head commits for `nx affected` commands
+        uses: nrwl/nx-set-shas@v3
+        with:
+          main-branch-name: 'main'
       - run: pnpm run test:build
         env:
           BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}


### PR DESCRIPTION
Per @ZackDeRose:

> ok, so this is because the command is using nx affected, but you haven't checked out all the branches
> nx affected compares git commits to see if a package could be affected
> easy fix: skip affected
>
>harder fix: pull down all the relevant branches
> I think query has an example

This seems like it may fix the issue we're experiencing with CI