### PR TITLE
fix: make validateAllFields more stable

### DIFF
--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -256,14 +256,14 @@ export class FormApi<TFormData, ValidatorType> {
         Object.values(this.fieldInfo) as FieldInfo<any, ValidatorType>[]
       ).forEach((field) => {
         Object.values(field.instances).forEach((instance) => {
+          // Validate the field
+          fieldValidationPromises.push(
+            Promise.resolve().then(() => instance.validate(cause)),
+          )
           // If any fields are not touched
           if (!instance.state.meta.isTouched) {
             // Mark them as touched
             instance.setMeta((prev) => ({ ...prev, isTouched: true }))
-            // Validate the field
-            fieldValidationPromises.push(
-              Promise.resolve().then(() => instance.validate(cause)),
-            )
           }
         })
       })

--- a/packages/form-core/src/tests/FormApi.spec.ts
+++ b/packages/form-core/src/tests/FormApi.spec.ts
@@ -816,4 +816,27 @@ describe('form api', () => {
       form.state.fieldMeta['firstName'].errorMap['onSubmit'],
     ).toBeUndefined()
   })
+
+  it('should validate all fields consistently', async () => {
+    const form = new FormApi({
+      defaultValues: {
+        firstName: '',
+        lastName: '',
+      },
+    })
+
+    const field = new FieldApi({
+      form,
+      name: 'firstName',
+      onChange: (v) => (v.length > 0 ? undefined : 'first name is required'),
+    })
+
+    field.mount()
+    form.mount()
+
+    await form.validateAllFields('change')
+    expect(field.getMeta().errorMap.onChange).toEqual('first name is required')
+    await form.validateAllFields('change')
+    expect(field.getMeta().errorMap.onChange).toEqual('first name is required')
+  })
 })


### PR DESCRIPTION
This PR closes #521 by making `validateSync` better at actually returning when it should trigger `validateAsync` internally. This makes our validation logic substantially more stable