### PR TITLE
fix(vue): Component default scoped slot value types

### DIFF
--- a/docs/framework/vue/quick-start.md
+++ b/docs/framework/vue/quick-start.md
@@ -28,7 +28,7 @@ form.provideFormContext()
   <div>
     <div>
       <form.Field name="fullName">
-        <template v-slot="field">
+        <template v-slot="{ field }">
           <input
             :name="field.name"
             :value="field.state.value"

--- a/examples/vue/simple/src/App.vue
+++ b/examples/vue/simple/src/App.vue
@@ -45,7 +45,7 @@ async function onChangeFirstName(value) {
         :onChangeAsyncDebounceMs="500"
         :onChangeAsync="onChangeFirstName"
       >
-        <template v-slot="field, state">
+        <template v-slot="{ field, state }">
           <label :htmlFor="field.name">First Name:</label>
           <input
             :name="field.name"
@@ -59,7 +59,7 @@ async function onChangeFirstName(value) {
     </div>
     <div>
       <form.Field name="lastName">
-        <template v-slot="field, state">
+        <template v-slot="{ field, state }">
           <label :htmlFor="field.name">Last Name:</label>
           <input
             :name="field.name"

--- a/examples/vue/simple/src/App.vue
+++ b/examples/vue/simple/src/App.vue
@@ -50,7 +50,7 @@ async function onChangeFirstName(value) {
           <input
             :name="field.name"
             :value="field.state.value"
-            @input="(e) => field.handleChange(e.target.value)"
+            @input="(e) => field.handleChange((e.target as HTMLInputElement).value)"
             @blur="field.handleBlur"
           />
           <FieldInfo :state="state" />
@@ -64,7 +64,7 @@ async function onChangeFirstName(value) {
           <input
             :name="field.name"
             :value="field.state.value"
-            @input="(e) => field.handleChange(e.target.value)"
+            @input="(e) => field.handleChange((e.target as HTMLInputElement).value)"
             @blur="field.handleBlur"
           />
           <FieldInfo :state="state" />

--- a/examples/vue/simple/src/App.vue
+++ b/examples/vue/simple/src/App.vue
@@ -50,7 +50,9 @@ async function onChangeFirstName(value) {
           <input
             :name="field.name"
             :value="field.state.value"
-            @input="(e) => field.handleChange((e.target as HTMLInputElement).value)"
+            @input="
+              (e) => field.handleChange((e.target as HTMLInputElement).value)
+            "
             @blur="field.handleBlur"
           />
           <FieldInfo :state="state" />
@@ -64,7 +66,9 @@ async function onChangeFirstName(value) {
           <input
             :name="field.name"
             :value="field.state.value"
-            @input="(e) => field.handleChange((e.target as HTMLInputElement).value)"
+            @input="
+              (e) => field.handleChange((e.target as HTMLInputElement).value)
+            "
             @blur="field.handleBlur"
           />
           <FieldInfo :state="state" />

--- a/packages/vue-form/src/tests/useField.test.tsx
+++ b/packages/vue-form/src/tests/useField.test.tsx
@@ -30,7 +30,7 @@ describe('useField', () => {
 
       return () => (
         <form.Field name="firstName" defaultValue="FirstName">
-          {(field: FieldApi<string, Person>) => (
+          {({ field }: { field: FieldApi<string, Person> }) => (
             <input
               data-testid={'fieldinput'}
               value={field.state.value}
@@ -68,7 +68,7 @@ describe('useField', () => {
           name="firstName"
           onChange={(value) => (value === 'other' ? error : undefined)}
         >
-          {(field: FieldApi<string, Person>) => (
+          {({ field }: { field: FieldApi<string, Person> }) => (
             <div>
               <input
                 data-testid="fieldinput"
@@ -111,7 +111,7 @@ describe('useField', () => {
           name="firstName"
           onChange={(value) => (value === 'other' ? error : undefined)}
         >
-          {(field: FieldApi<string, Person>) => (
+          {({ field }: { field: FieldApi<string, Person> }) => (
             <div>
               <input
                 data-testid="fieldinput"
@@ -159,7 +159,7 @@ describe('useField', () => {
             return error
           }}
         >
-          {(field: FieldApi<string, Person>) => (
+          {({ field }: { field: FieldApi<string, Person> }) => (
             <div>
               <input
                 data-testid="fieldinput"
@@ -211,7 +211,7 @@ describe('useField', () => {
             return error
           }}
         >
-          {(field: FieldApi<string, Person>) => (
+          {({ field }: { field: FieldApi<string, Person> }) => (
             <div>
               <input
                 data-testid="fieldinput"

--- a/packages/vue-form/src/tests/useForm.test.tsx
+++ b/packages/vue-form/src/tests/useForm.test.tsx
@@ -29,7 +29,7 @@ describe('useForm', () => {
 
       return () => (
         <form.Field name="firstName" defaultValue="">
-          {(field: FieldApi<string, Person>) => (
+          {({ field }: { field: FieldApi<string, Person> }) => (
             <input
               data-testid={'fieldinput'}
               value={field.state.value}
@@ -69,7 +69,7 @@ describe('useForm', () => {
 
       return () => (
         <form.Field name="firstName" defaultValue="">
-          {(field: FieldApi<string, Person>) => <p>{field.state.value}</p>}
+          {({ field }: { field: FieldApi<string, Person> }) => <p>{field.state.value}</p>}
         </form.Field>
       )
     })
@@ -96,7 +96,8 @@ describe('useForm', () => {
       return () => (
         <form.Provider>
           <form.Field name="firstName">
-            {(field: FieldApi<string, { firstName: string }>) => {
+            {({ field }: { field: FieldApi<string, { firstName: string }> }) => {
+              console.log('FIELD', field)
               return (
                 <input
                   value={field.state.value}

--- a/packages/vue-form/src/tests/useForm.test.tsx
+++ b/packages/vue-form/src/tests/useForm.test.tsx
@@ -97,7 +97,6 @@ describe('useForm', () => {
         <form.Provider>
           <form.Field name="firstName">
             {({ field }: { field: FieldApi<string, { firstName: string }> }) => {
-              console.log('FIELD', field)
               return (
                 <input
                   value={field.state.value}

--- a/packages/vue-form/src/tests/useForm.test.tsx
+++ b/packages/vue-form/src/tests/useForm.test.tsx
@@ -69,7 +69,9 @@ describe('useForm', () => {
 
       return () => (
         <form.Field name="firstName" defaultValue="">
-          {({ field }: { field: FieldApi<string, Person> }) => <p>{field.state.value}</p>}
+          {({ field }: { field: FieldApi<string, Person> }) => (
+            <p>{field.state.value}</p>
+          )}
         </form.Field>
       )
     })
@@ -96,7 +98,11 @@ describe('useForm', () => {
       return () => (
         <form.Provider>
           <form.Field name="firstName">
-            {({ field }: { field: FieldApi<string, { firstName: string }> }) => {
+            {({
+              field,
+            }: {
+              field: FieldApi<string, { firstName: string }>
+            }) => {
               return (
                 <input
                   value={field.state.value}

--- a/packages/vue-form/src/useField.tsx
+++ b/packages/vue-form/src/useField.tsx
@@ -1,19 +1,23 @@
-import {
-  type DeepKeys,
-  type DeepValue,
-  FieldApi,
-  type FieldOptions,
-  type Narrow,
-} from '@tanstack/form-core'
+import { FieldApi } from '@tanstack/form-core';
+import type {
+  FieldState,
+  DeepKeys,
+  DeepValue,
+  FieldOptions,
+  Narrow
+} from '@tanstack/form-core';
 import { useStore } from '@tanstack/vue-store'
 import {
-  type SetupContext,
   defineComponent,
-  type Ref,
   onMounted,
   onUnmounted,
-  watch,
-} from 'vue-demi'
+  watch
+} from 'vue-demi';
+import type {
+  SlotsType,
+  SetupContext,
+  Ref
+} from 'vue-demi';
 import { provideFormContext, useFormContext } from './formContext'
 
 declare module '@tanstack/form-core' {
@@ -130,7 +134,12 @@ export type FieldComponent<TParentData, TFormData> = <TField>(
           name: TField extends undefined ? TField : DeepKeys<TParentData>
           index?: never
         }),
-  context: SetupContext,
+  context: SetupContext<{}, SlotsType<{
+    default: {
+      field: FieldApi<FieldValue<TParentData, TField>, TFormData>
+      state: FieldState<any>
+    }
+  }>>,
 ) => any
 
 export const Field = defineComponent(
@@ -145,7 +154,10 @@ export const Field = defineComponent(
       parentFieldName: fieldApi.api.name,
     } as never)
 
-    return () => context.slots.default!(fieldApi.api, fieldApi.state.value)
+    return () => context.slots.default!({
+      field: fieldApi.api,
+      state: fieldApi.state.value
+    })
   },
   { name: 'Field', inheritAttrs: false },
 )

--- a/packages/vue-form/src/useField.tsx
+++ b/packages/vue-form/src/useField.tsx
@@ -1,23 +1,14 @@
-import { FieldApi } from '@tanstack/form-core';
+import { FieldApi } from '@tanstack/form-core'
 import type {
   FieldState,
   DeepKeys,
   DeepValue,
   FieldOptions,
-  Narrow
-} from '@tanstack/form-core';
+  Narrow,
+} from '@tanstack/form-core'
 import { useStore } from '@tanstack/vue-store'
-import {
-  defineComponent,
-  onMounted,
-  onUnmounted,
-  watch
-} from 'vue-demi';
-import type {
-  SlotsType,
-  SetupContext,
-  Ref
-} from 'vue-demi';
+import { defineComponent, onMounted, onUnmounted, watch } from 'vue-demi'
+import type { SlotsType, SetupContext, Ref } from 'vue-demi'
 import { provideFormContext, useFormContext } from './formContext'
 
 declare module '@tanstack/form-core' {
@@ -130,12 +121,15 @@ export type FieldComponent<TParentData, TFormData> = <TField>(
           name: TField extends undefined ? TField : DeepKeys<TParentData>
           index?: never
         }),
-  context: SetupContext<{}, SlotsType<{
-    default: {
-      field: FieldApi<FieldValue<TParentData, TField>, TFormData>
-      state: FieldState<any>
-    }
-  }>>,
+  context: SetupContext<
+    {},
+    SlotsType<{
+      default: {
+        field: FieldApi<FieldValue<TParentData, TField>, TFormData>
+        state: FieldState<any>
+      }
+    }>
+  >,
 ) => any
 
 export const Field = defineComponent(
@@ -150,10 +144,11 @@ export const Field = defineComponent(
       parentFieldName: fieldApi.api.name,
     } as never)
 
-    return () => context.slots.default!({
-      field: fieldApi.api,
-      state: fieldApi.state.value
-    })
+    return () =>
+      context.slots.default!({
+        field: fieldApi.api,
+        state: fieldApi.state.value,
+      })
   },
   { name: 'Field', inheritAttrs: false },
 )

--- a/packages/vue-form/src/useField.tsx
+++ b/packages/vue-form/src/useField.tsx
@@ -117,11 +117,7 @@ export type FieldValue<TFormData, TField> = TFormData extends any[]
 // //   ^?
 
 export type FieldComponent<TParentData, TFormData> = <TField>(
-  fieldOptions: {
-    children?: (
-      fieldApi: FieldApi<FieldValue<TParentData, TField>, TFormData>,
-    ) => any
-  } & Omit<
+  fieldOptions: Omit<
     UseFieldOptions<FieldValue<TParentData, TField>, TFormData>,
     'name' | 'index'
   > &

--- a/packages/vue-form/src/useForm.tsx
+++ b/packages/vue-form/src/useForm.tsx
@@ -2,7 +2,12 @@ import { FormApi, type FormState, type FormOptions } from '@tanstack/form-core'
 import { useStore } from '@tanstack/vue-store'
 import { type UseField, type FieldComponent, Field, useField } from './useField'
 import { provideFormContext } from './formContext'
-import { type EmitsOptions, type SlotsType, type SetupContext, defineComponent } from 'vue-demi'
+import {
+  type EmitsOptions,
+  type SlotsType,
+  type SetupContext,
+  defineComponent,
+} from 'vue-demi'
 import type { NoInfer } from './types'
 
 declare module '@tanstack/form-core' {
@@ -15,9 +20,15 @@ declare module '@tanstack/form-core' {
     useStore: <TSelected = NoInfer<FormState<TFormData>>>(
       selector?: (state: NoInfer<FormState<TFormData>>) => TSelected,
     ) => TSelected
-    Subscribe: <TSelected = NoInfer<FormState<TFormData>>>(props: {
-      selector?: (state: NoInfer<FormState<TFormData>>) => TSelected
-    }, context: SetupContext<EmitsOptions, SlotsType<{ default: NoInfer<FormState<TFormData>> }>>) => any
+    Subscribe: <TSelected = NoInfer<FormState<TFormData>>>(
+      props: {
+        selector?: (state: NoInfer<FormState<TFormData>>) => TSelected
+      },
+      context: SetupContext<
+        EmitsOptions,
+        SlotsType<{ default: NoInfer<FormState<TFormData>> }>
+      >,
+    ) => any
   }
 }
 

--- a/packages/vue-form/src/useForm.tsx
+++ b/packages/vue-form/src/useForm.tsx
@@ -2,7 +2,7 @@ import { FormApi, type FormState, type FormOptions } from '@tanstack/form-core'
 import { useStore } from '@tanstack/vue-store'
 import { type UseField, type FieldComponent, Field, useField } from './useField'
 import { provideFormContext } from './formContext'
-import { defineComponent } from 'vue-demi'
+import { type EmitsOptions, type SlotsType, type SetupContext, defineComponent } from 'vue-demi'
 import type { NoInfer } from './types'
 
 declare module '@tanstack/form-core' {
@@ -17,7 +17,7 @@ declare module '@tanstack/form-core' {
     ) => TSelected
     Subscribe: <TSelected = NoInfer<FormState<TFormData>>>(props: {
       selector?: (state: NoInfer<FormState<TFormData>>) => TSelected
-    }) => any
+    }, context: SetupContext<EmitsOptions, SlotsType<{ default: NoInfer<FormState<TFormData>> }>>) => any
   }
 }
 


### PR DESCRIPTION
Hi! This PR adds typings to the `Subscribe` and `Field` component default slot values.

<img width="453" alt="Screenshot 2023-09-08 at 12 22 55 AM" src="https://github.com/TanStack/form/assets/13049130/7ebacca6-3a3a-4825-9a0d-2b324aec9e0a">

<img width="528" alt="Screenshot 2023-09-08 at 12 17 50 PM" src="https://github.com/TanStack/form/assets/13049130/8b1be54d-254d-4f57-8ab9-6558233a038e">

Some reference: https://github.com/vuejs/core/pull/7982

Tests passed ✅ 
