### PR TITLE
fix: errors should no longer throw on intial render

### DIFF
--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -177,16 +177,21 @@ export class FormApi<TFormData, ValidatorType> {
 
   mount = () => {
     const doValidate = () => {
-      if (typeof this.options.onMount === 'function') {
-        return this.options.onMount(this.state.values, this)
-      }
-      if (this.options.validator) {
+      if (
+        this.options.validator &&
+        typeof this.options.onMount !== 'function'
+      ) {
         return (this.options.validator as Validator<TFormData>)().validate(
           this.state.values,
           this.options.onMount,
         )
       }
+      return (this.options.onMount as ValidateFn<TFormData, ValidatorType>)(
+        this.state.values,
+        this,
+      )
     }
+    if (!this.options.onMount) return
     const error = doValidate()
     if (error) {
       this.store.setState((prev) => ({
@@ -269,17 +274,16 @@ export class FormApi<TFormData, ValidatorType> {
 
     const errorMapKey = getErrorMapKey(cause)
     const doValidate = () => {
-      if (typeof validate === 'function') {
-        return validate(this.state.values, this) as ValidationError
-      }
       if (this.options.validator && typeof validate !== 'function') {
         return (this.options.validator as Validator<TFormData>)().validate(
           this.state.values,
           validate,
         )
       }
-      throw new Error(
-        `Form validation for ${errorMapKey} failed. ${errorMapKey} should either be a function, or \`validator\` should be correct.`,
+
+      return (validate as ValidateFn<TFormData, ValidatorType>)(
+        this.state.values,
+        this,
       )
     }
 


### PR DESCRIPTION
This PR fixes an error that was introduced in #505, which I did not catch prior to merging. Sorry y'all!