### PR TITLE
chore: refactor useStableOpts to use dedicated keys

### DIFF
--- a/packages/react-form/src/tests/useStableOptions.test-d.ts
+++ b/packages/react-form/src/tests/useStableOptions.test-d.ts
@@ -1,0 +1,91 @@
+import { assertType, it, describe } from 'vitest'
+import { useStableOpts } from '../utils/useStableOptions'
+
+interface PersonOptions {
+  name: string
+  age: number
+  speak: () => void
+}
+
+describe('useStableOpts', () => {
+  it('should be okay when stableKeys has all the keys', () => {
+    const opts = useStableOpts(
+      {
+        name: 'bob',
+        age: 12,
+        speak: () => {},
+      },
+      {
+        stableKeys: ['speak', 'age', 'name'],
+        unstableKeys: [],
+      } as const,
+    )
+
+    assertType<PersonOptions>(opts)
+  })
+
+  it('should be okay when unstableKeys has all the keys', () => {
+    const opts = useStableOpts(
+      {
+        name: 'bob',
+        age: 12,
+        speak: () => {},
+      },
+      {
+        stableKeys: [],
+        unstableKeys: ['name', 'age', 'speak'],
+      } as const,
+    )
+
+    assertType<PersonOptions>(opts)
+  })
+
+  it('should not care what order unstableKeys are in', () => {
+    const opts = useStableOpts(
+      {
+        name: 'bob',
+        age: 12,
+        speak: () => {},
+      },
+      {
+        stableKeys: [],
+        unstableKeys: ['speak', 'age', 'name'],
+      } as const,
+    )
+
+    assertType<PersonOptions>(opts)
+  })
+
+  it('should be fine when all keys are accounted for between two arrays', () => {
+    const opts = useStableOpts(
+      {
+        name: 'bob',
+        age: 12,
+        speak: () => {},
+      },
+      {
+        stableKeys: ['speak', 'age'],
+        unstableKeys: ['name'],
+      } as const,
+    )
+
+    assertType<PersonOptions>(opts)
+  })
+
+  it('should throw an error when unstable keys does not include one of the keys from the object', () => {
+    const opts = useStableOpts(
+      {
+        name: 'bob',
+        age: 12,
+        speak: () => {},
+      },
+      {
+        stableKeys: ['speak', 'age'],
+        // @ts-expect-error
+        unstableKeys: [],
+      } as const,
+    )
+
+    assertType<PersonOptions>(opts)
+  })
+})

--- a/packages/react-form/src/tests/useStableOptions.test.tsx
+++ b/packages/react-form/src/tests/useStableOptions.test.tsx
@@ -9,7 +9,7 @@ import { useStableOpts } from '../utils/useStableOptions'
 const user = userEvent.setup()
 
 describe('useStableOpts', () => {
-  it('should not re-render numbers', () => {
+  it('should not re-render keys to stabilize', async () => {
     const Child = ({ options }: { options: { a: number } }) => {
       return <div>{options.a}</div>
     }
@@ -19,7 +19,10 @@ describe('useStableOpts', () => {
         a: 1,
       })
 
-      const options = useStableOpts(opts)
+      const options = useStableOpts(opts, {
+        unstableKeys: [],
+        stableKeys: ['a'],
+      } as const)
       return (
         <div>
           <Child options={options} />
@@ -30,11 +33,11 @@ describe('useStableOpts', () => {
 
     const { getByText } = render(<Parent />)
     expect(getByText('1')).toBeInTheDocument()
-    user.click(getByText('Change a'))
+    await user.click(getByText('Change a'))
     expect(getByText('1')).toBeInTheDocument()
   })
 
-  it('should re-render functions', async () => {
+  it('should re-render unstable keys', async () => {
     const Child = ({ options }: { options: { a: () => number } }) => {
       return <div>{options.a()}</div>
     }
@@ -44,7 +47,10 @@ describe('useStableOpts', () => {
         a: () => 1 as number,
       })
 
-      const options = useStableOpts(opts)
+      const options = useStableOpts(opts, {
+        unstableKeys: ['a'],
+        stableKeys: [],
+      } as const)
       return (
         <div>
           <Child options={options} />
@@ -55,7 +61,7 @@ describe('useStableOpts', () => {
 
     const { getByText } = render(<Parent />)
     expect(getByText('1')).toBeInTheDocument()
-    user.click(getByText('Change a'))
+    await user.click(getByText('Change a'))
     await waitFor(() => expect(getByText('2')).toBeInTheDocument())
   })
 })

--- a/packages/react-form/src/utils/types.ts
+++ b/packages/react-form/src/utils/types.ts
@@ -1,0 +1,26 @@
+type Contra<T> = T extends any ? (arg: T) => void : never
+
+type InferContra<T> = [T] extends [(arg: infer I) => void] ? I : never
+
+/**
+ * "a" | "b" | "c" => "a"
+ */
+type PickOne<T> = InferContra<InferContra<Contra<Contra<T>>>>
+
+/**
+ * "a" | "b" | "c" => ["a", "b", "c"]
+ */
+export type UnionToTuple<T> = PickOne<T> extends infer U
+  ? Exclude<T, U> extends never
+    ? readonly [T]
+    : readonly [...UnionToTuple<Exclude<T, U>>, U]
+  : never
+
+/**
+ * "a" | "b" | "c" => ['a', 'b', 'c'] | ['a', 'c', 'b'] | ['b', 'a', 'c'] | ['b', 'c', 'a'] | ['c', 'a', 'b'] | ['c', 'b', 'a'];
+ */
+export type Permutation<T, U = T> = [T] extends readonly [never]
+  ? readonly []
+  : T extends T
+  ? readonly [T, ...Permutation<Exclude<U, T>>]
+  : never

--- a/packages/react-form/src/utils/useStableOptions.ts
+++ b/packages/react-form/src/utils/useStableOptions.ts
@@ -1,6 +1,7 @@
 import React, { useMemo, useRef } from 'react'
 import type { FormOptions } from '@tanstack/form-core'
 import type { UseFieldOptions } from '../types'
+import type { Permutation, UnionToTuple } from './types'
 
 /**
  * This allows us to not force our users to `useMemo` the arguments passed to
@@ -9,60 +10,96 @@ import type { UseFieldOptions } from '../types'
  * `useCallback`, such as `onSubmit` or similar.
  * @see https://github.com/TanStack/form/issues/437
  */
-// We expect these keys to always be stable, so we never listen for changes to them
-const stableKeyTypes = [
-  'string',
-  'number',
-  'bigint',
-  'boolean',
-  'symbol',
-  'undefined',
-  'object',
-] as Array<
-  | 'string'
-  | 'number'
-  | 'bigint'
-  | 'boolean'
-  | 'symbol'
-  | 'undefined'
-  | 'object'
-  | 'function'
->
-
-export function useStableOpts<PropType extends object>(
-  newOptions: Partial<PropType> = {},
+export function useStableOpts<
+  /**
+   * This complex jumbo of types forces us to pass **every** key from `Opts`,
+   * without any overlap between `ToKeep` and `ToRemove`.
+   */
+  Opts extends object,
+  OptArr extends UnionToTuple<keyof Opts>,
+  ToKeep extends ReadonlyArray<OptArr[keyof OptArr]>,
+  ToRemove extends UnionToTuple<
+    Exclude<keyof Opts, ToKeep[number]>
+  > extends infer U
+    ? U extends readonly [never]
+      ? readonly []
+      : U extends readonly unknown[]
+      ? Permutation<U[number]>
+      : never
+    : never,
+>(
+  newOptions: Opts,
+  keyMeta: {
+    stableKeys: ToKeep
+    unstableKeys: ToRemove
+  },
 ) {
+  const keyMetaRef = useRef(keyMeta)
   const oldOptions = useRef(newOptions)
 
   const options = useMemo(() => {
     let rerender = false
-    const changedKeys = {} as Partial<PropType>
+    const changedKeys = {} as Partial<Opts>
     for (const optKey in newOptions) {
       const key: keyof typeof newOptions = optKey as never
       // Functions must be assigned to `options`
-      if (stableKeyTypes.includes(typeof newOptions[key])) continue
-      if (
-        typeof newOptions[key] === 'function' &&
-        oldOptions.current[key] !== newOptions[key]
-      ) {
-        changedKeys[key] = newOptions[key]
-        rerender = true
-      }
+      if (keyMetaRef.current.stableKeys.includes(key as never)) continue
+      changedKeys[key] = newOptions[key]
+      rerender = true
     }
     // No change needed, return stable reference
     if (!rerender) return oldOptions.current
     return Object.assign({}, oldOptions.current, changedKeys)
   }, [newOptions])
 
-  return options as PropType
+  return options as Opts
 }
 
 export function useStableFormOpts<TData>(newOptions: FormOptions<TData> = {}) {
-  return useStableOpts<typeof newOptions>(newOptions)
+  return useStableOpts(newOptions, {
+    stableKeys: [
+      'defaultValues',
+      'defaultState',
+      'asyncDebounceMs',
+      'onMountAsyncDebounceMs',
+      'onChangeAsyncDebounceMs',
+      'onBlurAsyncDebounceMs',
+    ],
+    unstableKeys: [
+      'onMount',
+      'onMountAsync',
+      'onChange',
+      'onChangeAsync',
+      'onBlur',
+      'onBlurAsync',
+      'onSubmit',
+      'onSubmitInvalid',
+    ],
+  } as const)
 }
 
 export function useStableFieldOpts<TData, TFormData>(
   newOptions: UseFieldOptions<TData, TFormData>,
 ) {
-  return useStableOpts<typeof newOptions>(newOptions)
+  return useStableOpts(newOptions, {
+    stableKeys: [
+      'mode',
+      'name',
+      'index',
+      'defaultValue',
+      'asyncDebounceMs',
+      'asyncAlways',
+      'onChangeAsyncDebounceMs',
+      'onBlurAsyncDebounceMs',
+      'defaultMeta',
+    ],
+    unstableKeys: [
+      'onMount',
+      'onChange',
+      'onChangeAsync',
+      'onBlur',
+      'onBlurAsync',
+      'onSubmitAsync',
+    ],
+  } as const)
 }


### PR DESCRIPTION
This PR refactors `useStableOpts` from #440 to use explicit keys rather than implicitly removing stability from functions.

To do this, we:

- Made the API explicit with what keys are made stable or not
- Included **super** strict TypeScript typings so we will never have accidentally missed keys
- Wrote type tests
- Improved integration tests

**Pros of this change:**
- Makes the code `useStableFormOpts` and `useStableFieldOpts` more immediately readable
- Allows `useStableOpts` to be more generic than our current usage, allowing us to more easily reuse this code in the future if need be
- More configurable usage of `useStableOpts` to remove stability from keys that for example, in the future, may be objects of functions

**Cons of this change:**
- Slightly larger bundle size
- Harder to grok TypeScript typings for `useStableOpts`

> Credit for `UnionToType` belongs to this wonderful blog: https://www.hacklewayne.com/typescript-convert-union-to-tuple-array-yes-but-how