### PR TITLE
fix(form-core): allow set default field meta

### DIFF
--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -132,7 +132,7 @@ export class FieldApi<TData, TFormData> {
         meta: this.getMeta() ?? {
           isValidating: false,
           isTouched: false,
-          ...this.options.defaultMeta,
+          ...opts.defaultMeta,
         },
       },
       {

--- a/packages/form-core/src/tests/FieldApi.spec.ts
+++ b/packages/form-core/src/tests/FieldApi.spec.ts
@@ -19,21 +19,31 @@ describe('field api', () => {
     expect(field.getValue()).toBe('test')
   })
 
-  it('should set a value correctly', () => {
-    const form = new FormApi({
-      defaultValues: {
-        name: 'test',
-      },
-    })
-
+  it('should get default meta', () => {
+    const form = new FormApi()
     const field = new FieldApi({
       form,
       name: 'name',
     })
 
-    field.setValue('other')
+    expect(field.getMeta()).toEqual({
+      isTouched: false,
+      isValidating: false,
+    })
+  })
 
-    expect(field.getValue()).toBe('other')
+  it('should allow to set default meta', () => {
+    const form = new FormApi()
+    const field = new FieldApi({
+      form,
+      name: 'name',
+      defaultMeta: { isTouched: true },
+    })
+
+    expect(field.getMeta()).toEqual({
+      isTouched: true,
+      isValidating: false,
+    })
   })
 
   it('should set a value correctly', () => {


### PR DESCRIPTION
While writing tests for onChange validation in the react adapter, I noticed that the default meta wasn't being passed to the field. This PR aims to fix that