### PR TITLE
chore: bump CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
           fetch-depth: '0'
       - uses: pnpm/action-setup@v2.2.4
         with:
-          version: 7
+          version: 8
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.14.2
+          node-version: 18.15.0
           registry-url: https://registry.npmjs.org/
           cache: 'pnpm'
       - name: Install dependencies

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,10 +16,10 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
       - uses: pnpm/action-setup@v2.2.4
         with:
-          version: 7
+          version: 8
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.14.2
+          node-version: 18.15.0
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm --filter "./packages/**" --filter form --prefer-offline install --no-frozen-lockfile


### PR DESCRIPTION
This PR bumps CI/CD to use a newer version of Node/etc