### PR TITLE
fix: remove use-isomorphic-layout-effect package for nextjs compatibility

### DIFF
--- a/packages/react-form/package.json
+++ b/packages/react-form/package.json
@@ -62,8 +62,7 @@
   "dependencies": {
     "@tanstack/form-core": "workspace:*",
     "@tanstack/react-store": "0.1.3",
-    "@tanstack/store": "0.1.3",
-    "use-isomorphic-layout-effect": "^1.1.2"
+    "@tanstack/store": "0.1.3"
   },
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0",

--- a/packages/react-form/src/useField.tsx
+++ b/packages/react-form/src/useField.tsx
@@ -50,9 +50,9 @@ export function useField<
   TName,
   ValidatorType,
   FormValidator
-// Omit<typeof opts, 'onMount'> & {
-//   form: FormApi<TParentData>
-// }
+  // Omit<typeof opts, 'onMount'> & {
+  //   form: FormApi<TParentData>
+  // }
 > {
   // Get the form API either manually or from context
   const { formApi, parentFieldName } = useFormContext()
@@ -90,8 +90,8 @@ export function useField<
     fieldApi.store,
     opts.mode === 'array'
       ? (state) => {
-        return [state.meta, Object.keys(state.value).length]
-      }
+          return [state.meta, Object.keys(state.value).length]
+        }
       : undefined,
   )
   // Instantiates field meta and removes it when unrendered
@@ -112,13 +112,13 @@ type FieldComponentProps<
   ) => any
 } & (TParentData extends any[]
   ? {
-    name?: TName
-    index: number
-  }
+      name?: TName
+      index: number
+    }
   : {
-    name: TName
-    index?: never
-  }) &
+      name: TName
+      index?: never
+    }) &
   Omit<
     UseFieldOptions<TParentData, TName, ValidatorType, FormValidator>,
     'name' | 'index'

--- a/packages/react-form/src/useField.tsx
+++ b/packages/react-form/src/useField.tsx
@@ -3,8 +3,8 @@ import { useStore } from '@tanstack/react-store'
 import type { DeepKeys, DeepValue, Narrow } from '@tanstack/form-core'
 import { FieldApi, functionalUpdate } from '@tanstack/form-core'
 import { useFormContext, formContext } from './formContext'
-import useIsomorphicLayoutEffect from 'use-isomorphic-layout-effect'
 import type { UseFieldOptions } from './types'
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 
 declare module '@tanstack/form-core' {
   // eslint-disable-next-line no-shadow
@@ -50,9 +50,9 @@ export function useField<
   TName,
   ValidatorType,
   FormValidator
-  // Omit<typeof opts, 'onMount'> & {
-  //   form: FormApi<TParentData>
-  // }
+// Omit<typeof opts, 'onMount'> & {
+//   form: FormApi<TParentData>
+// }
 > {
   // Get the form API either manually or from context
   const { formApi, parentFieldName } = useFormContext()
@@ -90,8 +90,8 @@ export function useField<
     fieldApi.store,
     opts.mode === 'array'
       ? (state) => {
-          return [state.meta, Object.keys(state.value).length]
-        }
+        return [state.meta, Object.keys(state.value).length]
+      }
       : undefined,
   )
   // Instantiates field meta and removes it when unrendered
@@ -112,13 +112,13 @@ type FieldComponentProps<
   ) => any
 } & (TParentData extends any[]
   ? {
-      name?: TName
-      index: number
-    }
+    name?: TName
+    index: number
+  }
   : {
-      name: TName
-      index?: never
-    }) &
+    name: TName
+    index?: never
+  }) &
   Omit<
     UseFieldOptions<TParentData, TName, ValidatorType, FormValidator>,
     'name' | 'index'

--- a/packages/react-form/src/useForm.tsx
+++ b/packages/react-form/src/useForm.tsx
@@ -5,7 +5,7 @@ import { useStore } from '@tanstack/react-store'
 import React, { type ReactNode, useState } from 'react'
 import { type UseField, type FieldComponent, Field, useField } from './useField'
 import { formContext } from './formContext'
-import useIsomorphicLayoutEffect from 'use-isomorphic-layout-effect'
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 
 declare module '@tanstack/form-core' {
   // eslint-disable-next-line no-shadow

--- a/packages/react-form/src/useIsomorphicLayoutEffect.ts
+++ b/packages/react-form/src/useIsomorphicLayoutEffect.ts
@@ -1,3 +1,5 @@
 import { useEffect, useLayoutEffect } from 'react'
 
-export const useIsomorphicLayoutEffect = typeof document !== 'undefined' ? useLayoutEffect : useEffect
+export const useIsomorphicLayoutEffect =
+  // @ts-ignore
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect

--- a/packages/react-form/src/useIsomorphicLayoutEffect.ts
+++ b/packages/react-form/src/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,3 @@
+import { useEffect, useLayoutEffect } from 'react'
+
+export const useIsomorphicLayoutEffect = typeof document !== 'undefined' ? useLayoutEffect : useEffect

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   '@tanstack/form-core': workspace:*
   '@tanstack/react-form': workspace:*
@@ -460,9 +464,6 @@ importers:
       react-native:
         specifier: '*'
         version: 0.72.4(@babel/core@7.22.17)(@babel/preset-env@7.22.15)(react@18.2.0)
-      use-isomorphic-layout-effect:
-        specifier: ^1.1.2
-        version: 1.1.2(@types/react@18.2.21)(react@18.2.0)
     devDependencies:
       '@types/jscodeshift':
         specifier: ^0.11.3
@@ -3103,6 +3104,7 @@ packages:
 
   /@types/prop-types@15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
+    dev: true
 
   /@types/react-dom@18.2.7:
     resolution: {integrity: sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==}
@@ -3116,6 +3118,7 @@ packages:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.3
       csstype: 3.1.2
+    dev: true
 
   /@types/resolve@1.20.2:
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -3123,6 +3126,7 @@ packages:
 
   /@types/scheduler@0.16.3:
     resolution: {integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==}
+    dev: true
 
   /@types/semver@7.5.1:
     resolution: {integrity: sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==}
@@ -9598,19 +9602,6 @@ packages:
       requires-port: 1.0.0
     dev: true
 
-  /use-isomorphic-layout-effect@1.1.2(@types/react@18.2.21)(react@18.2.0):
-    resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    dependencies:
-      '@types/react': 18.2.21
-      react: 18.2.0
-    dev: false
-
   /use-sync-external-store@1.2.0(react@18.2.0):
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
     peerDependencies:
@@ -10174,7 +10165,3 @@ packages:
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "target": "ES2020",
     "module": "ES2020",
     "moduleResolution": "node",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2022"],
     "target": "ES2020",
     "module": "ES2020",
     "moduleResolution": "node",


### PR DESCRIPTION
Issue: https://github.com/TanStack/form/issues/470

The [use-isomorphic-layout-effect](https://github.com/Andarist/use-isomorphic-layout-effect) package seems to cause issues on NextJS.

See the detailed investigation [here](https://github.com/TanStack/form/issues/470#issuecomment-1777837403). 
TL;DR it may be a NextJS issue or an issue with `use-isomorphic-layout-effect` (it seems adding an "exports" section to its package.json file fixes the issue).

We only use the `useIsomorphicLayoutEffect` hook from that package and since its implementation is a one-liner, I've added it to `react-form`, which fixes the nextjs issue.