### PR TITLE
refactor: change form options spread to object assign

### DIFF
--- a/packages/react-form/src/createFormFactory.ts
+++ b/packages/react-form/src/createFormFactory.ts
@@ -1,4 +1,5 @@
 import type { FormApi, FormOptions } from '@tanstack/form-core'
+
 import { type UseField, type FieldComponent, Field, useField } from './useField'
 import { useForm } from './useForm'
 
@@ -13,7 +14,8 @@ export function createFormFactory<TFormData>(
 ): FormFactory<TFormData> {
   return {
     useForm: (opts) => {
-      return useForm<TFormData>({ ...defaultOpts, ...opts } as any) as any
+      const formOptions = Object.assign({}, defaultOpts, opts)
+      return useForm<TFormData>(formOptions)
     },
     useField: useField as any,
     Field: Field as any,


### PR DESCRIPTION
What this PR aims to:
- Small improvement in the fieldOptions object: change _Spread Operator_ to _Object.assign_.
  - with this even if receive anything that's not a object will not be appended 😎