### PR TITLE
fix: onChange should disappear when new input comes in

### DIFF
--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -140,6 +140,10 @@ export class FieldApi<
         onUpdate: () => {
           const state = this.store.state
 
+          state.meta.errors = Object.values(state.meta.errorMap).filter(
+            (val: unknown) => val !== undefined,
+          )
+
           state.meta.touchedErrors = state.meta.isTouched
             ? state.meta.errors
             : []
@@ -268,10 +272,9 @@ export class FieldApi<
     this.getInfo().validationCount = validationCount
     const error = normalizeError(validate(value as never, this as never))
     const errorMapKey = getErrorMapKey(cause)
-    if (error && this.state.meta.errorMap[errorMapKey] !== error) {
+    if (this.state.meta.errorMap[errorMapKey] !== error) {
       this.setMeta((prev) => ({
         ...prev,
-        errors: [...prev.errors, error],
         errorMap: {
           ...prev.errorMap,
           [getErrorMapKey(cause)]: error,
@@ -358,7 +361,6 @@ export class FieldApi<
           this.setMeta((prev) => ({
             ...prev,
             isValidating: false,
-            errors: [...prev.errors, error],
             errorMap: {
               ...prev.errorMap,
               [getErrorMapKey(cause)]: error,

--- a/packages/form-core/src/tests/FieldApi.spec.ts
+++ b/packages/form-core/src/tests/FieldApi.spec.ts
@@ -501,6 +501,36 @@ describe('field api', () => {
     })
   })
 
+  it('should reset onChange errors when the issue is resolved', () => {
+    const form = new FormApi({
+      defaultValues: {
+        name: 'other',
+      },
+    })
+
+    const field = new FieldApi({
+      form,
+      name: 'name',
+      onChange: (value) => {
+        if (value === 'other') return 'Please enter a different value'
+        return
+      },
+    })
+
+    field.mount()
+
+    field.setValue('other', { touch: true })
+    expect(field.getMeta().errors).toStrictEqual([
+      'Please enter a different value',
+    ])
+    expect(field.getMeta().errorMap).toEqual({
+      onChange: 'Please enter a different value',
+    })
+    field.setValue('test', { touch: true })
+    expect(field.getMeta().errors).toStrictEqual([])
+    expect(field.getMeta().errorMap).toEqual({})
+  })
+
   it('should handle default value on field using state.value', async () => {
     interface Form {
       name: string


### PR DESCRIPTION
This PR fixes an issue that was introduced in `0.3.0` that led to `onChange` causing issues when new input was typed