### PR TITLE
docs(validation): Improved validation guide

### DIFF
--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -16,29 +16,22 @@ It's up to you! The `<Field />` component accepts some callbacks as props such a
 Here is an example:
 
 ```tsx
- <form.Field
-  name="firstName"
-  onChange={(value) => {
-    return !value
-      ? "A first name is required"
-      : value.length < 3
-        ? "First name must be at least 3 characters"
-        : undefined;
-  }}
+<form.Field
+  name="age"
+  onChange={val => val < 13 ? "You must be 13 to make an account" : undefined}
 >
-  {(field) => {
-    return (
-      <>
-        <label htmlFor={field.name}>First Name:</label>
-        <input
-          name={field.name}
-          value={field.state.value}
-          onChange={(e) => field.handleChange(e.target.value)}
-        />
-        {field.state.meta.errors ? <em role="alert">{field.state.meta.errors.join(', ')}</em> : null}
-      </>
-    );
-  }}
+  {field => (
+    <>
+      <label htmlFor={field.name}>First Name:</label>
+      <input
+        name={field.name}
+        value={field.state.value}
+        type="number"
+        onChange={(e) => field.handleChange(e.target.valueAsNumber)}
+      />
+      {field.state.meta.errors ? <em role="alert">{field.state.meta.errors.join(', ')}</em> : null}
+    </>
+  )}
 </form.Field>
 ```
 
@@ -46,32 +39,24 @@ In the example above, the validation is done at each keystroke (`onChange`). If,
 
 ```tsx
 <form.Field
-  name="firstName"
-  // Implement onBlur instead of onChange here
-  onBlur={(value) => {
-    return !value
-      ? "A first name is required"
-      : value.length < 3
-        ? "First name must be at least 3 characters"
-        : undefined;
-  }}
+  name="age"
+  onBlur={val => val < 13 ? "You must be 13 to make an account" : undefined}
 >
-  {(field) => {
-    return (
-      <>
-        <label htmlFor={field.name}>First Name:</label>
-        <input
-          name={field.name}
-          value={field.state.value}
-          // Listen to the onBlur event on the field
-          onBlur={field.handleBlur}
-          // We always need to implement onChange, so that TanStack Form receives the changes
-          onChange={(e) => field.handleChange(e.target.value)}
-        />
-        {field.state.meta.errors ? <em role="alert">{field.state.meta.errors.join(', ')}</em> : null}
-      </>
-    );
-  }}
+  {field => (
+    <>
+      <label htmlFor={field.name}>First Name:</label>
+      <input
+        name={field.name}
+        value={field.state.value}
+        type="number"
+        // Listen to the onBlur event on the field
+        onBlur={field.handleBlur}
+        // We always need to implement onChange, so that TanStack Form receives the changes
+        onChange={(e) => field.handleChange(e.target.valueAsNumber)}
+      />
+      {field.state.meta.errors ? <em role="alert">{field.state.meta.errors.join(', ')}</em> : null}
+    </>
+  )}
 </form.Field>
 ```
 
@@ -79,31 +64,25 @@ So you can control when the validation is done by implementing the desired callb
 
 ```tsx
 <form.Field
-  name="firstName"
-  // Both onBlur and onChange are implemented here
-  onBlur={(value) => {
-    return !value
-      ? "A first name is required"
-      : value.length < 3
-        ? "First name must be at least 3 characters"
-        : undefined;
-  }}
-  onChange={(value) => value === 'error' && 'No error please!'}
+  name="age"
+  onChange={val => val < 13 ? "You must be 13 to make an account" : undefined}
+  onBlur={(val) => (val < 0 ? "Invalid value" : undefined)}
 >
-  {(field) => {
-    return (
-      <>
-        <label htmlFor={field.name}>First Name:</label>
-        <input
-          name={field.name}
-          value={field.state.value}
-          onChange={(e) => field.handleChange(e.target.value)}
-          onBlur={field.handleBlur}
-        />
-        {field.state.meta.errors ? <em role="alert">{field.state.meta.errors.join(', ')}</em> : null}
-      </>
-    );
-  }}
+  {field => (
+    <>
+      <label htmlFor={field.name}>First Name:</label>
+      <input
+        name={field.name}
+        value={field.state.value}
+        type="number"
+        // Listen to the onBlur event on the field
+        onBlur={field.handleBlur}
+        // We always need to implement onChange, so that TanStack Form receives the changes
+        onChange={(e) => field.handleChange(e.target.valueAsNumber)}
+      />
+      {field.state.meta.errors ? <em role="alert">{field.state.meta.errors.join(', ')}</em> : null}
+    </>
+  )}
 </form.Field>
 ```
 
@@ -117,7 +96,8 @@ Once you have your validation in place, you can map the errors from an array to 
 <form.Field
   name="age"
   onChange={val => val < 13 ? "You must be 13 to make an account" : undefined}
-  children={(field) => {
+>
+  {(field) => {
     return (
       <>
         {/* ... */}
@@ -127,7 +107,7 @@ Once you have your validation in place, you can map the errors from an array to 
       </>
     );
   }}
-/>
+</form.Field>
 ```
 
 Or use the `errorMap` property to access the specific error you're looking for:
@@ -163,60 +143,58 @@ To do this, we have dedicated `onChangeAsync`, `onBlurAsync`, and other methods 
 
 ```tsx
 <form.Field
-  name="firstName"
+  name="age"
   onChangeAsync={async (value) => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
     return (
-      value.includes("error") && 'No "error" allowed in first name'
+      value < 13 ? "You must be 13 to make an account" : undefined
     );
   }}
-  children={(field) => {
-    return (
-      <>
-        <label htmlFor={field.name}>First Name:</label>
-        <input
-          name={field.name}
-          value={field.state.value}
-          onBlur={field.handleBlur}
-          onChange={(e) => field.handleChange(e.target.value)}
-        />
-        <FieldInfo field={field} />
-      </>
-    );
-  }}
-/>
+>
+  {field => (
+    <>
+      <label htmlFor={field.name}>First Name:</label>
+      <input
+        name={field.name}
+        value={field.state.value}
+        type="number"
+        onChange={(e) => field.handleChange(e.target.valueAsNumber)}
+      />
+      {field.state.meta.errors ? <em role="alert">{field.state.meta.errors.join(', ')}</em> : null}
+    </>
+  )}
+</form.Field>
 ```
 
 Synchronous and Asynchronous validations can coexist. For example it is possible to define both `onBlur` and `onBlurAsync` on the same field:
 
-
-``` tsx
+```tsx
 <form.Field
-  name="firstName"
-  onBlur={(value) =>
-    !value
-      ? "A first name is required"
-      : value.length < 3
-      ? "First name must be at least 3 characters"
-      : undefined
-  }
+  name="age"
+  onBlur={(value) => value < 13 ? "You must be at least 13" : undefined}
   onBlurAsync={async (value) => {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    const currentAge = await fetchCurrentAgeOnProfile();
     return (
-      value.includes("error") && 'No "error" allowed in first name'
+      value < currentAge ? "You can only increase the age" : undefined
     );
   }}
 >
-  {(field) => (
-      <>
-		{/* ... */}
-      </>
+  {field => (
+    <>
+      <label htmlFor={field.name}>First Name:</label>
+      <input
+        name={field.name}
+        value={field.state.value}
+        type="number"
+        onChange={(e) => field.handleChange(e.target.valueAsNumber)}
+      />
+      {field.state.meta.errors ? <em role="alert">{field.state.meta.errors.join(', ')}</em> : null}
+    </>
   )}
 </form.Field>
 ```
 
 The synchronous validation method (`onBlur`) is run first and the asynchronous method (`onBlurAsync`) is only run if the synchronous one (`onBlur`) succeeds. To change this behaviour, set the `asyncAlways` option to `true`, and the async method will be run regardless of the result of the sync method.
-
 
 
 ### Built-in Debouncing
@@ -227,7 +205,7 @@ Instead, we enable an easy method for debouncing your `async` calls by adding a 
 
 ```tsx
 <form.Field
-  name="firstName"
+  name="age"
   asyncDebounceMs={500}
   onChangeAsync={async (value) => {
     // ...
@@ -246,7 +224,7 @@ This will debounce every async call with a 500ms delay. You can even override th
 
 ```tsx
 <form.Field
-  name="firstName"
+  name="age"
   asyncDebounceMs={500}
   onChangeAsyncDebounceMs={1500}
   onChangeAsync={async (value) => {
@@ -266,50 +244,6 @@ This will debounce every async call with a 500ms delay. You can even override th
 ```
 
 > This will run `onChangeAsync` every 1500ms while `onBlurAsync` will run every 500ms.
-
-## Validating fields that depend on each other
-
-Sometimes when validating a field value, we need to access the value of another field. For example a "repeat password" field that needs to be identical to a "password" field. On top of receiving the field value, each validation callback receives the `fieldAPI` object which has access to the `formAPI` object, which contains all the fields values.
-
-Here is an example
-```tsx
-<form.Field
-  name="password"
-  children={(field) => (
-    <>
-      <label htmlFor={field.name}>Password:</label>
-      <input
-        name={field.name}
-        value={field.state.value}
-        type="password"
-        onChange={(e) => field.handleChange(e.target.value)}
-      />
-      <FieldInfo field={field} />
-    </>
-  )}
-/>
-<form.Field
-  name="repeat_password"
-  onChange={(value, fieldAPI) => {
-    if (value !== fieldAPI.form.store.state.values.password) {
-      return "Passwords do not match";
-    }
-
-  }}
-  children={(field) => (
-    <>
-      <label htmlFor={field.name}>Repeat password:</label>
-      <input
-        name={field.name}
-        value={field.state.value}
-        type="password"
-        onChange={(e) => field.handleChange(e.target.value)}
-      />
-      <FieldInfo field={field} />
-    </>
-  )}
-/>
-```
 
 
 ## Adapter-Based Validation (Zod, Yup)
@@ -339,11 +273,11 @@ const form = useForm({
 });
 
 <form.Field
-  name="firstName"
+  name="age"
   validator={zodValidator}
   onChange={z
-    .string()
-    .min(3, "First name must be at least 3 characters")}
+    .number()
+    .gte(13, "You must be 13 to make an account")}
   children={(field) => {
     return (
       <>
@@ -358,18 +292,20 @@ These adapters also support async operations using the proper property names:
 
 ```tsx
 <form.Field
-  name="firstName"
+  name="age"
   onChange={z
-    .string()
-    .min(3, "First name must be at least 3 characters")}
+    .number()
+    .gte(13, "You must be 13 to make an account")}
   onChangeAsyncDebounceMs={500}
-  onChangeAsync={z.string().refine(
+  onChangeAsync={z.number().refine(
     async (value) => {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      return !value.includes("error");
+      const currentAge = await fetchCurrentAgeOnProfile();
+      return (
+        value >= currentAge
+      );
     },
     {
-      message: "No 'error' allowed in first name",
+      message: "You can only increase the age",
     },
   )}
   children={(field) => {

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -22,7 +22,7 @@ Here is an example:
 >
   {field => (
     <>
-      <label htmlFor={field.name}>First Name:</label>
+      <label htmlFor={field.name}>Age:</label>
       <input
         name={field.name}
         value={field.state.value}
@@ -44,7 +44,7 @@ In the example above, the validation is done at each keystroke (`onChange`). If,
 >
   {field => (
     <>
-      <label htmlFor={field.name}>First Name:</label>
+      <label htmlFor={field.name}>Age:</label>
       <input
         name={field.name}
         value={field.state.value}
@@ -70,7 +70,7 @@ So you can control when the validation is done by implementing the desired callb
 >
   {field => (
     <>
-      <label htmlFor={field.name}>First Name:</label>
+      <label htmlFor={field.name}>Age:</label>
       <input
         name={field.name}
         value={field.state.value}
@@ -153,7 +153,7 @@ To do this, we have dedicated `onChangeAsync`, `onBlurAsync`, and other methods 
 >
   {field => (
     <>
-      <label htmlFor={field.name}>First Name:</label>
+      <label htmlFor={field.name}>Age:</label>
       <input
         name={field.name}
         value={field.state.value}
@@ -181,7 +181,7 @@ Synchronous and Asynchronous validations can coexist. For example it is possible
 >
   {field => (
     <>
-      <label htmlFor={field.name}>First Name:</label>
+      <label htmlFor={field.name}>Age:</label>
       <input
         name={field.name}
         value={field.state.value}

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -384,7 +384,7 @@ These adapters also support async operations using the proper property names:
 
 ## Preventing invalid forms from being submitted
 
-The `onChange`, `onBlur` etc... callbacks are also run when the form is submitted and submission is be blocked if the form is invalid.
+The `onChange`, `onBlur` etc... callbacks are also run when the form is submitted and the submission is blocked if the form is invalid.
 
 The form state object has a `canSubmit` flag that is false when any field is invalid and the form has been touched (`canSubmit` is true until the form has been touched, even if some fields are "technically" invalid based on their `onChange`/`onBlur` props).
 

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -11,7 +11,7 @@ At the core of TanStack Form's functionalities is the concept of validation. Tan
 
 ## When is validation performed?
 
-It's up to you! The `<Field />` component accepts some callbacks as props such as `onChange`, `onBlur`, `onSubmitAsync` (more on async validation below). Those callbacks are passed the current value of the field, as well as the fieldAPI object, so that you can perform the validation. If you find a validation error, simply return the error message as string and it will be available in `field.state.meta.errors`.
+It's up to you! The `<Field />` component accepts some callbacks as props such as `onChange` or `onBlur`. Those callbacks are passed the current value of the field, as well as the fieldAPI object, so that you can perform the validation. If you find a validation error, simply return the error message as string and it will be available in `field.state.meta.errors`.
 
 Here is an example:
 
@@ -150,7 +150,7 @@ Or use the `errorMap` property to access the specific error you're looking for:
 
 ## Validation at field level vs at form level
 
-As shown above, each `<Field>` accepts its own validation rules via the `onChange`, `onBlur` etc... callbacks. It is also possible to define validation rules at the form level (as opposed to field by field) by passing similar callback to the `useForm()` hook.
+As shown above, each `<Field>` accepts its own validation rules via the `onChange`, `onBlur` etc... callbacks. It is also possible to define validation rules at the form level (as opposed to field by field) by passing similar callbacks to the `useForm()` hook.
 
 <!-- TODO: add more details when those callbacks are fixed -->
 
@@ -384,6 +384,8 @@ These adapters also support async operations using the proper property names:
 
 ## Preventing invalid forms from being submitted
 
+The `onChange`, `onBlur` etc... callbacks are also run when the form is submitted and submission is be blocked if the form is invalid.
+
 The form state object has a `canSubmit` flag that is false when any field is invalid and the form has been touched (`canSubmit` is true until the form has been touched, even if some fields are "technically" invalid based on their `onChange`/`onBlur` props).
 
 You can subscribe to it via `form.Subscribe` and use the value in order to, for example, disable the submit button when the form is invalid (in practice, disabled buttons are not accessible, use `aria-disabled` instead).
@@ -404,117 +406,4 @@ return (
     )}
   />
 );
-```
-
-Form submissions will be blocked if the form is invalid.
-
-BUT untouched forms are considered valid by default, so they **can** be submitted, even if they have `onChange`/`onBlur` validation rules that are not satisfied.
-
-For example, the form below **will** be submitted if the user clicks the submit button right away, before making any change:
-
-```tsx
-export default function App() {
-  const form = useForm({
-    // Memoize your default values to prevent re-renders
-    defaultValues: {
-      name: "",
-    },
-    onSubmit: async (values) => {
-      // Do something with form data
-      console.log(values);
-    },
-  });
-
-  return (
-    <form.Provider>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          void form.handleSubmit();
-        }}
-      >
-        <div>
-          <form.Field
-            name="name"
-            onChange={(value) =>
-              !value
-                ? "A first name is required"
-                : value.length < 3
-                  ? "First name must be at least 3 characters"
-                  : undefined
-            }
-
-          >
-            {(field) => {
-              return (
-                <>
-                  <label htmlFor={field.name}>First Name:</label>
-                  <input
-                    name={field.name}
-                    value={field.state.value}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                  />
-                  <FieldInfo field={field} />
-                </>
-              );
-            }}
-          </form.Field>
-        </div>
-
-        <button type="submit">Submit</button>
-      </form>
-    </form.Provider>
-  );
-}
-```
-
-In order to block the form submission, the field must implement the `onSubmitAsync` callback and run the validation inside it.
-
-<!-- TODO: this doesn't work currently -->
-
-```tsx
-  const validateName = (value: string) => !value
-    ? "A first name is required"
-    : value.length < 3
-      ? "First name must be at least 3 characters"
-      : undefined;
-
-  return (
-    <form.Provider>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          void form.handleSubmit();
-        }}
-      >
-        <div>
-          {/* A type-safe and pre-bound field component*/}
-          <form.Field
-            name="name"
-            onChange={validateName}
-            onSubmitAsync={validateName}
-
-          >
-            {(field) => {
-              return (
-                <>
-                  <label htmlFor={field.name}>First Name:</label>
-                  <input
-                    name={field.name}
-                    value={field.state.value}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                  />
-                  <FieldInfo field={field} />
-                </>
-              );
-            }}
-          </form.Field>
-        </div>
-
-        <button type="submit">Submit</button>
-      </form>
-    </form.Provider>
-  );
 ```


### PR DESCRIPTION
Issue: https://github.com/TanStack/form/issues/477

Add more info to the validation guide page.

While working on this, I've identified a few issues and inconsistencies. I'll probably create issues and discussion topics about these, but listing them here first in case I've missed some things:

## 1. formAPI's `onChange` not called
formAPI's `onChange` doesn't seem to be called at all and it expects the same return type as fieldAPI's `onChange`. If we want to allow doing validation at the form level in `onChange`, we probably need it to return a mapping of errors per field (same with onBlur and async methods).  [Here](https://codesandbox.io/p/sandbox/determined-mayer-yn4qfc?file=%2Fsrc%2Findex.tsx%3A43%2C29) is a repro of this.

## 2. Validate untouched forms
As I have mentioned in the docs, it seems that the way to prevent submission of untouched forms is to do some validation in the `onSubmitAsync` prop (at the `Field` level). However, once the form is in error due to an error raised in `onSubmitAsync`, it seems the form is stuck in error and the user can't submit, even if they've fixed the issue. [Here](https://codesandbox.io/p/sandbox/focused-lovelace-f2p8wz?file=%2Fsrc%2Findex.tsx%3A37%2C32) is a repro. Try submitting the form before making any change. Then it's impossible to submit again, even after providing correct values to the fields.

## 3. sync vs async validation
I don't know the motivation behind it but I wonder if we actually need to separate sync and async validation? For example, instead of having `onChange` and `onChangeAsync`, it could be simpler if we just had `onChange` that would accept a function that either returns a promise (async) or directly a validation error (sync)?

## 4. Per-event validation
This is a broader discussion topic but I'm seeing potential issues with separating out validation per event (onChange vs onBlur vs onMount etc...). I don't know if there is a use case where users would want to do different validations in `onChange` and `onBlur` and `onSubmitAsync` for example. From my experience, a field is either valid or invalid at a given time, regardless of *when* the validation is done, and users may often end up reusing the same validation rules in `onChange` and `onSubmitAsync` or in `onBlur` and `onSubmitAsync` for example.

Imo, it could make things simpler if we decoupled the validation rules (*what* makes a field valid) from *when* the validation should be done. 

Another challenge created by this approach is that errors are cleared by the same event that raised them. For example if `onBlur` returns a validation error, that error will only be cleared the next time the field is blurred. In some use cases, users could want to do the initial validation on blur but remove the errors as the user is typing to fix them. [Here](https://codesandbox.io/p/sandbox/determined-chaplygin-hlk7vz?file=%2Fsrc%2Findex.tsx%3A21%2C21) is an example:  (type 2 characters in the first name field then focus the other field: "First name must be at least 3 characters" is shown. It could be good to be able to remove the error as soon as the user types the third character).

I believe this is also what is causing point 2 above about validating untouched forms.