### PR TITLE
docs: fix invalid mdx comment syntax

### DIFF
--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -132,7 +132,7 @@ Or use the `errorMap` property to access the specific error you're looking for:
 
 As shown above, each `<Field>` accepts its own validation rules via the `onChange`, `onBlur` etc... callbacks. It is also possible to define validation rules at the form level (as opposed to field by field) by passing similar callbacks to the `useForm()` hook.
 
-<!-- TODO: add more details when those callbacks are fixed -->
+{/* TODO: add more details when those callbacks are fixed */}
 
 
 ## Asynchronous Functional Validation


### PR DESCRIPTION
Invalid MDX comment was breaking page at [https://tanstack.com/form/latest/docs/guides/validation](url).

<img width="400" alt="Screenshot 2023-10-31 at 18 29 26" src="https://github.com/TanStack/form/assets/55989505/68395967-3bb1-468b-8ac8-35b5c5673371">


**Error message:** ```Unexpected character `!` (U+0021) before name, expected a character that can start a name, such as a letter, `$`, or `_` (note: to create a comment in MDX, use `{/* text */}`)'```