### PR TITLE
Make runtime agnostic/Support React Native

### DIFF
--- a/docs/framework/react/quick-start.md
+++ b/docs/framework/react/quick-start.md
@@ -32,7 +32,12 @@ export default function App() {
           <form.Field
             name="fullName"
             children={(field) => (
-              <input name={field.name} {...field.getInputProps()} />
+              <input
+                name={field.name}
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
             )}
           />
         </div>

--- a/docs/framework/react/reference/formApi.md
+++ b/docs/framework/react/reference/formApi.md
@@ -8,10 +8,6 @@ title: Form API
 When using `@tanstack/react-form`, the [core form API](../../reference/formApi) is extended with additional methods for React-specific functionality:
 
 - ```tsx
-  getFormProps: () => FormProps
-  ```
-  - A function that returns props for the form element.
-- ```tsx
   Field: FieldComponent<TFormData>
   ```
   - A pre-bound and type-safe field component, specific to this forms instance.

--- a/docs/guides/basic-concepts.md
+++ b/docs/guides/basic-concepts.md
@@ -49,7 +49,11 @@ Example:
   name="firstName"
   children={(field) => (
     <>
-      <input {...field.getInputProps()} />
+      <input
+        value={field.state.value}
+        onBlur={field.handleBlur}
+        onChange={(e) => field.handleChange(e.target.value)}
+      />
       <FieldInfo field={field} />
     </>
   )}
@@ -68,12 +72,16 @@ const { value, error, touched, isValidating } = field.state
 
 ## Field API
 
-The Field API is an object passed to the render prop function when creating a field. It provides methods for working with the field's state, such as getInputProps, which returns an object with props needed to bind the field to a form input element.
+The Field API is an object passed to the render prop function when creating a field. It provides methods for working with the field's state.
 
 Example:
 
 ```tsx
-<input {...field.getInputProps()} />
+<input
+  value={field.state.value}
+  onBlur={field.handleBlur}
+  onChange={(e) => field.handleChange(e.target.value)}
+/>
 ```
 
 ## Validation
@@ -92,7 +100,11 @@ Example:
   }}
   children={(field) => (
     <>
-      <input {...field.getInputProps()} />
+      <input
+        value={field.state.value}
+        onBlur={field.handleBlur}
+        onChange={(e) => field.handleChange(e.target.value)}
+      />
       <FieldInfo field={field} />
     </>
   )}
@@ -143,7 +155,12 @@ Example:
                     return (
                       <div>
                         <label htmlFor={field.name}>Name:</label>
-                        <input name={field.name} {...field.getInputProps()} />
+                        <input
+                          name={field.name}
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(e) => field.handleChange(e.target.value)}
+                        />
                         <button
                           type="button"
                           onClick={() => hobbiesField.removeValue(i)}
@@ -162,7 +179,12 @@ Example:
                     return (
                       <div>
                         <label htmlFor={field.name}>Description:</label>
-                        <input name={field.name} {...field.getInputProps()} />
+                        <input
+                          name={field.name}
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(e) => field.handleChange(e.target.value)}
+                        />
                         <FieldInfo field={field} />
                       </div>
                     )
@@ -202,7 +224,12 @@ Example:
     return (
       <div>
         <label htmlFor={field.name}>Name:</label>
-        <input name={field.name} {...field.getInputProps()} />
+        <input
+          name={field.name}
+          value={field.state.value}
+          onBlur={field.handleBlur}
+          onChange={(e) => field.handleChange(e.target.value)}
+        />
         <button type="button" onClick={() => hobbiesField.removeValue(i)}>
           X
         </button>

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -36,7 +36,7 @@ function FieldInfo({ field }: { field: FieldApi<any, any> }) {
     <>
       {field.state.meta.touchedError ? (
         <em>{field.state.meta.touchedError}</em>
-      ) : null}{' '}
+      ) : null}
       {field.state.meta.isValidating ? 'Validating...' : null}
     </>
   )
@@ -93,7 +93,12 @@ export default function App() {
                 return (
                   <>
                     <label htmlFor={field.name}>First Name:</label>
-                    <input name={field.name} {...field.getInputProps()} />
+                    <input
+                      name={field.name}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                    />
                     <FieldInfo field={field} />
                   </>
                 )
@@ -106,7 +111,12 @@ export default function App() {
               children={(field) => (
                 <>
                   <label htmlFor={field.name}>Last Name:</label>
-                  <input name={field.name} {...field.getInputProps()} />
+                  <input
+                    name={field.name}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                  />
                   <FieldInfo field={field} />
                 </>
               )}

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -26,20 +26,20 @@ In the example below, you can see TanStack Form in action with the React framewo
 [Open in CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-form/tree/main/examples/react/simple)
 
 ```tsx
-import React from "react";
-import ReactDOM from "react-dom/client";
-import { useForm } from "@tanstack/react-form";
-import type { FieldApi } from "@tanstack/react-form";
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { useForm } from '@tanstack/react-form'
+import type { FieldApi } from '@tanstack/react-form'
 
 function FieldInfo({ field }: { field: FieldApi<any, any> }) {
   return (
     <>
       {field.state.meta.touchedError ? (
         <em>{field.state.meta.touchedError}</em>
-      ) : null}{" "}
-      {field.state.meta.isValidating ? "Validating..." : null}
+      ) : null}{' '}
+      {field.state.meta.isValidating ? 'Validating...' : null}
     </>
-  );
+  )
 }
 
 export default function App() {
@@ -47,40 +47,46 @@ export default function App() {
     // Memoize your default values to prevent re-renders
     defaultValues: React.useMemo(
       () => ({
-        firstName: "",
-        lastName: "",
+        firstName: '',
+        lastName: '',
       }),
       [],
     ),
     onSubmit: async (values) => {
       // Do something with form data
-      console.log(values);
+      console.log(values)
     },
-  });
+  })
 
   return (
     <div>
       <h1>Simple Form Example</h1>
       {/* A pre-bound form component */}
       <form.Provider>
-        <form {...form.getFormProps()}>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            void form.handleSubmit()
+          }}
+        >
           <div>
             {/* A type-safe and pre-bound field component*/}
             <form.Field
               name="firstName"
               onChange={(value) =>
                 !value
-                  ? "A first name is required"
+                  ? 'A first name is required'
                   : value.length < 3
-                  ? "First name must be at least 3 characters"
+                  ? 'First name must be at least 3 characters'
                   : undefined
               }
               onChangeAsyncDebounceMs={500}
               onChangeAsync={async (value) => {
-                await new Promise((resolve) => setTimeout(resolve, 1000));
+                await new Promise((resolve) => setTimeout(resolve, 1000))
                 return (
-                  value.includes("error") && 'No "error" allowed in first name'
-                );
+                  value.includes('error') && 'No "error" allowed in first name'
+                )
               }}
               children={(field) => {
                 // Avoid hasty abstractions. Render props are great!
@@ -90,7 +96,7 @@ export default function App() {
                     <input name={field.name} {...field.getInputProps()} />
                     <FieldInfo field={field} />
                   </>
-                );
+                )
               }}
             />
           </div>
@@ -110,19 +116,19 @@ export default function App() {
             selector={(state) => [state.canSubmit, state.isSubmitting]}
             children={([canSubmit, isSubmitting]) => (
               <button type="submit" disabled={!canSubmit}>
-                {isSubmitting ? "..." : "Submit"}
+                {isSubmitting ? '...' : 'Submit'}
               </button>
             )}
           />
         </form>
       </form.Provider>
     </div>
-  );
+  )
 }
 
-const rootElement = document.getElementById("root")!;
+const rootElement = document.getElementById('root')!
 
-ReactDOM.createRoot(rootElement).render(<App />);
+ReactDOM.createRoot(rootElement).render(<App />)
 ```
 
 ## You talked me into it, so what now?

--- a/docs/reference/fieldApi.md
+++ b/docs/reference/fieldApi.md
@@ -5,8 +5,6 @@ title: Field API
 
 ### Creating a new FieldApi Instance
 
-
-
 Normally, you will not need to create a new `FieldApi` instance directly. Instead, you will use a framework hook/function like `useField` or `createField` to create a new instance for you that utilizes your frameworks reactivity model. However, if you need to create a new instance manually, you can do so by calling the `new FieldApi` constructor.
 
 ```tsx
@@ -28,55 +26,58 @@ An object type representing the options for a field in a form.
 - ```tsx
   defaultMeta?: Partial<FieldMeta>
   ```
+
   - An optional object with default metadata for the field.
 
 - ```tsx
   onMount?: (formApi: FieldApi<TData, TFormData>) => void
   ```
+
   - An optional function that takes a param of `formApi` which is a generic type of `TData` and `TFormData`
 
 - ```tsx
    onChange?: ValidateFn<TData, TFormData>
   ```
+
   - An optional property that takes a `ValidateFn` which is a generic of `TData` and `TFormData`
 
 - ```tsx
     onChangeAsync?: ValidateAsyncFn<TData, TFormData>
   ```
-  - An optional property similar to `onChange` but async validation
 
+  - An optional property similar to `onChange` but async validation
 
 - ```tsx
      onChangeAsyncDebounceMs?: number
   ```
-  - An optional number to represent how long the  `onChangeAsync` should wait before running
+
+  - An optional number to represent how long the `onChangeAsync` should wait before running
   - If set to a number larger than 0, will debounce the async validation event by this length of time in milliseconds
 
 - ```tsx
     onBlur?: ValidateFn<TData, TFormData>
   ```
+
   - An optional function, when that run when subscribing to blur event of input
 
 - ```tsx
    onBlurAsync?: ValidateAsyncFn<TData, TFormData>
   ```
+
   - An optional function that takes a `ValidateFn` which is a generic of `TData` and `TFormData` happens async
 
   ```tsx
   onBlurAsyncDebounceMs?: number
   ```
-  - An optional number to represent how long the  `onBlurAsyncDebounceMs` should wait before running
-  -  If set to a number larger than 0, will debounce the async validation event by this length of time in milliseconds
+
+  - An optional number to represent how long the `onBlurAsyncDebounceMs` should wait before running
+  - If set to a number larger than 0, will debounce the async validation event by this length of time in milliseconds
 
   ```tsx
   onSubmitAsync?: number
   ```
-  -  If set to a number larger than 0, will debounce the async validation event by this length of time in milliseconds
 
-
-
-
-
+  - If set to a number larger than 0, will debounce the async validation event by this length of time in milliseconds
 
 ### `ValidationCause`
 
@@ -205,13 +206,13 @@ A class representing the API for managing a form field.
   ```
   - Validates the field value.
 - ```tsx
-  getChangeProps<T extends UserChangeProps<any>>(props: T = {} as T): ChangeProps<TData> & Omit<T, keyof ChangeProps<TData>>
+  handleBlur(): void;
   ```
-  - Gets the change and blur event handlers.
+  - Handles the blur event.
 - ```tsx
-  getInputProps<T extends UserInputProps>(props: T = {} as T): InputProps & Omit<T, keyof InputProps>
+  handleChange(value: TData): void
   ```
-  - Gets the input event handlers.
+  - Handles the change event.
 
 ### `FieldState<TData>`
 

--- a/examples/react/simple/src/index.tsx
+++ b/examples/react/simple/src/index.tsx
@@ -8,7 +8,7 @@ function FieldInfo({ field }: { field: FieldApi<any, any> }) {
     <>
       {field.state.meta.touchedError ? (
         <em>{field.state.meta.touchedError}</em>
-      ) : null}{" "}
+      ) : null}
       {field.state.meta.isValidating ? "Validating..." : null}
     </>
   );
@@ -65,7 +65,12 @@ export default function App() {
                 return (
                   <>
                     <label htmlFor={field.name}>First Name:</label>
-                    <input name={field.name} {...field.getInputProps()} />
+                    <input
+                      name={field.name}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                    />
                     <FieldInfo field={field} />
                   </>
                 );
@@ -78,7 +83,12 @@ export default function App() {
               children={(field) => (
                 <>
                   <label htmlFor={field.name}>Last Name:</label>
-                  <input name={field.name} {...field.getInputProps()} />
+                  <input
+                    name={field.name}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                  />
                   <FieldInfo field={field} />
                 </>
               )}

--- a/examples/react/simple/src/index.tsx
+++ b/examples/react/simple/src/index.tsx
@@ -35,7 +35,13 @@ export default function App() {
       <h1>Simple Form Example</h1>
       {/* A pre-bound form component */}
       <form.Provider>
-        <form {...form.getFormProps()}>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            void form.handleSubmit();
+          }}
+        >
           <div>
             {/* A type-safe and pre-bound field component*/}
             <form.Field

--- a/examples/react/simple/tsconfig.json
+++ b/examples/react/simple/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react",
-    "noEmit": true
+    "noEmit": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"]
   },
   "include": ["**/*.ts", "**/*.tsx", ".eslintrc.cjs", "rollup.config.js"]
 }

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -57,28 +57,6 @@ export type FieldMeta = {
   isValidating: boolean
 }
 
-export type UserChangeProps<TData> = {
-  onChange?: (updater: Updater<TData>) => void
-  onBlur?: (event: any) => void
-}
-
-export type UserInputProps = {
-  onChange?: (event: any) => void
-  onBlur?: (event: any) => void
-}
-
-export type ChangeProps<TData> = {
-  value: TData
-  onChange: (value: TData) => void
-  onBlur: (event: any) => void
-}
-
-export type InputProps<T> = {
-  value: T
-  onChange: (event: any) => void
-  onBlur: (event: any) => void
-}
-
 let uid = 0
 
 export type FieldState<TData> = {
@@ -409,43 +387,17 @@ export class FieldApi<TData, TFormData> {
     return this.validateAsync(value, cause)
   }
 
-  getChangeProps = <T extends UserChangeProps<any>>(
-    props: T = {} as T,
-  ): ChangeProps<typeof this._tdata> &
-    Omit<T, keyof ChangeProps<typeof this._tdata>> => {
-    return {
-      ...props,
-      value: this.state.value,
-      onChange: (value) => {
-        this.setValue(value as never)
-        props.onChange?.(value)
-      },
-      onBlur: (e) => {
-        const prevTouched = this.state.meta.isTouched
-        this.setMeta((prev) => ({ ...prev, isTouched: true }))
-        if (!prevTouched) {
-          this.validate('change')
-        }
-        this.validate('blur')
-      },
-    } as ChangeProps<typeof this._tdata> &
-      Omit<T, keyof ChangeProps<typeof this._tdata>>
+  handleChange = (updater: Updater<typeof this._tdata>) => {
+    this.setValue(updater, { touch: true })
   }
 
-  getInputProps = <T extends UserInputProps>(
-    props: T = {} as T,
-  ): InputProps<typeof this._tdata> &
-    Omit<T, keyof InputProps<typeof this._tdata>> => {
-    return {
-      ...props,
-      value: this.state.value,
-      onChange: (e) => {
-        this.setValue(e.target.value)
-        props.onChange?.(e.target.value)
-      },
-      onBlur: this.getChangeProps(props).onBlur,
-    } as InputProps<typeof this._tdata> &
-      Omit<T, keyof InputProps<typeof this._tdata>>
+  handleBlur = () => {
+    const prevTouched = this.state.meta.isTouched
+    if (!prevTouched) {
+      this.setMeta((prev) => ({ ...prev, isTouched: true }))
+      this.validate('change')
+    }
+    this.validate('blur')
   }
 }
 

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -4,16 +4,6 @@ import type { DeepKeys, DeepValue, Updater } from './utils'
 import { functionalUpdate, getBy, setBy } from './utils'
 import type { FieldApi, FieldMeta, ValidationCause } from './FieldApi'
 
-export interface Register {
-  // FormSubmitEvent
-}
-
-export type FormSubmitEvent = Register extends {
-  FormSubmitEvent: infer E
-}
-  ? E
-  : Event
-
 export type FormOptions<TData> = {
   defaultValues?: TData
   defaultState?: Partial<FormState<TData>>
@@ -223,12 +213,7 @@ export class FormApi<TFormData> {
     return Promise.all(fieldValidationPromises)
   }
 
-  // validateForm = async () => {}
-
-  handleSubmit = async (e: FormSubmitEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-
+  handleSubmit = async () => {
     // Check to see that the form and all fields have been touched
     // If they have not, touch them all and run validation
     // Run form validation
@@ -236,7 +221,7 @@ export class FormApi<TFormData> {
 
     this.store.setState((old) => ({
       ...old,
-      // Submittion attempts mark the form as not submitted
+      // Submission attempts mark the form as not submitted
       isSubmitted: false,
       // Count submission attempts
       submissionAttempts: old.submissionAttempts + 1,

--- a/packages/react-form/src/index.ts
+++ b/packages/react-form/src/index.ts
@@ -1,5 +1,4 @@
 export type {
-  ChangeProps,
   DeepKeys,
   DeepValue,
   FieldApiOptions,
@@ -9,12 +8,9 @@ export type {
   FieldState,
   FormOptions,
   FormState,
-  InputProps,
   RequiredByKey,
   Updater,
   UpdaterFn,
-  UserChangeProps,
-  UserInputProps,
   ValidationCause,
   ValidationError,
   ValidationMeta,

--- a/packages/react-form/src/index.ts
+++ b/packages/react-form/src/index.ts
@@ -22,7 +22,6 @@ export type {
 
 export { FormApi, FieldApi, functionalUpdate } from '@tanstack/form-core'
 
-export type { FormProps } from './useForm'
 export { useForm } from './useForm'
 
 export type { UseField, FieldComponent } from './useField'

--- a/packages/react-form/src/tests/createFormFactory.test.tsx
+++ b/packages/react-form/src/tests/createFormFactory.test.tsx
@@ -1,3 +1,4 @@
+/// <reference lib="dom" />
 import { render } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import * as React from 'react'
@@ -25,7 +26,7 @@ describe('createFormFactory', () => {
           <form.Field
             name="firstName"
             children={(field) => {
-              return <p>{field.getInputProps().value}</p>
+              return <p>{field.state.value}</p>
             }}
           />
         </form.Provider>

--- a/packages/react-form/src/tests/useField.test.tsx
+++ b/packages/react-form/src/tests/useField.test.tsx
@@ -1,3 +1,4 @@
+/// <reference lib="dom" />
 import * as React from 'react'
 import { render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -26,7 +27,12 @@ describe('useField', () => {
             defaultValue="FirstName"
             children={(field) => {
               return (
-                <input data-testid="fieldinput" {...field.getInputProps()} />
+                <input
+                  data-testid="fieldinput"
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                />
               )
             }}
           />
@@ -61,7 +67,9 @@ describe('useField', () => {
                 <input
                   data-testid="fieldinput"
                   name={field.name}
-                  {...field.getInputProps()}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.setValue(e.target.value)}
                 />
                 <p>{field.getMeta().error}</p>
               </div>
@@ -100,7 +108,9 @@ describe('useField', () => {
                 <input
                   data-testid="fieldinput"
                   name={field.name}
-                  {...field.getInputProps()}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
                 />
                 <p>{field.getMeta().error}</p>
               </div>
@@ -143,7 +153,9 @@ describe('useField', () => {
                 <input
                   data-testid="fieldinput"
                   name={field.name}
-                  {...field.getInputProps()}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
                 />
                 <p>{field.getMeta().error}</p>
               </div>
@@ -189,7 +201,9 @@ describe('useField', () => {
                 <input
                   data-testid="fieldinput"
                   name={field.name}
-                  {...field.getInputProps()}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
                 />
                 <p>{field.getMeta().error}</p>
               </div>

--- a/packages/react-form/src/tests/useForm.test.tsx
+++ b/packages/react-form/src/tests/useForm.test.tsx
@@ -1,3 +1,4 @@
+/// <reference lib="dom" />
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
@@ -25,7 +26,12 @@ describe('useForm', () => {
             defaultValue={''}
             children={(field) => {
               return (
-                <input data-testid="fieldinput" {...field.getInputProps()} />
+                <input
+                  data-testid="fieldinput"
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                />
               )
             }}
           />
@@ -61,7 +67,7 @@ describe('useForm', () => {
           <form.Field
             name="firstName"
             children={(field) => {
-              return <p>{field.getInputProps().value}</p>
+              return <p>{field.state.value}</p>
             }}
           />
         </form.Provider>

--- a/packages/react-form/src/useForm.tsx
+++ b/packages/react-form/src/useForm.tsx
@@ -6,17 +6,10 @@ import React from 'react'
 import { type UseField, type FieldComponent, Field, useField } from './useField'
 import { formContext } from './formContext'
 
-export type FormSubmitEvent = React.FormEvent<HTMLFormElement>
-
 declare module '@tanstack/form-core' {
-  interface Register {
-    FormSubmitEvent: FormSubmitEvent
-  }
-
   // eslint-disable-next-line no-shadow
   interface FormApi<TFormData> {
     Provider: (props: { children: any }) => any
-    getFormProps: () => FormProps
     Field: FieldComponent<TFormData, TFormData>
     useField: UseField<TFormData>
     useStore: <TSelected = NoInfer<FormState<TFormData>>>(
@@ -31,11 +24,6 @@ declare module '@tanstack/form-core' {
   }
 }
 
-export type FormProps = {
-  onSubmit: (e: FormSubmitEvent) => void
-  disabled: boolean
-}
-
 export function useForm<TData>(opts?: FormOptions<TData>): FormApi<TData> {
   const [formApi] = React.useState(() => {
     // @ts-ignore
@@ -45,12 +33,6 @@ export function useForm<TData>(opts?: FormOptions<TData>): FormApi<TData> {
     api.Provider = (props) => (
       <formContext.Provider {...props} value={{ formApi: api }} />
     )
-    api.getFormProps = () => {
-      return {
-        onSubmit: formApi.handleSubmit,
-        disabled: api.state.isSubmitting,
-      }
-    }
     api.Field = Field as any
     api.useField = useField as any
     api.useStore = (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
-    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "lib": ["ES2020"],
     "module": "ES2020",
     "moduleResolution": "node",
     "noImplicitAny": true,


### PR DESCRIPTION
This PR aims to solve React Native support and make the code less runtime/UI reliant by removing all methods and types that utilized the DOM. This includes:

- Removing `APIForm.getFormProps()`
- Removing `APIField.getInputProps()`
- Removing `APIField.getChangeProps()`
- Changing `APIForm.handleSubmit()` to remove `e` argument
- Adding a new `APIField.handleChange()` to call on an input by: `onChange={e => field.handleChange(e.target.value)}`
- Adding a new `APIField.handleBlur()` to call on an input by: `onBlur={field.handleBlur}`

While this might seem like a more verbose syntax, it brings a few additional benifits:

- Avoids headaches with typings for UI libraries like React Aria or ShadCN/UI that might not use exact `input` or similar under-the-hood.
- Allows us more flexibility if UI libraries or runtimes have different props names
- Reduces our API surface area, which makes cognitive load easier in the end
- Detaches our implementation from React, which should be easier to adopt to other frameworks 