### PR TITLE
Validator Overhaul

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -25,7 +25,7 @@ Feature/Capability Key:
 | Nested object/array fields                        | ✅                                           | ❓                             | ❓                                     | ❓                                               | ❓                                     |
 | Async validation                                  | ✅                                           | ❓                             | ❓                                     | ❓                                               | ❓                                     |
 | Built-in async validation debounce                | ✅                                           | ❓                             | ❓                                     | ❓                                               | ❓                                     |
-| Schema-based Validation                           | 🔶                                           | ❓                             | ❓                                     | ❓                                               | ❓                                     |
+| Schema-based Validation                           | ✅                                          | ❓                             | ❓                                     | ❓                                               | ❓                                     |
 
 [bpl-tanstack-form]: https://bundlephobia.com/result?p=@tanstack/react-form
 [bp-tanstack-form]: https://badgen.net/bundlephobia/minzip/@tanstack/react-form?label=💾

--- a/docs/config.json
+++ b/docs/config.json
@@ -49,6 +49,10 @@
         {
           "label": "FieldApi",
           "to": "reference/fieldApi"
+        },
+        {
+          "label": "Types",
+          "to": "reference/types"
         }
       ]
     }

--- a/docs/framework/react/quick-start.md
+++ b/docs/framework/react/quick-start.md
@@ -15,9 +15,9 @@ export default function App() {
     defaultValues: {
       fullName: '',
     },
-    onSubmit: async ({ values }) => {
+    onSubmit: async ({ value }) => {
       // Do something with form data
-      console.log(values)
+      console.log(value)
     },
   })
 

--- a/docs/framework/react/quick-start.md
+++ b/docs/framework/react/quick-start.md
@@ -15,7 +15,7 @@ export default function App() {
     defaultValues: {
       fullName: '',
     },
-    onSubmit: async (values) => {
+    onSubmit: async ({ values }) => {
       // Do something with form data
       console.log(values)
     },

--- a/docs/framework/react/reference/Field.md
+++ b/docs/framework/react/reference/Field.md
@@ -3,22 +3,31 @@ id: field
 title: Field
 ---
 
-### `FieldComponent<TParentData>`
+### `FieldComponent<TParentData, TFormValidator>`
 
 A type alias representing a field component for a specific form data type.
 
 ```tsx
-export type FieldComponent = <TField extends DeepKeys<TParentData>>({
+export type FieldComponent<
+  TParentData,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
+> = <
+  TName extends DeepKeys<TParentData>,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
+  TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
+>({
   children,
   ...fieldOptions
-}: {
-  children: (
-    fieldApi: FieldApi<DeepValue<TParentData, TField>, TParentData>,
-  ) => any
-  name: TField
-} & Omit<
-  FieldOptions<DeepValue<TParentData, TField>, TParentData>,
-  'name'
+}: FieldComponentProps<
+  TParentData,
+  TName,
+  TFieldValidator,
+  TFormValidator,
+  TData
 >) => any
 ```
 
@@ -27,39 +36,35 @@ A function component that takes field options and a render function as children 
 ### `Field`
 
 ```tsx
-export function Field<TData, TParentData>({
+export function Field<
+  TParentData,
+  TName extends DeepKeys<TParentData>,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
+>({
   children,
   ...fieldOptions
-}: { children: (fieldApi: FieldApi<TData, TParentData>) => any } & FieldOptions<
-  TData,
-  TParentData
->): any
+}: {
+  children: (
+    fieldApi: FieldApi<TParentData, TName, TFieldValidator, TFormValidator>,
+  ) => any
+} & UseFieldOptions<TParentData, TName, TFieldValidator, TFormValidator>): JSX.Element
 ```
 
 A functional React component that renders a form field.
 
 - ```tsx
-  children: (fieldApi: FieldApi<TData, TParentData>) => any
+  children: (fieldApi: FieldApi<TParentData, TName, TFieldValidator, TFormValidator>) => any
   ```
   - A render function that takes a field API instance and returns a React element.
 - ```tsx
-  fieldOptions: FieldOptions<TData, TParentData>
+  fieldOptions: UseFieldOptions<TParentData, TName, TFieldValidator, TFormValidator>
   ```
   - The field options.
 
 The `Field` component uses the `useField` hook internally to manage the field instance.
 
-### `createFieldComponent`
-
-```tsx
-export function createFieldComponent<TParentData>(
-  formApi: FormApi<TParentData>,
-): FieldComponent<TParentData>
-```
-
-A factory function that creates a connected field component for a specific form API instance.
-
-- ```tsx
-  formApi: FormApi<TParentData>
-  ```
-  - The form API instance to connect the field component to.

--- a/docs/framework/react/reference/createFormFactory.md
+++ b/docs/framework/react/reference/createFormFactory.md
@@ -3,34 +3,34 @@ id: createFormFactory
 title: createFormFactory
 ---
 
-### `createFormFactory`
+### `createFormFactory<TFormData, TFormValidator>`
 
 ```tsx
-export function createFormFactory<TFormData>(
-  opts?: FormOptions<TFormData>,
-): FormFactory<TFormData>
+export function createFormFactory<TFormData, TFormValidator>(
+  opts?: FormOptions<TFormData, TFormValidator>,
+): FormFactory<TFormData, TFormValidator>
 ```
 
-A function that creates a new `FormFactory<TFormData>` instance.
+A function that creates a new `FormFactory<TFormData, TFormValidator>` instance.
 
 - `opts`
-  - Optional form options and a `listen` function to be called with the form state.
+  - Optional form options.
 
-### `FormFactory<TFormData>`
+### `FormFactory<TFormData, TFormValidator>`
 
 A type representing a form factory. Form factories provide a type-safe way to interact with the form API as opposed to using the globally exported form utilities.
 
 ```tsx
-export type FormFactory<TFormData> = {
-  useForm: (opts?: FormOptions<TFormData>) => FormApi<TFormData>
+export type FormFactory<TFormData, TFormValidator> = {
+  useForm: (opts?: FormOptions<TFormData, TFormValidator>) => FormApi<TFormData>
   useField: UseField<TFormData>
-  Field: FieldComponent<TFormData>
+  Field: FieldComponent<TFormData, TFormValidator>
 }
 ```
 
 - `useForm`
-  - A custom hook that creates and returns a new instance of the `FormApi<TFormData>` class.
+  - A custom hook that creates and returns a new instance of the `FormApi` class.
 - `useField`
-  - A custom hook that returns an instance of the `FieldApi<TFormData>` class.
+  - A custom hook that returns an instance of the `FieldApi` class.
 - `Field`
   - A form field component.

--- a/docs/framework/react/reference/fieldApi.md
+++ b/docs/framework/react/reference/fieldApi.md
@@ -3,11 +3,11 @@ id: fieldApi
 title: Field API
 ---
 
-### `FieldApi<TData, TParentData>`
+### `FieldApi<TParentData, TName, TFieldValidator, TFormValidator, TData>`
 
-When using `@tanstack/react-form`, the [core field API](../../reference/fieldApi) is extended with additional methods for React-specific functionality:
+When using `@tanstack/react-form`, the [core field API](../../reference/fieldApi) is extended at type level with additional methods for React-specific functionality:
 
 - ```tsx
-  Field: FieldComponent<TData, TParentData>
+  Field: FieldComponent<TParentData, TFormValidator>
   ```
   - A pre-bound and type-safe sub-field component using this field as a root.

--- a/docs/framework/react/reference/formApi.md
+++ b/docs/framework/react/reference/formApi.md
@@ -3,23 +3,32 @@ id: formApi
 title: Form API
 ---
 
-### `FormApi<TFormData>`
+### `FormApi<TFormData, TFormValidator>`
 
-When using `@tanstack/react-form`, the [core form API](../../reference/formApi) is extended with additional methods for React-specific functionality:
+When using `@tanstack/react-form`, the [core form API](../../reference/formApi) is extended at type level with additional methods for React-specific functionality:
 
 - ```tsx
-  Field: FieldComponent<TFormData>
+  Provider: (props: PropsWithChildren) => JSX.Element
   ```
-  - A pre-bound and type-safe field component, specific to this forms instance.
+  - React provider use to wrap your components. Reference React's [ContextProvider]("https://react.dev/reference/react/createContext#provider")
+- ```tsx
+  Field: FieldComponent<TFormData, TFormValidator>
+  ```
+  - A React component to render form fields. With this, you can render and manage individual form fields.
 - ```tsx
   useField: UseField<TFormData>
   ```
-  - A pre-bound and type-safe custom hook to use fields from this form instance.
+  - A custom React hook that provides functionalities related to individual form fields. It gives you access to field values, errors, and allows you to set or update field values.
 - ```tsx
-  useStore<TSelected = NoInfer<FormState<TFormData>>>(selector?: (state: NoInfer<FormState<TFormData>>) => TSelected): TSelected
+  useStore: <TSelected = NoInfer<FormState<TFormData>>>(
+        selector?: (state: NoInfer<FormState<TFormData>>) => TSelected,
+  ) => TSelected
   ```
-  - A custom hook to use the form store.
+  - A `useStore` hook that connects to the internal store of the form. It can be used to access the form's current state or any other related state information. You can optionally pass in a selector function to cherry-pick specific parts of the state
 - ```tsx
-  Subscribe<TSelected = NoInfer<FormState<TFormData>>>(props: {selector?: (state: NoInfer<FormState<TFormData>>) => TSelected; children: ((state: NoInfer<TSelected>) => React.ReactNode) | React.ReactNode}): any
+   Subscribe: <TSelected = NoInfer<FormState<TFormData>>>(props: {
+        selector?: (state: NoInfer<FormState<TFormData>>) => TSelected
+        children: ((state: NoInfer<TSelected>) => ReactNode) | ReactNode
+  }) => JSX.Element
   ```
-  - A subscription component to provide the selected form state to children.
+  - A `Subscribe` function that allows you to listen and react to changes in the form's state. It's especially useful when you need to execute side effects or render specific components in response to state updates.

--- a/docs/framework/react/reference/useField.md
+++ b/docs/framework/react/reference/useField.md
@@ -8,12 +8,28 @@ title: useField
 A type representing a hook for using a field in a form with the given form data type.
 
 ```tsx
-export type UseField = <TField extends DeepKeys<TParentData>>(
-  opts?: { name: TField } & FieldOptions<
-    DeepValue<TParentData, TField>,
-    TParentData
+export type UseField<TParentData> = <
+  TName extends DeepKeys<TParentData>,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
+>(
+  opts?: { name: Narrow<TName> } & UseFieldOptions<
+    TParentData,
+    TName,
+    TFieldValidator,
+    TFormValidator
   >,
-) => FieldApi<DeepValue<TParentData, TField>, TParentData>
+) => FieldApi<
+  TParentData,
+  TName,
+  TFieldValidator,
+  TFormValidator,
+  DeepValue<TParentData, TName>
+>
 ```
 
 - A function that takes an optional object with a `name` property and field options, and returns a `FieldApi` instance for the specified field.
@@ -21,31 +37,30 @@ export type UseField = <TField extends DeepKeys<TParentData>>(
 ### `useField`
 
 ```tsx
-export function useField<TData, TParentData>(
-  opts: FieldOptions<TData, TParentData>,
-): FieldApi<TData, TParentData>
+export function useField<
+  TParentData,
+  TName extends DeepKeys<TParentData>,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
+>(
+  opts: UseFieldOptions<TParentData, TName, TFieldValidator, TFormValidator>,
+): FieldApi<TParentData, TName, TFieldValidator, TFormValidator> 
 ```
 
 A hook for managing a field in a form.
 
 - ```tsx
-  opts: FieldOptions<TData, TParentData>
+  opts: UseFieldOptions<TParentData, TName, TFieldValidator, TFormValidator>
   ```
   - An object with field options.
 
 #### Returns
 
 - ```tsx
-  FieldApi<TData, TParentData>
+  FieldApi<TParentData, TName, TFieldValidator, TFormValidator>
   ```
   - The `FieldApi` instance for the specified field.
-
-### `createUseField`
-
-```tsx
-export function createUseField<TParentData>(
-  formApi: FormApi<TParentData>,
-): UseField<TParentData>
-```
-
-A function that creates a `UseField` hook bound to the given `formApi`.

--- a/docs/framework/react/reference/useForm.md
+++ b/docs/framework/react/reference/useForm.md
@@ -6,70 +6,13 @@ title: useForm
 ### `useForm`
 
 ```tsx
-export function useForm<TData>(opts?: FormOptions<TData>): FormApi<TData>
+export function useForm<
+  TFormData,
+  TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
+>(
+  opts?: FormOptions<TFormData, TFormValidator>,
+): FormApi<TFormData, TFormValidator>
 ```
-A custom react hook that returns an instance of the `FormApi<TData>` class.
+A custom React Hook that returns an instance of the `FormApi` class.
 This API encapsulates all the necessary functionalities related to the form. It allows you to manage form state, handle submissions, and interact with form fields
 
-
-
-### `FormProps`
-
-An object type representing the form component props.
-
-- Inherits from `React.HTMLProps<HTMLFormElement>`.
-- `children: React.ReactNode`
-  - The form's child elements.
-
-```tsx
-  onSubmit: (e: FormSubmitEvent) => void
-```
-  - `onSubmit` function of type `FormSubmitEvent = React.FormEvent<HTMLFormElement>`
-
-```tsx
-  disabled: boolean
-```
-  - `disabled` boolean to disable form
-
-
-
-### Return value of `UseForm` is  `FormApi<TFormData>`
-
-- The `FormApi` contains the following properties
-
-```tsx
-Provider: (props: { children: any }) => any
-```
-- React provider use to wrap your components
-- Reference React [ContextProvider]("https://react.dev/reference/react/createContext#provider")
-
-
-
-```tsx
-   Field: FieldComponent<TFormData, TFormData>getFormProps: () => FormProps
-```
-- A React component to render form fields. With this, you can render and manage individual form fields.
-
-```tsx
-   useField: UseField<TFormData>
-```
-- A custom React hook that provides functionalities related to individual form fields. It gives you access to field values, errors, and allows you to set or update field values.
-
-
-```tsx
-   useStore: <TSelected = NoInfer<FormState<TFormData>>>(
-      selector?: (state: NoInfer<FormState<TFormData>>) => TSelected,
-    ) => TSelected
-```
-- a `useStore` hook that connects to the internal store of the form. It can be used to access the form's current state or any other related state information. You can optionally pass in a selector function to cherry-pick specific parts of the state
-
-
-```tsx
-   Subscribe: <TSelected = NoInfer<FormState<TFormData>>>(props: {
-      selector?: (state: NoInfer<FormState<TFormData>>) => TSelected
-      children:
-        | ((state: NoInfer<TSelected>) => React.ReactNode)
-        | React.ReactNode
-    }) => any
-```
-- a `Subscribe` function that allows you to listen and react to changes in the form's state. It's especially useful when you need to execute side effects or render specific components in response to state updates.

--- a/docs/framework/solid/quick-start.md
+++ b/docs/framework/solid/quick-start.md
@@ -13,9 +13,9 @@ function App() {
     defaultValues: {
       fullName: '',
     },
-    onSubmit: async (values) => {
+    onSubmit: async ({ value }) => {
       // Do something with form data
-      console.log(values)
+      console.log(value)
     },
   }))
 

--- a/docs/framework/vue/quick-start.md
+++ b/docs/framework/vue/quick-start.md
@@ -3,6 +3,12 @@ id: quick-start
 title: Quick Start
 ---
 
+> There is a bug in Vue's TypeScript support that's impacting our types that you'll likely run into: 
+>
+> https://github.com/vuejs/language-tools/issues/3782
+>
+> Please give it a thumbs up, but _do not reply with comments such as "+1" or "When will this be fixed?", as such comments are unhelpful and rude_. 
+
 The bare minimum to get started with TanStack Form is to create a form and add a field. Keep in mind that this example does not include any validation or error handling... yet.
 
 ```vue
@@ -14,9 +20,9 @@ const form = useForm({
   defaultValues: {
     fullName: '',
   },
-  onSubmit: async (values) => {
+  onSubmit: async ({ value }) => {
     // Do something with form data
-    console.log(values)
+    console.log(value)
   },
 })
 
@@ -43,3 +49,4 @@ form.provideFormContext()
 ```
 
 From here, you'll be ready to explore all of the other features of TanStack Form!
+

--- a/docs/guides/basic-concepts.md
+++ b/docs/guides/basic-concepts.md
@@ -27,9 +27,9 @@ A Form Instance is an object that represents an individual form and provides met
 
 ```tsx
 const form = formFactory.useForm({
-  onSubmit: async (values) => {
+  onSubmit: async ({ value }) => {
     // Do something with form data
-    console.log(values)
+    console.log(value)
   },
 })
 ```
@@ -58,7 +58,7 @@ Example:
 
 ## Field State
 
-Each field has its own state, which includes its current value, validation status, error messages, and other metadata. You can access a field's state using the field.state property.
+Each field has its own state, which includes its current value, validation status, error messages, and other metadata. You can access a field's state using the `field.state` property.
 
 Example:
 
@@ -82,17 +82,27 @@ Example:
 
 ## Validation
 
-`@tanstack/react-form` provides both synchronous and asynchronous validation out of the box. Validation functions can be passed to the form.Field component using the validate and validateAsync props.
+`@tanstack/react-form` provides both synchronous and asynchronous validation out of the box. Validation functions can be passed to the `form.Field` component using the `validators` prop.
 
 Example:
 
 ```tsx
 <form.Field
   name="firstName"
-  validate={(value) => !value && 'A first name is required'}
-  validateAsync={async (value) => {
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-    return value.includes('error') && 'No "error" allowed in first name'
+   validators={{
+    onChange: ({ value }) =>
+      !value
+        ? "A first name is required"
+        : value.length < 3
+        ? "First name must be at least 3 characters"
+        : undefined,
+    onChangeAsync: async ({ value }) => {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      return (
+        value.includes("error") &&
+        'No "error" allowed in first name'
+      );
+    },
   }}
   children={(field) => (
     <>
@@ -114,21 +124,29 @@ In addition to hand-rolled validation options, we also provide adapters like `@t
 Example:
 
 ```tsx
+import { zodValidator } from "@tanstack/zod-form-adapter";
+import { z } from "zod";
+
+// ...
+
 <form.Field
   name="firstName"
-  onChange={z
-    .string()
-    .min(3, "First name must be at least 3 characters")}
-  onChangeAsyncDebounceMs={500}
-  onChangeAsync={z.string().refine(
-    async (value) => {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      return !value.includes("error");
-    },
-    {
-      message: "No 'error' allowed in first name",
-    },
-  )}
+  validatorAdapter={zodValidator}
+  validators={{
+    onChange: z
+      .string()
+      .min(3, "First name must be at least 3 characters"),
+    onChangeAsyncDebounceMs: 500,
+    onChangeAsync: z.string().refine(
+      async (value) => {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        return !value.includes("error");
+      },
+      {
+        message: "No 'error' allowed in first name",
+      },
+    ),
+  }}
 />
 ```
 
@@ -151,7 +169,7 @@ Example:
 
 ## Array Fields
 
-Array fields allow you to manage a list of values within a form, such as a list of hobbies. You can create an array field using the form.Field component with the mode="array" prop. The component accepts a children prop, which is a render prop function that takes an arrayField object as its argument.
+Array fields allow you to manage a list of values within a form, such as a list of hobbies. You can create an array field using the `form.Field` component with the `mode="array"` prop. The component accepts a children prop, which is a render prop function that takes an `arrayField` object as its argument.
 
 When working with array fields, you can use the fields `pushValue`, `removeValue`, and `swapValues` methods to add, remove, and swap values in the array.
 

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -142,7 +142,44 @@ Or use the `errorMap` property to access the specific error you're looking for:
 
 As shown above, each `<Field>` accepts its own validation rules via the `onChange`, `onBlur` etc... callbacks. It is also possible to define validation rules at the form level (as opposed to field by field) by passing similar callbacks to the `useForm()` hook.
 
-{/* TODO: add more details when those callbacks are fixed */}
+Example:
+
+```tsx
+export default function App() {
+  const form = useForm({
+    defaultValues: {
+      age: 0,
+    },
+    onSubmit: async ({ value }) => {
+      console.log(value);
+    },
+    validators: {
+      // Add validators to the form the same way you would add them to a field
+      onChange({ value }) {
+        if (value.age < 13) {
+          return "Must be 13 or older to sign";
+        }
+      },
+    },
+  });
+
+  // Subscribe to the form's error map so that updates to it will render
+  // alternately, you can use `form.Subscribe`
+  const formErrorMap = form.useStore((state) => state.errorMap);
+
+  return (
+    <div>
+      {/* ... */}
+      {formErrorMap.onChange ? (
+        <div>
+          <em>There was an error on the form: {formErrorMap.onChange}</em>
+        </div>
+      ) : null}
+      {/* ... */}
+  	</div>
+  );
+}
+```
 
 
 ## Asynchronous Functional Validation

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -270,7 +270,7 @@ import { z } from "zod";
 
 const form = useForm({
   // Either add the validator here or on `Field`
-  validator: zodValidator,
+  validatorAdapter: zodValidator,
   // ...
 });
 

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -18,7 +18,9 @@ Here is an example:
 ```tsx
 <form.Field
   name="age"
-  onChange={val => val < 13 ? "You must be 13 to make an account" : undefined}
+  validators={{
+  	onChange: val => val < 13 ? "You must be 13 to make an account" : undefined
+  }}
 >
   {field => (
     <>
@@ -40,7 +42,9 @@ In the example above, the validation is done at each keystroke (`onChange`). If,
 ```tsx
 <form.Field
   name="age"
-  onBlur={val => val < 13 ? "You must be 13 to make an account" : undefined}
+  validators={{
+  	onBlur: val => val < 13 ? "You must be 13 to make an account" : undefined
+  }}
 >
   {field => (
     <>
@@ -65,8 +69,10 @@ So you can control when the validation is done by implementing the desired callb
 ```tsx
 <form.Field
   name="age"
-  onChange={val => val < 13 ? "You must be 13 to make an account" : undefined}
-  onBlur={(val) => (val < 0 ? "Invalid value" : undefined)}
+  validators={{
+  	onChange: val => val < 13 ? "You must be 13 to make an account" : undefined,
+ 	onBlur: (val) => (val < 0 ? "Invalid value" : undefined)
+  }}
 >
   {field => (
     <>
@@ -95,7 +101,9 @@ Once you have your validation in place, you can map the errors from an array to 
 ```tsx
 <form.Field
   name="age"
-  onChange={val => val < 13 ? "You must be 13 to make an account" : undefined}
+  validators={{
+  	onChange: val => val < 13 ? "You must be 13 to make an account" : undefined
+  }}
 >
   {(field) => {
     return (
@@ -115,7 +123,9 @@ Or use the `errorMap` property to access the specific error you're looking for:
 ```tsx
 <form.Field
   name="age"
-  onChange={val => val < 13 ? "You must be 13 to make an account" : undefined}
+  validators={{
+  	onChange: val => val < 13 ? "You must be 13 to make an account" : undefined
+  }}
 >
   {(field) => (
       <>
@@ -144,11 +154,13 @@ To do this, we have dedicated `onChangeAsync`, `onBlurAsync`, and other methods 
 ```tsx
 <form.Field
   name="age"
-  onChangeAsync={async (value) => {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    return (
-      value < 13 ? "You must be 13 to make an account" : undefined
-    );
+  validators={{
+  	onChangeAsync: async (value) => {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        return (
+          value < 13 ? "You must be 13 to make an account" : undefined
+        );
+    }
   }}
 >
   {field => (
@@ -171,12 +183,14 @@ Synchronous and Asynchronous validations can coexist. For example it is possible
 ```tsx
 <form.Field
   name="age"
-  onBlur={(value) => value < 13 ? "You must be at least 13" : undefined}
-  onBlurAsync={async (value) => {
-    const currentAge = await fetchCurrentAgeOnProfile();
-    return (
-      value < currentAge ? "You can only increase the age" : undefined
-    );
+  validators={{
+	  onBlur: (value) => value < 13 ? "You must be at least 13" : undefined,
+	  onBlurAsync: async (value) => {
+        const currentAge = await fetchCurrentAgeOnProfile();
+        return (
+          value < currentAge ? "You can only increase the age" : undefined
+        );
+      }
   }}
 >
   {field => (
@@ -207,8 +221,10 @@ Instead, we enable an easy method for debouncing your `async` calls by adding a 
 <form.Field
   name="age"
   asyncDebounceMs={500}
-  onChangeAsync={async (value) => {
-    // ...
+  validators={{
+      onChangeAsync={async (value) => {
+        // ...
+      }
   }}
   children={(field) => {
     return (
@@ -226,12 +242,14 @@ This will debounce every async call with a 500ms delay. You can even override th
 <form.Field
   name="age"
   asyncDebounceMs={500}
-  onChangeAsyncDebounceMs={1500}
-  onChangeAsync={async (value) => {
-    // ...
-  }}
-  onBlurAsync={async (value) => {
-    // ...
+  validators={{
+      onChangeAsyncDebounceMs: 1500,
+      onChangeAsync: async (value) => {
+        // ...
+      },
+      onBlurAsync: async (value) => {
+        // ...
+      }
   }}
   children={(field) => {
     return (
@@ -276,10 +294,10 @@ const form = useForm({
 
 <form.Field
   name="age"
-  validator={zodValidator}
-  onChange={z
-    .number()
-    .gte(13, "You must be 13 to make an account")}
+  validatorAdapter={zodValidator}
+  validators={{
+    onChange: z.number().gte(13, "You must be 13 to make an account")
+  }}
   children={(field) => {
     return (
       <>
@@ -295,21 +313,23 @@ These adapters also support async operations using the proper property names:
 ```tsx
 <form.Field
   name="age"
-  onChange={z
-    .number()
-    .gte(13, "You must be 13 to make an account")}
-  onChangeAsyncDebounceMs={500}
-  onChangeAsync={z.number().refine(
-    async (value) => {
-      const currentAge = await fetchCurrentAgeOnProfile();
-      return (
-        value >= currentAge
-      );
-    },
-    {
-      message: "You can only increase the age",
-    },
-  )}
+  validators={{
+      onChange: z
+        .number()
+        .gte(13, "You must be 13 to make an account"),
+      onChangeAsyncDebounceMs: 500,
+      onChangeAsync: z.number().refine(
+        async (value) => {
+          const currentAge = await fetchCurrentAgeOnProfile();
+          return (
+            value >= currentAge
+          );
+        },
+        {
+          message: "You can only increase the age",
+        },
+      )
+  }}
   children={(field) => {
     return (
       <>

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -26,33 +26,33 @@ In the example below, you can see TanStack Form in action with the React framewo
 [Open in CodeSandbox](https://codesandbox.io/s/github/tanstack/form/tree/main/examples/react/simple)
 
 ```tsx
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import { useForm } from '@tanstack/react-form'
-import type { FieldApi } from '@tanstack/react-form'
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+import { useForm } from "@tanstack/react-form";
+import type { FieldApi } from "@tanstack/react-form";
 
-function FieldInfo({ field }: { field: FieldApi<any, any> }) {
+function FieldInfo({ field }: { field: FieldApi<any, any, any, any> }) {
   return (
     <>
-      {field.state.meta.touchedError ? (
-        <em>{field.state.meta.touchedError}</em>
+      {field.state.meta.touchedErrors ? (
+        <em>{field.state.meta.touchedErrors}</em>
       ) : null}
-      {field.state.meta.isValidating ? 'Validating...' : null}
+      {field.state.meta.isValidating ? "Validating..." : null}
     </>
-  )
+  );
 }
 
 export default function App() {
   const form = useForm({
     defaultValues: {
-      firstName: '',
-      lastName: '',
+      firstName: "",
+      lastName: "",
     },
-    onSubmit: async (values) => {
+    onSubmit: async ({ value }) => {
       // Do something with form data
-      console.log(values)
+      console.log(value);
     },
-  })
+  });
 
   return (
     <div>
@@ -60,28 +60,30 @@ export default function App() {
       <form.Provider>
         <form
           onSubmit={(e) => {
-            e.preventDefault()
-            e.stopPropagation()
-            void form.handleSubmit()
+            e.preventDefault();
+            e.stopPropagation();
+            void form.handleSubmit();
           }}
         >
           <div>
             {/* A type-safe field component*/}
             <form.Field
               name="firstName"
-              onChange={(value) =>
-                !value
-                  ? 'A first name is required'
-                  : value.length < 3
-                  ? 'First name must be at least 3 characters'
-                  : undefined
-              }
-              onChangeAsyncDebounceMs={500}
-              onChangeAsync={async (value) => {
-                await new Promise((resolve) => setTimeout(resolve, 1000))
-                return (
-                  value.includes('error') && 'No "error" allowed in first name'
-                )
+              validators={{
+                onChange: ({ value }) =>
+                  !value
+                    ? "A first name is required"
+                    : value.length < 3
+                    ? "First name must be at least 3 characters"
+                    : undefined,
+                onChangeAsyncDebounceMs: 500,
+                onChangeAsync: async ({ value }) => {
+                  await new Promise((resolve) => setTimeout(resolve, 1000));
+                  return (
+                    value.includes("error") &&
+                    'No "error" allowed in first name'
+                  );
+                },
               }}
               children={(field) => {
                 // Avoid hasty abstractions. Render props are great!
@@ -96,7 +98,7 @@ export default function App() {
                     />
                     <FieldInfo field={field} />
                   </>
-                )
+                );
               }}
             />
           </div>
@@ -121,19 +123,19 @@ export default function App() {
             selector={(state) => [state.canSubmit, state.isSubmitting]}
             children={([canSubmit, isSubmitting]) => (
               <button type="submit" disabled={!canSubmit}>
-                {isSubmitting ? '...' : 'Submit'}
+                {isSubmitting ? "..." : "Submit"}
               </button>
             )}
           />
         </form>
       </form.Provider>
     </div>
-  )
+  );
 }
 
-const rootElement = document.getElementById('root')!
+const rootElement = document.getElementById("root")!;
 
-ReactDOM.createRoot(rootElement).render(<App />)
+createRoot(rootElement).render(<App />);
 ```
 
 ## You talked me into it, so what now?

--- a/docs/reference/fieldApi.md
+++ b/docs/reference/fieldApi.md
@@ -11,7 +11,7 @@ Normally, you will not need to create a new `FieldApi` instance directly. Instea
 const fieldApi: FieldApi<TData> = new FieldApi(formOptions: Field Options<TData>)
 ```
 
-### `FieldOptions<TParentData, TName, ValidatorType, FormValidator, TData>`
+### `FieldOptions<TParentData, TName, TFieldValidator, TFormValidator, TData>`
 
 An object type representing the options for a field in a form.
 
@@ -44,10 +44,24 @@ An object type representing the options for a field in a form.
   - If `true`, always run async validation, even if there are errors emitted during synchronous validation.
 
 - ```typescript
-  validator?: ValidatorType
+  validatorAdapter?: ValidatorType
   ```
 
   - A validator provided by an extension, like `yupValidator` from `@tanstack/yup-form-adapter`
+
+
+- ```tsx
+  validators?: FieldValidators<
+      TParentData,
+      TName,
+      TFieldValidator,
+      TFormValidator,
+      TData
+  >
+  ```
+  - A list of validators to pass to the field
+
+### `FieldValidators<TParentData, TName, TFieldValidator, TFormValidator, TData>`
 
 - ```tsx
   onMount?: (formApi: FieldApi<TData, TParentData>) => void
@@ -93,19 +107,28 @@ An object type representing the options for a field in a form.
   - An optional number to represent how long the `onBlurAsyncDebounceMs` should wait before running
   - If set to a number larger than 0, will debounce the async validation event by this length of time in milliseconds
 
-  ```tsx
-  onSubmitAsync?: number
-  ```
-
-  - If set to a number larger than 0, will debounce the async validation event by this length of time in milliseconds. If `validator` is passed, this may also accept a property from the respective validator (IE: `z.string().refine(async (val) => val.length > 3, { message: 'Testing 123' })` if `zodAdapter` is passed)
-
-### `ValidationCause`
-
-A type representing the cause of a validation event.
 
 - ```tsx
-  'change' | 'blur' | 'submit' | 'mount'
+  onSubmit?: ValidateFn<TData, TParentData>
   ```
+
+  - An optional function, when that run when subscribing to submit event of input. If `validator` is passed, this may also accept a property from the respective validator (IE: `z.string().min(1)` if `zodAdapter` is passed)
+
+- ```tsx
+  onSubmitAsync?: ValidateAsyncFn<TData, TParentData>
+  ```
+
+  - An optional function that takes a `ValidateFn` which is a generic of `TData` and `TParentData` happens async. If `validator` is passed, this may also accept a property from the respective validator (IE: `z.string().refine(async (val) => val.length > 3, { message: 'Testing 123' })` if `zodAdapter` is passed)
+
+  ```tsx
+  onSubmitAsyncDebounceMs?: number
+  ```
+
+  - An optional number to represent how long the `onSubmitAsyncDebounceMs` should wait before running
+  - If set to a number larger than 0, will debounce the async validation event by this length of time in milliseconds
+
+
+
 
 ### `FieldMeta`
 
@@ -138,7 +161,7 @@ An object type representing the required options for the `FieldApi` class.
 
 - Inherits from `FieldOptions<TData, TParentData>` with the `form` property set as required.
 
-### `FieldApi<TData, TParentData>`
+### `FieldApi<TParentData, TName, TFieldValidator, TFormValidator, TData>`
 
 A class representing the API for managing a form field.
 

--- a/docs/reference/formApi.md
+++ b/docs/reference/formApi.md
@@ -5,45 +5,63 @@ title: Form API
 
 ### Creating a new FormApi Instance
 
-
-
 Normally, you will not need to create a new `FormApi` instance directly. Instead, you will use a framework hook/function like `useForm` or `createForm` to create a new instance for you that utilizes your frameworks reactivity model. However, if you need to create a new instance manually, you can do so by calling the `new FormApi` constructor.
 
 ```tsx
 const formApi: FormApi<TData> = new FormApi(formOptions: FormOptions<TData>)
 ```
 
-### `FormOptions<TData, ValidatorType>`
+### `FormOptions<TFormData, TFormValidator>`
 
 An object representing the options for a form.
 
 - ```tsx
-    defaultValues?: TData
+  asyncDebounceMs?: number
+  ```
+  -  Optional time in milliseconds if you want to introduce a delay before firing off an async action.
+
+- ```tsx
+  asyncAlways?: boolean
+  ```
+  -  If true, always run async validation, even when sync validation has produced an error. Defaults to `undefined`.
+
+- ```tsx
+  defaultValues?: TData
   ```
   - Set initial values for your form.
+  
 - ```tsx
-    defaultState?: Partial<FormState<TData>>
+  defaultState?: Partial<FormState<TData>>
   ```
   - The default state for the form.
 
 - ```tsx
-    asyncDebounceMs?: number
+  onSubmit?: (values: TData, formApi: FormApi<TData>) => any | Promise<any>
   ```
-  -  Optional time in milliseconds if you want to introduce a delay before firing off an async action.
+  - A function to be called when the form is submitted, what should happen once the user submits a valid form  returns `any` or a promise `Promise<any>`
+
+- ```tsx
+  onSubmitInvalid?: (values: TData, formApi: FormApi<TData>) => void
+  ```
+  - Specify an action for scenarios where the user tries to submit an invalid form.
+
+- ```tsx
+  validatorAdapter?: TFormValidator
+  ```
+  - A validator adapter to support usage of extra validation types (IE: Zod, Yup, or Valibot usage)
+
+- ```tsx
+  validators?: FormValidators<TFormData, TFormValidator>
+  ```
+  - A list of validators to pass to the form
+
+### `FormValidators<TFormData, TFormValidator>`
 
 - ```tsx
   onMount?: (values: TData, formApi: FormApi<TData>) => ValidationError
   ```
   -  Optional function that fires as soon as the component mounts.
-- ```tsx
-    onMountAsync?: ( values: TData, formApi: FormApi<TData>) => ValidationError | Promise<ValidationError>
-  ```
-  -  Optional async function that fires when the component mounts
-- ```tsx
-    onMountAsyncDebounceMs?: number
-  ```
-  - The default time in milliseconds that if set to a number larger than 0, will debounce the async validation event by this length of time in milliseconds.
-
+  
 - ```tsx
      onChange?: (values: TData, formApi: FormApi<TData>) => ValidationError
   ```
@@ -74,18 +92,7 @@ An object representing the options for a form.
   ```
   - The default time in milliseconds that if set to a number larger than 0, will debounce the async validation event by this length of time in milliseconds.
 
-- ```tsx
-  onSubmit?: (values: TData, formApi: FormApi<TData>) => any | Promise<any>
-  ```
-  - A function to be called when the form is submitted, what should happen once the user submits a valid form  returns `any` or a promise `Promise<any>`
-
-- ```tsx
-    onSubmitInvalid?: (values: TData, formApi: FormApi<TData>) => void
-  ```
-  - Specify an action for scenarios where the user tries to submit an invalid form.
-
-
-### `FormApi<TFormData, ValidatorType>`
+### `FormApi<TFormData, TFormValidator>`
 
 A class representing the Form API. It handles the logic and interactions with the form state.
 
@@ -95,35 +102,31 @@ A class representing the Form API. It handles the logic and interactions with th
   options: FormOptions<TFormData> = {}
   ```
   - The options for the form.
+  
 - ```tsx
   store: Store<FormState<TFormData>>
   ```
   - A [TanStack Store instance](https://tanstack.com/store/latest/docs/reference/Store) that keeps track of the form's state.
+  
 - ```tsx
   state: FormState<TFormData>
   ```
   - The current state of the form.
+  
 - ```tsx
-  fieldInfo: Record<DeepKeys<TFormData>, FieldInfo<TFormData>> ={} as any
+  fieldInfo: Record<DeepKeys<TFormData>, FieldInfo<TFormData, TFormValidator>> =
+      {} as any
   ```
   - A record of field information for each field in the form.
-- ```tsx
-    fieldName?: string
-  ```
-  - An optional string representing the name of the field.
-- ```tsx
-  validationMeta: ValidationMeta
-  ```
-  - The validation metadata for the form.
 
 #### Methods
 
 - ```tsx
-    constructor(opts?: FormOptions<TFormData>)
+    constructor(opts?: FormOptions<TFormData, TFormValidator>)
   ```
   - Constructs a new `FormApi` instance with the given form options.
 - ```tsx
-    update(options: FormOptions<TFormData>)
+    update(options: FormOptions<TFormData, TFormValidator>)
   ```
   - Updates the form options and form state.
 - ```tsx
@@ -131,14 +134,14 @@ A class representing the Form API. It handles the logic and interactions with th
   ```
   - Resets the form state to the default values.
 - ```tsx
-  validateAllFields()
+  validateAllFields(cause: ValidationCause): Promise<ValidationError[]>
   ```
-  - Validates all fields in the form.
+  - Validates all fields in the form using the correct handlers for a given validation type.
 
 - ```tsx
     handleSubmit()
   ```
-  - Handles the form submission, performs validation, and calls the appropriate onSubmit or onInvalidSubmit callbacks.
+  - Handles the form submission, performs validation, and calls the appropriate `onSubmit` or `onInvalidSubmit` callbacks.
 - ```tsx
     getFieldValue<TField extends DeepKeys<TFormData>>(field: TField)
   ```
@@ -184,109 +187,110 @@ An object representing the current state of the form.
   values: TData
   ```
   - The current values of the form fields.
+
+- ```tsx
+  errors: ValidationError[]
+  ```
+  - The error array for the form itself.
+
+- ```tsx
+  errorMap: ValidationErrorMap
+  ```
+  - The error map for the form itself.
+  
 - ```tsx
   isFormValidating: boolean
   ```
   - A boolean indicating if the form is currently validating.
-- ```tsx
-  formValidationCount: number
-  ```
-  - A counter for tracking the number of validations performed on the form.
+  
 - ```tsx
   isFormValid: boolean
   ```
   - A boolean indicating if the form is valid.
-- ```tsx
-    formError?: ValidationError
-  ```
-  - A possible validation error for the form.
+  
 - ```tsx
   fieldMeta: Record<DeepKeys<TData>, FieldMeta>
   ```
   - A record of field metadata for each field in the form.
+  
 - ```tsx
   isFieldsValidating: boolean
   ```
   - A boolean indicating if any of the form fields are currently validating.
+  
 - ```tsx
   isFieldsValid: boolean
   ```
   - A boolean indicating if all the form fields are valid.
+  
 - ```tsx
   isSubmitting: boolean
   ```
   - A boolean indicating if the form is currently submitting.
+  
 - ```tsx
   isTouched: boolean
   ```
   - A boolean indicating if any of the form fields have been touched.
+  
 - ```tsx
   isSubmitted: boolean
   ```
   - A boolean indicating if the form has been submitted.
+  
 - ```tsx
   isValidating: boolean
   ```
   - A boolean indicating if the form or any of its fields are currently validating.
+  
 - ```tsx
   isValid: boolean
   ```
   - A boolean indicating if the form and all its fields are valid.
+  
 - ```tsx
   canSubmit: boolean
   ```
   - A boolean indicating if the form can be submitted based on its current state.
+  
 - ```tsx
   submissionAttempts: number
   ```
   - A counter for tracking the number of submission attempts.
+
+- ```tsx
+  validationMetaMap: Record<ValidationErrorMapKeys, ValidationMeta | undefined>
+  ```
+  - An internal mechanism used for keeping track of validation logic in a form.
 
 ### `FieldInfo<TFormData>`
 
 An object representing the field information for a specific field within the form.
 
 - ```tsx
-  instances: Record<string, FieldApi<any, TFormData>>
+  instances: Record<
+    string,
+    FieldApi<
+      TFormData,
+      any,
+      Validator<unknown, unknown> | undefined,
+      TFormValidator
+    >
+  >
   ```
   - A record of field instances with unique identifiers as keys.
+
+- ```tsx
+  validationMetaMap: Record<ValidationErrorMapKeys, ValidationMeta | undefined>
+  ```
+  - A record of field validation internal handling.
   - Check below for `ValidationMeta`
-
-
 
 ### `ValidationMeta`
 
-An object representing the validation metadata for a field.
+An object representing the validation metadata for a field. Not intended for public usage.
 
 - ```tsx
-    validationCount?: number
+    lastAbortController: AbortController
   ```
-  - A counter for tracking the number of validations performed on the field.
-
-- ```tsx
-    validationAsyncCount?: number
-  ```
-  - A counter for tracking the number of validations performed on the field async.
-- ```tsx
-    validationPromise?: Promise<ValidationError>
-  ```
-  - A promise representing the current validation state of the field.
-- ```tsx
-    validationResolve?: (error: ValidationError) => void
-  ```
-  - A function to resolve the validation promise with a possible validation error.
-- ```tsx
-    validationReject?: (error: unknown) => void
-  ```
-  - A function to reject the validation promise with an error.
-
-### `ValidationError`
-
-A type representing a validation error. Possible values are `undefined`, `false`, `null`, or a `string` with an error message.
-
-### `ValidationErrorMapKeys`
-A type representing the keys used to map to `ValidationError` in `ValidationErrorMap`. It is defined with `on${Capitalize<ValidationCause>}`
-
-
-### `ValidationErrorMap`
-
-A type that represents a map with the keys as `ValidationErrorMapKeys` and the values as `ValidationError`
+  - An abort controller stored in memory to cancel previous async validation attempts.

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -1,0 +1,20 @@
+---
+id: types
+title: Types
+
+---
+
+### Using TanStack Form Types
+
+Normally, you will not need use these types directly. However, if you're debugging hard-to-reach issues or are a maintainer of one of our packages, these types can help you distinguish what's going on.
+
+### `ValidationError`
+
+A type representing a validation error. Possible values are `undefined`, `false`, `null`, or a `string` with an error message.
+
+### `ValidationErrorMapKeys`
+A type representing the keys used to map to `ValidationError` in `ValidationErrorMap`. It is defined with `on${Capitalize<ValidationCause>}`
+
+### `ValidationErrorMap`
+
+A type that represents a map with the keys as `ValidationErrorMapKeys` and the values as `ValidationError`

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -7,7 +7,8 @@ TanStack Form is written 100% in **TypeScript** with the highest quality generic
 
 Things to keep in mind:
 
-- Types currently require using TypeScript v4.1 or greater
+- `strict: true` is required in your `tsconfig.json` to get the most out of TanStack Form's types
+- Types currently require using TypeScript v4.8 or greater
 - Changes to types in this repository are considered **non-breaking** and are usually released as **patch** semver changes (otherwise every type enhancement would be a major version!).
 - It is **highly recommended that you lock your react-form package version to a specific patch release and upgrade with the expectation that types may be fixed or upgraded between any release**
 - The non-type-related public API of TanStack Form still follows semver very strictly.

--- a/examples/react/simple/package.json
+++ b/examples/react/simple/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite --port=3001",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:types": "tsc --noEmit"
   },
   "dependencies": {
     "@tanstack/react-form": "0.10.3",

--- a/examples/react/simple/src/index.tsx
+++ b/examples/react/simple/src/index.tsx
@@ -41,19 +41,21 @@ export default function App() {
             {/* A type-safe field component*/}
             <form.Field
               name="firstName"
-              onChange={(value) =>
-                !value
-                  ? "A first name is required"
-                  : value.length < 3
-                  ? "First name must be at least 3 characters"
-                  : undefined
-              }
-              onChangeAsyncDebounceMs={500}
-              onChangeAsync={async (value) => {
-                await new Promise((resolve) => setTimeout(resolve, 1000));
-                return (
-                  value.includes("error") && 'No "error" allowed in first name'
-                );
+              validators={{
+                onChange: (value) =>
+                  !value
+                    ? "A first name is required"
+                    : value.length < 3
+                    ? "First name must be at least 3 characters"
+                    : undefined,
+                onChangeAsyncDebounceMs: 500,
+                onChangeAsync: async (value) => {
+                  await new Promise((resolve) => setTimeout(resolve, 1000));
+                  return (
+                    value.includes("error") &&
+                    'No "error" allowed in first name'
+                  );
+                },
               }}
               children={(field) => {
                 // Avoid hasty abstractions. Render props are great!

--- a/examples/react/simple/src/index.tsx
+++ b/examples/react/simple/src/index.tsx
@@ -3,7 +3,7 @@ import { createRoot } from "react-dom/client";
 import { useForm } from "@tanstack/react-form";
 import type { FieldApi } from "@tanstack/react-form";
 
-function FieldInfo({ field }: { field: FieldApi<any, any> }) {
+function FieldInfo({ field }: { field: FieldApi<any, any, any, any> }) {
   return (
     <>
       {field.state.meta.touchedErrors ? (

--- a/examples/react/simple/src/index.tsx
+++ b/examples/react/simple/src/index.tsx
@@ -3,7 +3,7 @@ import { createRoot } from "react-dom/client";
 import { useForm } from "@tanstack/react-form";
 import type { FieldApi } from "@tanstack/react-form";
 
-function FieldInfo({ field }: { field: FieldApi<any, any, unknown, unknown> }) {
+function FieldInfo({ field }: { field: FieldApi<any, any> }) {
   return (
     <>
       {field.state.meta.touchedErrors ? (

--- a/examples/react/simple/src/index.tsx
+++ b/examples/react/simple/src/index.tsx
@@ -42,14 +42,14 @@ export default function App() {
             <form.Field
               name="firstName"
               validators={{
-                onChange: (value) =>
+                onChange: ({ value }) =>
                   !value
                     ? "A first name is required"
                     : value.length < 3
                     ? "First name must be at least 3 characters"
                     : undefined,
                 onChangeAsyncDebounceMs: 500,
-                onChangeAsync: async (value) => {
+                onChangeAsync: async ({ value }) => {
                   await new Promise((resolve) => setTimeout(resolve, 1000));
                   return (
                     value.includes("error") &&

--- a/examples/react/simple/src/index.tsx
+++ b/examples/react/simple/src/index.tsx
@@ -20,9 +20,9 @@ export default function App() {
       firstName: "",
       lastName: "",
     },
-    onSubmit: async (values) => {
+    onSubmit: async ({ value }) => {
       // Do something with form data
-      console.log(values);
+      console.log(value);
     },
   });
 

--- a/examples/react/simple/tsconfig.json
+++ b/examples/react/simple/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "jsx": "react",
     "noEmit": true,
+    "strict": true,
     "lib": ["DOM", "DOM.Iterable", "ES2020"]
   }
 }

--- a/examples/react/valibot/package.json
+++ b/examples/react/valibot/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite --port=3001",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:types": "tsc --noEmit"
   },
   "dependencies": {
     "@tanstack/react-form": "0.10.3",

--- a/examples/react/valibot/src/index.tsx
+++ b/examples/react/valibot/src/index.tsx
@@ -5,7 +5,7 @@ import { valibotValidator } from "@tanstack/valibot-form-adapter";
 import { customAsync, minLength, string, stringAsync } from "valibot";
 import type { FieldApi } from "@tanstack/react-form";
 
-function FieldInfo({ field }: { field: FieldApi<any, any> }) {
+function FieldInfo({ field }: { field: FieldApi<any, any, any, any> }) {
   return (
     <>
       {field.state.meta.touchedErrors ? (

--- a/examples/react/valibot/src/index.tsx
+++ b/examples/react/valibot/src/index.tsx
@@ -5,7 +5,7 @@ import { valibotValidator } from "@tanstack/valibot-form-adapter";
 import { customAsync, minLength, string, stringAsync } from "valibot";
 import type { FieldApi } from "@tanstack/react-form";
 
-function FieldInfo({ field }: { field: FieldApi<any, any, unknown, unknown> }) {
+function FieldInfo({ field }: { field: FieldApi<any, any> }) {
   return (
     <>
       {field.state.meta.touchedErrors ? (

--- a/examples/react/valibot/src/index.tsx
+++ b/examples/react/valibot/src/index.tsx
@@ -22,9 +22,9 @@ export default function App() {
       firstName: "",
       lastName: "",
     },
-    onSubmit: async (values) => {
+    onSubmit: async ({ value }) => {
       // Do something with form data
-      console.log(values);
+      console.log(value);
     },
     // Add a validator to support Valibot usage in Form and Field
     validatorAdapter: valibotValidator,

--- a/examples/react/valibot/src/index.tsx
+++ b/examples/react/valibot/src/index.tsx
@@ -27,7 +27,7 @@ export default function App() {
       console.log(values);
     },
     // Add a validator to support Valibot usage in Form and Field
-    validator: valibotValidator,
+    validatorAdapter: valibotValidator,
   });
 
   return (

--- a/examples/react/valibot/src/index.tsx
+++ b/examples/react/valibot/src/index.tsx
@@ -45,16 +45,18 @@ export default function App() {
             {/* A type-safe field component*/}
             <form.Field
               name="firstName"
-              onChange={string([
-                minLength(3, "First name must be at least 3 characters"),
-              ])}
-              onChangeAsyncDebounceMs={500}
-              onChangeAsync={stringAsync([
-                customAsync(async (value) => {
-                  await new Promise((resolve) => setTimeout(resolve, 1000));
-                  return !value.includes("error");
-                }, "No 'error' allowed in first name"),
-              ])}
+              validators={{
+                onChange: string([
+                  minLength(3, "First name must be at least 3 characters"),
+                ]),
+                onChangeAsyncDebounceMs: 500,
+                onChangeAsync: stringAsync([
+                  customAsync(async (value) => {
+                    await new Promise((resolve) => setTimeout(resolve, 1000));
+                    return !value.includes("error");
+                  }, "No 'error' allowed in first name"),
+                ]),
+              }}
               children={(field) => {
                 // Avoid hasty abstractions. Render props are great!
                 return (

--- a/examples/react/valibot/tsconfig.json
+++ b/examples/react/valibot/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "jsx": "react",
     "noEmit": true,
+    "strict": true,
     "lib": ["DOM", "DOM.Iterable", "ES2020"]
   }
 }

--- a/examples/react/yup/package.json
+++ b/examples/react/yup/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite --port=3001",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:types": "tsc --noEmit"
   },
   "dependencies": {
     "@tanstack/react-form": "0.10.3",

--- a/examples/react/yup/src/index.tsx
+++ b/examples/react/yup/src/index.tsx
@@ -45,20 +45,22 @@ export default function App() {
             {/* A type-safe field component*/}
             <form.Field
               name="firstName"
-              onChange={yup
-                .string()
-                .min(3, "First name must be at least 3 characters")}
-              onChangeAsyncDebounceMs={500}
-              onChangeAsync={yup
-                .string()
-                .test(
-                  "no error",
-                  "No 'error' allowed in first name",
-                  async (value) => {
-                    await new Promise((resolve) => setTimeout(resolve, 1000));
-                    return !value.includes("error");
-                  },
-                )}
+              validators={{
+                onChange: yup
+                  .string()
+                  .min(3, "First name must be at least 3 characters"),
+                onChangeAsyncDebounceMs: 500,
+                onChangeAsync: yup
+                  .string()
+                  .test(
+                    "no error",
+                    "No 'error' allowed in first name",
+                    async (value) => {
+                      await new Promise((resolve) => setTimeout(resolve, 1000));
+                      return !value.includes("error");
+                    },
+                  ),
+              }}
               children={(field) => {
                 // Avoid hasty abstractions. Render props are great!
                 return (

--- a/examples/react/yup/src/index.tsx
+++ b/examples/react/yup/src/index.tsx
@@ -27,7 +27,7 @@ export default function App() {
       console.log(values);
     },
     // Add a validator to support Yup usage in Form and Field
-    validator: yupValidator,
+    validatorAdapter: yupValidator,
   });
 
   return (

--- a/examples/react/yup/src/index.tsx
+++ b/examples/react/yup/src/index.tsx
@@ -5,7 +5,7 @@ import { yupValidator } from "@tanstack/yup-form-adapter";
 import * as yup from "yup";
 import type { FieldApi } from "@tanstack/react-form";
 
-function FieldInfo({ field }: { field: FieldApi<any, any> }) {
+function FieldInfo({ field }: { field: FieldApi<any, any, any, any> }) {
   return (
     <>
       {field.state.meta.touchedErrors ? (

--- a/examples/react/yup/src/index.tsx
+++ b/examples/react/yup/src/index.tsx
@@ -22,9 +22,9 @@ export default function App() {
       firstName: "",
       lastName: "",
     },
-    onSubmit: async (values) => {
+    onSubmit: async ({ value }) => {
       // Do something with form data
-      console.log(values);
+      console.log(value);
     },
     // Add a validator to support Yup usage in Form and Field
     validatorAdapter: yupValidator,

--- a/examples/react/yup/src/index.tsx
+++ b/examples/react/yup/src/index.tsx
@@ -5,7 +5,7 @@ import { yupValidator } from "@tanstack/yup-form-adapter";
 import * as yup from "yup";
 import type { FieldApi } from "@tanstack/react-form";
 
-function FieldInfo({ field }: { field: FieldApi<any, any, unknown, unknown> }) {
+function FieldInfo({ field }: { field: FieldApi<any, any> }) {
   return (
     <>
       {field.state.meta.touchedErrors ? (

--- a/examples/react/yup/src/index.tsx
+++ b/examples/react/yup/src/index.tsx
@@ -57,7 +57,7 @@ export default function App() {
                     "No 'error' allowed in first name",
                     async (value) => {
                       await new Promise((resolve) => setTimeout(resolve, 1000));
-                      return !value.includes("error");
+                      return !value?.includes("error");
                     },
                   ),
               }}

--- a/examples/react/yup/tsconfig.json
+++ b/examples/react/yup/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "jsx": "react",
     "noEmit": true,
+    "strict": true,
     "lib": ["DOM", "DOM.Iterable", "ES2020"]
   }
 }

--- a/examples/react/zod/package.json
+++ b/examples/react/zod/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite --port=3001",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:types": "tsc --noEmit"
   },
   "dependencies": {
     "@tanstack/react-form": "0.10.3",

--- a/examples/react/zod/src/index.tsx
+++ b/examples/react/zod/src/index.tsx
@@ -27,7 +27,7 @@ export default function App() {
       console.log(values);
     },
     // Add a validator to support Zod usage in Form and Field
-    validator: zodValidator,
+    validatorAdapter: zodValidator,
   });
 
   return (

--- a/examples/react/zod/src/index.tsx
+++ b/examples/react/zod/src/index.tsx
@@ -22,9 +22,9 @@ export default function App() {
       firstName: "",
       lastName: "",
     },
-    onSubmit: async (values) => {
+    onSubmit: async ({ value }) => {
       // Do something with form data
-      console.log(values);
+      console.log(value);
     },
     // Add a validator to support Zod usage in Form and Field
     validatorAdapter: zodValidator,

--- a/examples/react/zod/src/index.tsx
+++ b/examples/react/zod/src/index.tsx
@@ -5,7 +5,7 @@ import { zodValidator } from "@tanstack/zod-form-adapter";
 import { z } from "zod";
 import type { FieldApi } from "@tanstack/react-form";
 
-function FieldInfo({ field }: { field: FieldApi<any, any> }) {
+function FieldInfo({ field }: { field: FieldApi<any, any, any, any> }) {
   return (
     <>
       {field.state.meta.touchedErrors ? (

--- a/examples/react/zod/src/index.tsx
+++ b/examples/react/zod/src/index.tsx
@@ -45,19 +45,21 @@ export default function App() {
             {/* A type-safe field component*/}
             <form.Field
               name="firstName"
-              onChange={z
-                .string()
-                .min(3, "First name must be at least 3 characters")}
-              onChangeAsyncDebounceMs={500}
-              onChangeAsync={z.string().refine(
-                async (value) => {
-                  await new Promise((resolve) => setTimeout(resolve, 1000));
-                  return !value.includes("error");
-                },
-                {
-                  message: "No 'error' allowed in first name",
-                },
-              )}
+              validators={{
+                onChange: z
+                  .string()
+                  .min(3, "First name must be at least 3 characters"),
+                onChangeAsyncDebounceMs: 500,
+                onChangeAsync: z.string().refine(
+                  async (value) => {
+                    await new Promise((resolve) => setTimeout(resolve, 1000));
+                    return !value.includes("error");
+                  },
+                  {
+                    message: "No 'error' allowed in first name",
+                  },
+                ),
+              }}
               children={(field) => {
                 // Avoid hasty abstractions. Render props are great!
                 return (

--- a/examples/react/zod/src/index.tsx
+++ b/examples/react/zod/src/index.tsx
@@ -5,7 +5,7 @@ import { zodValidator } from "@tanstack/zod-form-adapter";
 import { z } from "zod";
 import type { FieldApi } from "@tanstack/react-form";
 
-function FieldInfo({ field }: { field: FieldApi<any, any, unknown, unknown> }) {
+function FieldInfo({ field }: { field: FieldApi<any, any> }) {
   return (
     <>
       {field.state.meta.touchedErrors ? (

--- a/examples/react/zod/tsconfig.json
+++ b/examples/react/zod/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "jsx": "react",
     "noEmit": true,
+    "strict": true,
     "lib": ["DOM", "DOM.Iterable", "ES2020"]
   }
 }

--- a/examples/solid/simple/src/index.tsx
+++ b/examples/solid/simple/src/index.tsx
@@ -46,14 +46,14 @@ function App() {
             <form.Field
               name="firstName"
               validators={{
-                onChange: (value) =>
+                onChange: ({ value }) =>
                   !value
                     ? 'A first name is required'
                     : value.length < 3
                     ? 'First name must be at least 3 characters'
                     : undefined,
                 onChangeAsyncDebounceMs: 500,
-                onChangeAsync: async (value) => {
+                onChangeAsync: async ({ value }) => {
                   await new Promise((resolve) => setTimeout(resolve, 1000))
                   return (
                     value.includes('error') &&

--- a/examples/solid/simple/src/index.tsx
+++ b/examples/solid/simple/src/index.tsx
@@ -45,19 +45,21 @@ function App() {
             {/* A type-safe field component*/}
             <form.Field
               name="firstName"
-              onChange={(value) =>
-                !value
-                  ? 'A first name is required'
-                  : value.length < 3
-                  ? 'First name must be at least 3 characters'
-                  : undefined
-              }
-              onChangeAsyncDebounceMs={500}
-              onChangeAsync={async (value) => {
-                await new Promise((resolve) => setTimeout(resolve, 1000))
-                return (
-                  value.includes('error') && 'No "error" allowed in first name'
-                )
+              validators={{
+                onChange: (value) =>
+                  !value
+                    ? 'A first name is required'
+                    : value.length < 3
+                    ? 'First name must be at least 3 characters'
+                    : undefined,
+                onChangeAsyncDebounceMs: 500,
+                onChangeAsync: async (value) => {
+                  await new Promise((resolve) => setTimeout(resolve, 1000))
+                  return (
+                    value.includes('error') &&
+                    'No "error" allowed in first name'
+                  )
+                },
               }}
               children={(field) => {
                 // Avoid hasty abstractions. Render props are great!

--- a/examples/solid/simple/src/index.tsx
+++ b/examples/solid/simple/src/index.tsx
@@ -4,7 +4,7 @@ import { render } from 'solid-js/web'
 import { createForm, type FieldApi } from '@tanstack/solid-form'
 
 interface FieldInfoProps {
-  field: FieldApi<any, any>
+  field: FieldApi<any, any, any, any>
 }
 
 function FieldInfo(props: FieldInfoProps) {

--- a/examples/solid/simple/src/index.tsx
+++ b/examples/solid/simple/src/index.tsx
@@ -24,9 +24,9 @@ function App() {
       firstName: '',
       lastName: '',
     },
-    onSubmit: async (values) => {
+    onSubmit: async ({ value }) => {
       // Do something with form data
-      console.log(values)
+      console.log(value)
     },
   }))
 

--- a/examples/solid/simple/src/index.tsx
+++ b/examples/solid/simple/src/index.tsx
@@ -4,7 +4,7 @@ import { render } from 'solid-js/web'
 import { createForm, type FieldApi } from '@tanstack/solid-form'
 
 interface FieldInfoProps {
-  field: FieldApi<any, any, unknown, unknown>
+  field: FieldApi<any, any>
 }
 
 function FieldInfo(props: FieldInfoProps) {

--- a/examples/solid/valibot/src/index.tsx
+++ b/examples/solid/valibot/src/index.tsx
@@ -26,9 +26,9 @@ function App() {
       firstName: '',
       lastName: '',
     },
-    onSubmit: async (values) => {
+    onSubmit: async ({ value }) => {
       // Do something with form data
-      console.log(values)
+      console.log(value)
     },
     // Add a validator to support Valibot usage in Form and Field
     validatorAdapter: valibotValidator,

--- a/examples/solid/valibot/src/index.tsx
+++ b/examples/solid/valibot/src/index.tsx
@@ -49,16 +49,18 @@ function App() {
             {/* A type-safe field component*/}
             <form.Field
               name="firstName"
-              onChange={string([
-                minLength(3, 'First name must be at least 3 characters'),
-              ])}
-              onChangeAsyncDebounceMs={500}
-              onChangeAsync={stringAsync([
-                customAsync(async (value) => {
-                  await new Promise((resolve) => setTimeout(resolve, 1000))
-                  return !value.includes('error')
-                }, "No 'error' allowed in first name"),
-              ])}
+              validators={{
+                onChange: string([
+                  minLength(3, 'First name must be at least 3 characters'),
+                ]),
+                onChangeAsyncDebounceMs: 500,
+                onChangeAsync: stringAsync([
+                  customAsync(async (value) => {
+                    await new Promise((resolve) => setTimeout(resolve, 1000))
+                    return !value.includes('error')
+                  }, "No 'error' allowed in first name"),
+                ]),
+              }}
               children={(field) => {
                 // Avoid hasty abstractions. Render props are great!
                 return (

--- a/examples/solid/valibot/src/index.tsx
+++ b/examples/solid/valibot/src/index.tsx
@@ -6,7 +6,7 @@ import { valibotValidator } from '@tanstack/valibot-form-adapter'
 import { customAsync, minLength, string, stringAsync } from 'valibot'
 
 interface FieldInfoProps {
-  field: FieldApi<any, any>
+  field: FieldApi<any, any, any, any>
 }
 
 function FieldInfo(props: FieldInfoProps) {

--- a/examples/solid/valibot/src/index.tsx
+++ b/examples/solid/valibot/src/index.tsx
@@ -6,7 +6,7 @@ import { valibotValidator } from '@tanstack/valibot-form-adapter'
 import { customAsync, minLength, string, stringAsync } from 'valibot'
 
 interface FieldInfoProps {
-  field: FieldApi<any, any, unknown, unknown>
+  field: FieldApi<any, any>
 }
 
 function FieldInfo(props: FieldInfoProps) {

--- a/examples/solid/valibot/src/index.tsx
+++ b/examples/solid/valibot/src/index.tsx
@@ -31,7 +31,7 @@ function App() {
       console.log(values)
     },
     // Add a validator to support Valibot usage in Form and Field
-    validator: valibotValidator,
+    validatorAdapter: valibotValidator,
   }))
 
   return (

--- a/examples/solid/yup/src/index.tsx
+++ b/examples/solid/yup/src/index.tsx
@@ -49,20 +49,22 @@ function App() {
             {/* A type-safe field component*/}
             <form.Field
               name="firstName"
-              onChange={yup
-                .string()
-                .min(3, 'First name must be at least 3 characters')}
-              onChangeAsyncDebounceMs={500}
-              onChangeAsync={yup
-                .string()
-                .test(
-                  'no error',
-                  "No 'error' allowed in first name",
-                  async (value) => {
-                    await new Promise((resolve) => setTimeout(resolve, 1000))
-                    return !value?.includes('error')
-                  },
-                )}
+              validators={{
+                onChange: yup
+                  .string()
+                  .min(3, 'First name must be at least 3 characters'),
+                onChangeAsyncDebounceMs: 500,
+                onChangeAsync: yup
+                  .string()
+                  .test(
+                    'no error',
+                    "No 'error' allowed in first name",
+                    async (value) => {
+                      await new Promise((resolve) => setTimeout(resolve, 1000))
+                      return !value?.includes('error')
+                    },
+                  ),
+              }}
               children={(field) => {
                 // Avoid hasty abstractions. Render props are great!
                 return (

--- a/examples/solid/yup/src/index.tsx
+++ b/examples/solid/yup/src/index.tsx
@@ -31,7 +31,7 @@ function App() {
       console.log(values)
     },
     // Add a validator to support Yup usage in Form and Field
-    validator: yupValidator,
+    validatorAdapter: yupValidator,
   }))
 
   return (

--- a/examples/solid/yup/src/index.tsx
+++ b/examples/solid/yup/src/index.tsx
@@ -26,9 +26,9 @@ function App() {
       firstName: '',
       lastName: '',
     },
-    onSubmit: async (values) => {
+    onSubmit: async ({ value }) => {
       // Do something with form data
-      console.log(values)
+      console.log(value)
     },
     // Add a validator to support Yup usage in Form and Field
     validatorAdapter: yupValidator,

--- a/examples/solid/yup/src/index.tsx
+++ b/examples/solid/yup/src/index.tsx
@@ -6,7 +6,7 @@ import { yupValidator } from '@tanstack/yup-form-adapter'
 import * as yup from 'yup'
 
 interface FieldInfoProps {
-  field: FieldApi<any, any>
+  field: FieldApi<any, any, any, any>
 }
 
 function FieldInfo(props: FieldInfoProps) {

--- a/examples/solid/yup/src/index.tsx
+++ b/examples/solid/yup/src/index.tsx
@@ -6,7 +6,7 @@ import { yupValidator } from '@tanstack/yup-form-adapter'
 import * as yup from 'yup'
 
 interface FieldInfoProps {
-  field: FieldApi<any, any, unknown, unknown>
+  field: FieldApi<any, any>
 }
 
 function FieldInfo(props: FieldInfoProps) {

--- a/examples/solid/zod/src/index.tsx
+++ b/examples/solid/zod/src/index.tsx
@@ -6,7 +6,7 @@ import { zodValidator } from '@tanstack/zod-form-adapter'
 import { z } from 'zod'
 
 interface FieldInfoProps {
-  field: FieldApi<any, any, unknown, unknown>
+  field: FieldApi<any, any>
 }
 
 function FieldInfo(props: FieldInfoProps) {

--- a/examples/solid/zod/src/index.tsx
+++ b/examples/solid/zod/src/index.tsx
@@ -49,19 +49,21 @@ function App() {
             {/* A type-safe field component*/}
             <form.Field
               name="firstName"
-              onChange={z
-                .string()
-                .min(3, 'First name must be at least 3 characters')}
-              onChangeAsyncDebounceMs={500}
-              onChangeAsync={z.string().refine(
-                async (value) => {
-                  await new Promise((resolve) => setTimeout(resolve, 1000))
-                  return !value.includes('error')
-                },
-                {
-                  message: "No 'error' allowed in first name",
-                },
-              )}
+              validators={{
+                onChange: z
+                  .string()
+                  .min(3, 'First name must be at least 3 characters'),
+                onChangeAsyncDebounceMs: 500,
+                onChangeAsync: z.string().refine(
+                  async (value) => {
+                    await new Promise((resolve) => setTimeout(resolve, 1000))
+                    return !value.includes('error')
+                  },
+                  {
+                    message: "No 'error' allowed in first name",
+                  },
+                ),
+              }}
               children={(field) => {
                 // Avoid hasty abstractions. Render props are great!
                 return (

--- a/examples/solid/zod/src/index.tsx
+++ b/examples/solid/zod/src/index.tsx
@@ -6,7 +6,7 @@ import { zodValidator } from '@tanstack/zod-form-adapter'
 import { z } from 'zod'
 
 interface FieldInfoProps {
-  field: FieldApi<any, any>
+  field: FieldApi<any, any, any, any>
 }
 
 function FieldInfo(props: FieldInfoProps) {

--- a/examples/solid/zod/src/index.tsx
+++ b/examples/solid/zod/src/index.tsx
@@ -31,7 +31,7 @@ function App() {
       console.log(values)
     },
     // Add a validator to support Zod usage in Form and Field
-    validator: zodValidator,
+    validatorAdapter: zodValidator,
   }))
 
   return (

--- a/examples/solid/zod/src/index.tsx
+++ b/examples/solid/zod/src/index.tsx
@@ -26,9 +26,9 @@ function App() {
       firstName: '',
       lastName: '',
     },
-    onSubmit: async (values) => {
+    onSubmit: async ({ value }) => {
       // Do something with form data
-      console.log(values)
+      console.log(value)
     },
     // Add a validator to support Zod usage in Form and Field
     validatorAdapter: zodValidator,

--- a/examples/vue/simple/src/App.vue
+++ b/examples/vue/simple/src/App.vue
@@ -32,6 +32,9 @@ async function onChangeFirstName({ value }: { value: string }) {
     "
   >
     <div>
+      <!-- Ignore errors in form.Field temporary due to a bug in Vue:-->
+      <!-- https://github.com/vuejs/language-tools/issues/3782 -->
+      <!-- @vue-ignore -->
       <form.Field
         name="firstName"
         :validators="{

--- a/examples/vue/simple/src/App.vue
+++ b/examples/vue/simple/src/App.vue
@@ -15,7 +15,7 @@ const form = useForm({
 
 form.provideFormContext()
 
-async function onChangeFirstName(value: string) {
+async function onChangeFirstName({ value }: { value: string }) {
   await new Promise((resolve) => setTimeout(resolve, 1000))
   return value.includes(`error`) && `No 'error' allowed in first name`
 }
@@ -35,7 +35,7 @@ async function onChangeFirstName(value: string) {
       <form.Field
         name="firstName"
         :validators="{
-          onChange: (value) =>
+          onChange: ({ value }) =>
             !value
               ? `A first name is required`
               : value.length < 3

--- a/examples/vue/simple/src/App.vue
+++ b/examples/vue/simple/src/App.vue
@@ -34,16 +34,16 @@ async function onChangeFirstName(value: string) {
     <div>
       <form.Field
         name="firstName"
-        @change="
-          (value) =>
+        :validators="{
+          onChange: (value) =>
             !value
               ? `A first name is required`
               : value.length < 3
               ? `First name must be at least 3 characters`
-              : undefined
-        "
-        :onChangeAsyncDebounceMs="500"
-        :onChangeAsync="onChangeFirstName"
+              : undefined,
+          onChangeAsyncDebounceMs: 500,
+          onChangeAsync: onChangeFirstName,
+        }"
       >
         <template v-slot="{ field, state }">
           <label :htmlFor="field.name">First Name:</label>

--- a/examples/vue/simple/src/App.vue
+++ b/examples/vue/simple/src/App.vue
@@ -7,9 +7,9 @@ const form = useForm({
     firstName: '',
     lastName: '',
   },
-  onSubmit: async (values) => {
+  onSubmit: async ({ value }) => {
     // Do something with form data
-    alert(JSON.stringify(values))
+    alert(JSON.stringify(value))
   },
 })
 

--- a/examples/vue/simple/src/FieldInfo.vue
+++ b/examples/vue/simple/src/FieldInfo.vue
@@ -2,7 +2,7 @@
 import { FieldApi } from '@tanstack/vue-form'
 
 const props = defineProps<{
-  state: FieldApi<any, any, unknown, unknown>['state']
+  state: FieldApi<any, any>['state']
 }>()
 </script>
 

--- a/examples/vue/simple/src/FieldInfo.vue
+++ b/examples/vue/simple/src/FieldInfo.vue
@@ -2,7 +2,7 @@
 import { FieldApi } from '@tanstack/vue-form'
 
 const props = defineProps<{
-  state: FieldApi<any, any>['state']
+  state: FieldApi<any, any, any, any>['state']
 }>()
 </script>
 

--- a/examples/vue/valibot/src/App.vue
+++ b/examples/vue/valibot/src/App.vue
@@ -38,6 +38,9 @@ const onChangeFirstName = stringAsync([
     "
   >
     <div>
+      <!-- Ignore errors in form.Field temporary due to a bug in Vue:-->
+      <!-- https://github.com/vuejs/language-tools/issues/3782 -->
+      <!-- @vue-ignore -->
       <form.Field
         name="firstName"
         :validators="{

--- a/examples/vue/valibot/src/App.vue
+++ b/examples/vue/valibot/src/App.vue
@@ -9,9 +9,9 @@ const form = useForm({
     firstName: '',
     lastName: '',
   },
-  onSubmit: async (values) => {
+  onSubmit: async ({ value }) => {
     // Do something with form data
-    alert(JSON.stringify(values))
+    alert(JSON.stringify(value))
   },
   // Add a validator to support Valibot usage in Form and Field
   validatorAdapter: valibotValidator,

--- a/examples/vue/valibot/src/App.vue
+++ b/examples/vue/valibot/src/App.vue
@@ -14,7 +14,7 @@ const form = useForm({
     alert(JSON.stringify(values))
   },
   // Add a validator to support Valibot usage in Form and Field
-  validator: valibotValidator,
+  validatorAdapter: valibotValidator,
 })
 
 form.provideFormContext()

--- a/examples/vue/valibot/src/App.vue
+++ b/examples/vue/valibot/src/App.vue
@@ -40,11 +40,13 @@ const onChangeFirstName = stringAsync([
     <div>
       <form.Field
         name="firstName"
-        :onChange="
-          string([minLength(3, 'First name must be at least 3 characters')])
-        "
-        :onChangeAsyncDebounceMs="500"
-        :onChangeAsync="onChangeFirstName"
+        :validators="{
+          onChange: string([
+            minLength(3, 'First name must be at least 3 characters'),
+          ]),
+          onChangeAsyncDebounceMs: 500,
+          onChangeAsync: onChangeFirstName,
+        }"
       >
         <template v-slot="{ field, state }">
           <label :htmlFor="field.name">First Name:</label>

--- a/examples/vue/valibot/src/FieldInfo.vue
+++ b/examples/vue/valibot/src/FieldInfo.vue
@@ -2,7 +2,7 @@
 import { FieldApi } from '@tanstack/vue-form'
 
 const props = defineProps<{
-  state: FieldApi<any, any, unknown, unknown>['state']
+  state: FieldApi<any, any>['state']
 }>()
 </script>
 

--- a/examples/vue/valibot/src/FieldInfo.vue
+++ b/examples/vue/valibot/src/FieldInfo.vue
@@ -2,7 +2,7 @@
 import { FieldApi } from '@tanstack/vue-form'
 
 const props = defineProps<{
-  state: FieldApi<any, any>['state']
+  state: FieldApi<any, any, any, any>['state']
 }>()
 </script>
 

--- a/examples/vue/yup/src/App.vue
+++ b/examples/vue/yup/src/App.vue
@@ -9,9 +9,9 @@ const form = useForm({
     firstName: '',
     lastName: '',
   },
-  onSubmit: async (values) => {
+  onSubmit: async ({ value }) => {
     // Do something with form data
-    alert(JSON.stringify(values))
+    alert(JSON.stringify(value))
   },
   // Add a validator to support Yup usage in Form and Field
   validatorAdapter: yupValidator,

--- a/examples/vue/yup/src/App.vue
+++ b/examples/vue/yup/src/App.vue
@@ -14,7 +14,7 @@ const form = useForm({
     alert(JSON.stringify(values))
   },
   // Add a validator to support Yup usage in Form and Field
-  validator: yupValidator,
+  validatorAdapter: yupValidator,
 })
 
 form.provideFormContext()

--- a/examples/vue/yup/src/App.vue
+++ b/examples/vue/yup/src/App.vue
@@ -40,11 +40,13 @@ const onChangeFirstName = yup
     <div>
       <form.Field
         name="firstName"
-        :onChange="
-          yup.string().min(3, 'First name must be at least 3 characters')
-        "
-        :onChangeAsyncDebounceMs="500"
-        :onChangeAsync="onChangeFirstName"
+        :validators="{
+          onChange: yup
+            .string()
+            .min(3, 'First name must be at least 3 characters'),
+          onChangeAsyncDebounceMs: 500,
+          onChangeAsync: onChangeFirstName,
+        }"
       >
         <template v-slot="{ field, state }">
           <label :htmlFor="field.name">First Name:</label>

--- a/examples/vue/yup/src/App.vue
+++ b/examples/vue/yup/src/App.vue
@@ -38,6 +38,9 @@ const onChangeFirstName = yup
     "
   >
     <div>
+      <!-- Ignore errors in form.Field temporary due to a bug in Vue:-->
+      <!-- https://github.com/vuejs/language-tools/issues/3782 -->
+      <!-- @vue-ignore -->
       <form.Field
         name="firstName"
         :validators="{

--- a/examples/vue/yup/src/FieldInfo.vue
+++ b/examples/vue/yup/src/FieldInfo.vue
@@ -2,7 +2,7 @@
 import { FieldApi } from '@tanstack/vue-form'
 
 const props = defineProps<{
-  state: FieldApi<any, any, unknown, unknown>['state']
+  state: FieldApi<any, any>['state']
 }>()
 </script>
 

--- a/examples/vue/yup/src/FieldInfo.vue
+++ b/examples/vue/yup/src/FieldInfo.vue
@@ -2,7 +2,7 @@
 import { FieldApi } from '@tanstack/vue-form'
 
 const props = defineProps<{
-  state: FieldApi<any, any>['state']
+  state: FieldApi<any, any, any, any>['state']
 }>()
 </script>
 

--- a/examples/vue/zod/src/App.vue
+++ b/examples/vue/zod/src/App.vue
@@ -14,7 +14,7 @@ const form = useForm({
     alert(JSON.stringify(values))
   },
   // Add a validator to support Zod usage in Form and Field
-  validator: zodValidator,
+  validatorAdapter: zodValidator,
 })
 
 form.provideFormContext()

--- a/examples/vue/zod/src/App.vue
+++ b/examples/vue/zod/src/App.vue
@@ -9,9 +9,9 @@ const form = useForm({
     firstName: '',
     lastName: '',
   },
-  onSubmit: async (values) => {
+  onSubmit: async ({ value }) => {
     // Do something with form data
-    alert(JSON.stringify(values))
+    alert(JSON.stringify(value))
   },
   // Add a validator to support Zod usage in Form and Field
   validatorAdapter: zodValidator,

--- a/examples/vue/zod/src/App.vue
+++ b/examples/vue/zod/src/App.vue
@@ -41,6 +41,9 @@ const onChangeFirstName = z.string().refine(
     "
   >
     <div>
+      <!-- Ignore errors in form.Field temporary due to a bug in Vue:-->
+      <!-- https://github.com/vuejs/language-tools/issues/3782 -->
+      <!-- @vue-ignore -->
       <form.Field
         name="firstName"
         :validators="{

--- a/examples/vue/zod/src/App.vue
+++ b/examples/vue/zod/src/App.vue
@@ -43,11 +43,13 @@ const onChangeFirstName = z.string().refine(
     <div>
       <form.Field
         name="firstName"
-        :onChange="
-          z.string().min(3, 'First name must be at least 3 characters')
-        "
-        :onChangeAsyncDebounceMs="500"
-        :onChangeAsync="onChangeFirstName"
+        :validators="{
+          onChange: z
+            .string()
+            .min(3, 'First name must be at least 3 characters'),
+          onChangeAsyncDebounceMs: 500,
+          onChangeAsync: onChangeFirstName,
+        }"
       >
         <template v-slot="{ field, state }">
           <label :htmlFor="field.name">First Name:</label>

--- a/examples/vue/zod/src/FieldInfo.vue
+++ b/examples/vue/zod/src/FieldInfo.vue
@@ -2,7 +2,7 @@
 import { FieldApi } from '@tanstack/vue-form'
 
 const props = defineProps<{
-  state: FieldApi<any, any, unknown, unknown>['state']
+  state: FieldApi<any, any>['state']
 }>()
 </script>
 

--- a/examples/vue/zod/src/FieldInfo.vue
+++ b/examples/vue/zod/src/FieldInfo.vue
@@ -2,7 +2,7 @@
 import { FieldApi } from '@tanstack/vue-form'
 
 const props = defineProps<{
-  state: FieldApi<any, any>['state']
+  state: FieldApi<any, any, any, any>['state']
 }>()
 </script>
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@types/jest": "^26.0.4",
     "@types/jsonfile": "^6.1.1",
     "@types/luxon": "^2.3.1",
-    "@types/node": "^17.0.25",
+    "@types/node": "^18.15.3",
     "@types/react": "^18.0.14",
     "@types/react-dom": "^18.0.5",
     "@types/semver": "^7.3.13",

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -567,10 +567,8 @@ export class FieldApi<
     // Attempt to sync validate first
     const { hasErrored } = this.validateSync(value, cause)
 
-    if (hasErrored) {
-      if (!this.options.asyncAlways) {
-        return this.state.meta.errors
-      }
+    if (hasErrored && !this.options.asyncAlways) {
+      return this.state.meta.errors
     }
     // No error? Attempt async validation
     return this.validateAsync(value, cause)

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -109,6 +109,7 @@ export interface FieldValidators<
     FormValidator,
     TData
   >
+  onSubmitAsyncDebounceMs?: number
 }
 
 export interface FieldOptions<
@@ -478,6 +479,7 @@ export class FieldApi<
       onSubmitAsync,
       onBlurAsyncDebounceMs,
       onChangeAsyncDebounceMs,
+      onSubmitAsyncDebounceMs,
     } = this.options.validators || {}
 
     const validate =
@@ -487,14 +489,12 @@ export class FieldApi<
         ? onSubmitAsync
         : onBlurAsync
     if (!validate) return []
-    const debounceMs =
-      cause === 'submit'
-        ? 0
-        : (cause === 'change'
-            ? onChangeAsyncDebounceMs
-            : onBlurAsyncDebounceMs) ??
-          asyncDebounceMs ??
-          0
+
+    let debounceMs = asyncDebounceMs ?? 0
+
+    if (cause === 'submit') debounceMs = onSubmitAsyncDebounceMs ?? debounceMs
+    if (cause === 'change') debounceMs = onChangeAsyncDebounceMs ?? debounceMs
+    if (cause === 'blur') debounceMs = onBlurAsyncDebounceMs ?? debounceMs
 
     if (this.state.meta.isValidating !== true) {
       this.setMeta((prev) => ({ ...prev, isValidating: true }))

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -593,7 +593,6 @@ export class FieldApi<
   }
 
   handleChange = (updater: Updater<TData>) => {
-    debugger
     this.setValue(updater, { touch: true })
   }
 

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -270,7 +270,15 @@ export class FieldApi<
     this.update(this.options as never)
     const { onMount } = this.options.validators || {}
 
-    onMount && this._runValidator(onMount, this.state.value, 'validate')
+    if (onMount) {
+      const error = this._runValidator(onMount, this.state.value, 'validate')
+      if (error) {
+        this.setMeta((prev) => ({
+          ...prev,
+          errorMap: { ...prev.errorMap, onMount: error },
+        }))
+      }
+    }
 
     return () => {
       const preserveValue = this.options.preserveValue

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -12,132 +12,164 @@ import { runValidatorOrAdapter } from './utils'
 export type FieldValidateFn<
   TParentData,
   TName extends DeepKeys<TParentData>,
-  ValidatorType,
-  FormValidator,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > = (props: {
   value: TData
-  fieldApi: FieldApi<TParentData, TName, ValidatorType, FormValidator, TData>
+  fieldApi: FieldApi<TParentData, TName, TFieldValidator, TFormValidator, TData>
 }) => ValidationError
 
 export type FieldValidateOrFn<
   TParentData,
   TName extends DeepKeys<TParentData>,
-  ValidatorType,
-  FormValidator,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
-> = ValidatorType extends Validator<TData, infer TFN>
+> = TFieldValidator extends Validator<TData, infer TFN>
   ?
       | TFN
-      | FieldValidateFn<TParentData, TName, ValidatorType, FormValidator, TData>
-  : FormValidator extends Validator<TData, infer FFN>
+      | FieldValidateFn<
+          TParentData,
+          TName,
+          TFieldValidator,
+          TFormValidator,
+          TData
+        >
+  : TFormValidator extends Validator<TParentData, infer FFN>
   ?
       | FFN
-      | FieldValidateFn<TParentData, TName, ValidatorType, FormValidator, TData>
-  : FieldValidateFn<TParentData, TName, ValidatorType, FormValidator, TData>
+      | FieldValidateFn<
+          TParentData,
+          TName,
+          TFieldValidator,
+          TFormValidator,
+          TData
+        >
+  : FieldValidateFn<TParentData, TName, TFieldValidator, TFormValidator, TData>
 
 export type FieldValidateAsyncFn<
   TParentData,
   TName extends DeepKeys<TParentData>,
-  ValidatorType,
-  FormValidator,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > = (options: {
   value: TData
-  fieldApi: FieldApi<TParentData, TName, ValidatorType, FormValidator, TData>
+  fieldApi: FieldApi<TParentData, TName, TFieldValidator, TFormValidator, TData>
   signal: AbortSignal
 }) => ValidationError | Promise<ValidationError>
 
 export type FieldAsyncValidateOrFn<
   TParentData,
   TName extends DeepKeys<TParentData>,
-  ValidatorType,
-  FormValidator,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
-> = ValidatorType extends Validator<TData, infer TFN>
+> = TFieldValidator extends Validator<TData, infer TFN>
   ?
       | TFN
       | FieldValidateAsyncFn<
           TParentData,
           TName,
-          ValidatorType,
-          FormValidator,
+          TFieldValidator,
+          TFormValidator,
           TData
         >
-  : FormValidator extends Validator<TData, infer FFN>
+  : TFormValidator extends Validator<TParentData, infer FFN>
   ?
       | FFN
       | FieldValidateAsyncFn<
           TParentData,
           TName,
-          ValidatorType,
-          FormValidator,
+          TFieldValidator,
+          TFormValidator,
           TData
         >
   : FieldValidateAsyncFn<
       TParentData,
       TName,
-      ValidatorType,
-      FormValidator,
+      TFieldValidator,
+      TFormValidator,
       TData
     >
 
 export interface FieldValidators<
   TParentData,
   TName extends DeepKeys<TParentData>,
-  ValidatorType,
-  FormValidator,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > {
   onMount?: FieldValidateOrFn<
     TParentData,
     TName,
-    ValidatorType,
-    FormValidator,
+    TFieldValidator,
+    TFormValidator,
     TData
   >
   onChange?: FieldValidateOrFn<
     TParentData,
     TName,
-    ValidatorType,
-    FormValidator,
+    TFieldValidator,
+    TFormValidator,
     TData
   >
   onChangeAsync?: FieldAsyncValidateOrFn<
     TParentData,
     TName,
-    ValidatorType,
-    FormValidator,
+    TFieldValidator,
+    TFormValidator,
     TData
   >
   onChangeAsyncDebounceMs?: number
   onBlur?: FieldValidateOrFn<
     TParentData,
     TName,
-    ValidatorType,
-    FormValidator,
+    TFieldValidator,
+    TFormValidator,
     TData
   >
   onBlurAsync?: FieldAsyncValidateOrFn<
     TParentData,
     TName,
-    ValidatorType,
-    FormValidator,
+    TFieldValidator,
+    TFormValidator,
     TData
   >
   onBlurAsyncDebounceMs?: number
   onSubmit?: FieldValidateOrFn<
     TParentData,
     TName,
-    ValidatorType,
-    FormValidator,
+    TFieldValidator,
+    TFormValidator,
     TData
   >
   onSubmitAsync?: FieldAsyncValidateOrFn<
     TParentData,
     TName,
-    ValidatorType,
-    FormValidator,
+    TFieldValidator,
+    TFormValidator,
     TData
   >
   onSubmitAsyncDebounceMs?: number
@@ -146,8 +178,12 @@ export interface FieldValidators<
 export interface FieldOptions<
   TParentData,
   TName extends DeepKeys<TParentData>,
-  ValidatorType,
-  FormValidator,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > {
   name: TName
@@ -156,12 +192,12 @@ export interface FieldOptions<
   asyncDebounceMs?: number
   asyncAlways?: boolean
   preserveValue?: boolean
-  validatorAdapter?: ValidatorType
+  validatorAdapter?: TFieldValidator
   validators?: FieldValidators<
     TParentData,
     TName,
-    ValidatorType,
-    FormValidator,
+    TFieldValidator,
+    TFormValidator,
     TData
   >
   defaultMeta?: Partial<FieldMeta>
@@ -170,17 +206,21 @@ export interface FieldOptions<
 export interface FieldApiOptions<
   TParentData,
   TName extends DeepKeys<TParentData>,
-  ValidatorType,
-  FormValidator,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > extends FieldOptions<
     TParentData,
     TName,
-    ValidatorType,
-    FormValidator,
+    TFieldValidator,
+    TFormValidator,
     TData
   > {
-  form: FormApi<TParentData, FormValidator>
+  form: FormApi<TParentData, TFormValidator>
 }
 
 export type FieldMeta = {
@@ -205,24 +245,28 @@ export type ResolveName<TParentData> = unknown extends TParentData
 export class FieldApi<
   TParentData,
   TName extends DeepKeys<TParentData>,
-  ValidatorType,
-  FormValidator,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > {
   uid: number
   form: FieldApiOptions<
     TParentData,
     TName,
-    ValidatorType,
-    FormValidator,
+    TFieldValidator,
+    TFormValidator,
     TData
   >['form']
   name!: DeepKeys<TParentData>
   options: FieldApiOptions<
     TParentData,
     TName,
-    ValidatorType,
-    FormValidator,
+    TFieldValidator,
+    TFormValidator,
     TData
   > = {} as any
   store!: Store<FieldState<TData>>
@@ -233,8 +277,8 @@ export class FieldApi<
     opts: FieldApiOptions<
       TParentData,
       TName,
-      ValidatorType,
-      FormValidator,
+      TFieldValidator,
+      TFormValidator,
       TData
     >,
   ) {
@@ -322,6 +366,7 @@ export class FieldApi<
       if (error) {
         this.setMeta((prev) => ({
           ...prev,
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           errorMap: { ...prev?.errorMap, onMount: error },
         }))
       }
@@ -345,8 +390,8 @@ export class FieldApi<
     opts: FieldApiOptions<
       TParentData,
       TName,
-      ValidatorType,
-      FormValidator,
+      TFieldValidator,
+      TFormValidator,
       TData
     >,
   ) => {
@@ -418,7 +463,7 @@ export class FieldApi<
     TSubData extends DeepValue<TData, TSubName> = DeepValue<TData, TSubName>,
   >(
     name: TSubName,
-  ): FieldApi<TData, TSubName, ValidatorType, TSubData> =>
+  ): FieldApi<TData, TSubName, TFieldValidator, TSubData> =>
     new FieldApi({
       name: `${this.name}.${name}` as never,
       form: this.form,
@@ -595,6 +640,7 @@ export class FieldApi<
             return {
               ...prev,
               errorMap: {
+                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
                 ...prev?.errorMap,
                 [getErrorMapKey(cause)]: error,
               },

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -6,13 +6,8 @@ import type {
   ValidationErrorMap,
   Validator,
 } from './types'
-import {
-  DeepKeys,
-  DeepValue,
-  getAsyncValidatorArray,
-  getSyncValidatorArray,
-  Updater,
-} from './utils'
+import type { DeepKeys, DeepValue, Updater } from './utils'
+import { getAsyncValidatorArray, getSyncValidatorArray } from './utils'
 
 export type FieldValidateFn<
   TParentData,

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -120,7 +120,7 @@ export interface FieldOptions<
   asyncDebounceMs?: number
   asyncAlways?: boolean
   preserveValue?: boolean
-  validator?: ValidatorType
+  validatorAdapter?: ValidatorType
   validators?: FieldValidators<
     TParentData,
     TName,
@@ -373,15 +373,15 @@ export class FieldApi<
     this.getInfo().validationCount = validationCount
 
     const doValidate = (validate: (typeof validates)[number]['validate']) => {
-      if (this.options.validator && typeof validate !== 'function') {
-        return (this.options.validator as Validator<TData>)().validate(
+      if (this.options.validatorAdapter && typeof validate !== 'function') {
+        return (this.options.validatorAdapter as Validator<TData>)().validate(
           value,
           validate,
         )
       }
 
-      if (this.form.options.validator && typeof validate !== 'function') {
-        return (this.form.options.validator as Validator<TData>)().validate(
+      if (this.form.options.validatorAdapter && typeof validate !== 'function') {
+        return (this.form.options.validatorAdapter as Validator<TData>)().validate(
           value,
           validate,
         )
@@ -508,16 +508,16 @@ export class FieldApi<
     }
 
     const doValidate = () => {
-      if (this.options.validator && typeof validate !== 'function') {
-        return (this.options.validator as Validator<TData>)().validateAsync(
+      if (this.options.validatorAdapter && typeof validate !== 'function') {
+        return (this.options.validatorAdapter as Validator<TData>)().validateAsync(
           value,
           validate,
         )
       }
 
-      if (this.form.options.validator && typeof validate !== 'function') {
+      if (this.form.options.validatorAdapter && typeof validate !== 'function') {
         return (
-          this.form.options.validator as Validator<TData>
+          this.form.options.validatorAdapter as Validator<TData>
         )().validateAsync(value, validate)
       }
 

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -463,7 +463,13 @@ export class FieldApi<
     TSubData extends DeepValue<TData, TSubName> = DeepValue<TData, TSubName>,
   >(
     name: TSubName,
-  ): FieldApi<TData, TSubName, TFieldValidator, TSubData> =>
+  ): FieldApi<
+    TData,
+    TSubName,
+    Validator<TSubData, unknown> | undefined,
+    Validator<TData, unknown> | undefined,
+    TSubData
+  > =>
     new FieldApi({
       name: `${this.name}.${name}` as never,
       form: this.form,

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -17,38 +17,37 @@ import type {
 } from './types'
 import type { ValidationErrorMapKeys } from './types'
 
-type ValidateFn<TData, ValidatorType> = (props: {
+export type FormValidateFn<TData, ValidatorType> = (props: {
   value: TData
   formApi: FormApi<TData, ValidatorType>
 }) => ValidationError
 
-type ValidateOrFn<TData, ValidatorType> = ValidatorType extends Validator<TData>
-  ? Parameters<ReturnType<ValidatorType>['validate']>[1]
-  : ValidateFn<TData, ValidatorType>
+export type FormValidateOrFn<TData, ValidatorType> =
+  ValidatorType extends Validator<TData, infer TFN>
+    ? TFN
+    : FormValidateFn<TData, ValidatorType>
 
-type ValidateAsyncFn<TData, ValidatorType> = (props: {
+export type FormValidateAsyncFn<TData, ValidatorType> = (props: {
   value: TData
   formApi: FormApi<TData, ValidatorType>
   signal: AbortSignal
 }) => ValidationError | Promise<ValidationError>
 
-type AsyncValidateOrFn<TData, ValidatorType> =
-  ValidatorType extends Validator<TData>
-    ?
-        | Parameters<ReturnType<ValidatorType>['validate']>[1]
-        | ValidateAsyncFn<TData, ValidatorType>
-    : ValidateAsyncFn<TData, ValidatorType>
+export type FormAsyncValidateOrFn<TData, ValidatorType> =
+  ValidatorType extends Validator<TData, infer FFN>
+    ? FFN | FormValidateAsyncFn<TData, ValidatorType>
+    : FormValidateAsyncFn<TData, ValidatorType>
 
 export interface FormValidators<TData, ValidatorType> {
-  onMount?: ValidateOrFn<TData, ValidatorType>
-  onChange?: ValidateOrFn<TData, ValidatorType>
-  onChangeAsync?: AsyncValidateOrFn<TData, ValidatorType>
+  onMount?: FormValidateOrFn<TData, ValidatorType>
+  onChange?: FormValidateOrFn<TData, ValidatorType>
+  onChangeAsync?: FormAsyncValidateOrFn<TData, ValidatorType>
   onChangeAsyncDebounceMs?: number
-  onBlur?: ValidateOrFn<TData, ValidatorType>
-  onBlurAsync?: AsyncValidateOrFn<TData, ValidatorType>
+  onBlur?: FormValidateOrFn<TData, ValidatorType>
+  onBlurAsync?: FormAsyncValidateOrFn<TData, ValidatorType>
   onBlurAsyncDebounceMs?: number
-  onSubmit?: ValidateOrFn<TData, ValidatorType>
-  onSubmitAsync?: AsyncValidateOrFn<TData, ValidatorType>
+  onSubmit?: FormValidateOrFn<TData, ValidatorType>
+  onSubmitAsync?: FormAsyncValidateOrFn<TData, ValidatorType>
   onSubmitAsyncDebounceMs?: number
 }
 

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -59,14 +59,14 @@ export type FormOptions<TData, ValidatorType> = {
   asyncDebounceMs?: number
   validatorAdapter?: ValidatorType
   validators?: FormValidators<TData, ValidatorType>
-  onSubmit?: (
-    values: TData,
-    formApi: FormApi<TData, ValidatorType>,
-  ) => any | Promise<any>
-  onSubmitInvalid?: (
-    values: TData,
-    formApi: FormApi<TData, ValidatorType>,
-  ) => void
+  onSubmit?: (props: {
+    value: TData
+    formApi: FormApi<TData, ValidatorType>
+  }) => any | Promise<any>
+  onSubmitInvalid?: (props: {
+    value: TData
+    formApi: FormApi<TData, ValidatorType>
+  }) => void
 }
 
 export type ValidationMeta = {
@@ -525,7 +525,10 @@ export class FormApi<TFormData, ValidatorType> {
     // Fields are invalid, do not submit
     if (!this.state.isFieldsValid) {
       done()
-      this.options.onSubmitInvalid?.(this.state.values, this)
+      this.options.onSubmitInvalid?.({
+        value: this.state.values,
+        formApi: this,
+      })
       return
     }
 
@@ -534,13 +537,16 @@ export class FormApi<TFormData, ValidatorType> {
 
     if (!this.state.isValid) {
       done()
-      this.options.onSubmitInvalid?.(this.state.values, this)
+      this.options.onSubmitInvalid?.({
+        value: this.state.values,
+        formApi: this,
+      })
       return
     }
 
     try {
       // Run the submit code
-      await this.options.onSubmit?.(this.state.values, this)
+      await this.options.onSubmit?.({ value: this.state.values, formApi: this })
 
       this.store.batch(() => {
         this.store.setState((prev) => ({ ...prev, isSubmitted: true }))

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -1,12 +1,8 @@
 import { Store } from '@tanstack/store'
+import type { DeepKeys, DeepValue, Updater } from './utils'
 import {
-  DeepKeys,
-  DeepValue,
   getAsyncValidatorArray,
   getSyncValidatorArray,
-  Updater,
-} from './utils'
-import {
   deleteBy,
   functionalUpdate,
   getBy,

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -39,7 +39,7 @@ export type FormOptions<TData, ValidatorType> = {
   defaultState?: Partial<FormState<TData>>
   asyncAlways?: boolean
   asyncDebounceMs?: number
-  validator?: ValidatorType
+  validatorAdapter?: ValidatorType
   validators?: FormValidators<TData, ValidatorType>
   onSubmit?: (
     values: TData,
@@ -188,10 +188,10 @@ export class FormApi<TFormData, ValidatorType> {
   mount = () => {
     const doValidate = () => {
       if (
-        this.options.validator &&
+        this.options.validatorAdapter &&
         typeof this.options.validators?.onMount !== 'function'
       ) {
-        return (this.options.validator as Validator<TFormData>)().validate(
+        return (this.options.validatorAdapter as Validator<TFormData>)().validate(
           this.state.values,
           this.options.validators?.onMount,
         )
@@ -283,8 +283,8 @@ export class FormApi<TFormData, ValidatorType> {
 
     const errorMapKey = getErrorMapKey(cause)
     const doValidate = () => {
-      if (this.options.validator && typeof validate !== 'function') {
-        return (this.options.validator as Validator<TFormData>)().validate(
+      if (this.options.validatorAdapter && typeof validate !== 'function') {
+        return (this.options.validatorAdapter as Validator<TFormData>)().validate(
           this.state.values,
           validate,
         )
@@ -378,8 +378,8 @@ export class FormApi<TFormData, ValidatorType> {
       if (typeof validate === 'function') {
         return validate(this.state.values, this) as ValidationError
       }
-      if (this.options.validator && typeof validate !== 'function') {
-        return (this.options.validator as Validator<TFormData>)().validateAsync(
+      if (this.options.validatorAdapter && typeof validate !== 'function') {
+        return (this.options.validatorAdapter as Validator<TFormData>)().validateAsync(
           this.state.values,
           validate,
         )

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -70,7 +70,6 @@ export type FormOptions<TData, ValidatorType> = {
 }
 
 export type ValidationMeta = {
-  lastRan: number
   lastAbortController: AbortController
 }
 
@@ -421,20 +420,12 @@ export class FormApi<TFormData, ValidatorType> {
       const key = getErrorMapKey(validateObj.cause)
       const fieldOnChangeMeta = this.state.validationMetaMap[key]
 
-      const now = Date.now()
-      const lastRunDiff = now - (fieldOnChangeMeta?.lastRan ?? 0)
-
-      if (fieldOnChangeMeta?.lastRan && lastRunDiff < validateObj.debounceMs) {
-        continue
-      }
       fieldOnChangeMeta?.lastAbortController.abort()
       // Sorry Safari 12
       // eslint-disable-next-line compat/compat
       const controller = new AbortController()
 
       this.state.validationMetaMap[key] = {
-        ...fieldOnChangeMeta,
-        lastRan: now,
         lastAbortController: controller,
       }
 
@@ -442,15 +433,22 @@ export class FormApi<TFormData, ValidatorType> {
         new Promise<ValidationError | undefined>(async (resolve) => {
           let rawError!: ValidationError | undefined
           try {
-            rawError = await runValidatorOrAdapter({
-              validateFn: validateObj.validate,
-              value: {
-                value: this.state.values,
-                formApi: this,
-                signal: controller.signal,
-              },
-              methodName: 'validateAsync',
-              adapters: [this.options.validatorAdapter as never],
+            rawError = await new Promise((resolve, reject) => {
+              setTimeout(() => {
+                if (controller.signal.aborted) return resolve(undefined)
+                runValidatorOrAdapter({
+                  validateFn: validateObj.validate,
+                  value: {
+                    value: this.state.values,
+                    formApi: this,
+                    signal: controller.signal,
+                  },
+                  methodName: 'validateAsync',
+                  adapters: [this.options.validatorAdapter as never],
+                })
+                  .then(resolve)
+                  .catch(reject)
+              }, onChangeAsyncDebounceMs)
             })
           } catch (e: unknown) {
             rawError = e as ValidationError

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -159,15 +159,14 @@ export class FormApi<
   TFormData,
   TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
 > {
-  // // This carries the context for nested fields
   options: FormOptions<TFormData, TFormValidator> = {}
   store!: Store<FormState<TFormData>>
   // Do not use __state directly, as it is not reactive.
   // Please use form.useStore() utility to subscribe to state
   state!: FormState<TFormData>
+  // // This carries the context for nested fields
   fieldInfo: Record<DeepKeys<TFormData>, FieldInfo<TFormData, TFormValidator>> =
     {} as any
-  fieldName?: string
 
   constructor(opts?: FormOptions<TFormData, TFormValidator>) {
     this.store = new Store<FormState<TFormData>>(
@@ -327,7 +326,8 @@ export class FormApi<
       })
     })
 
-    return Promise.all(fieldValidationPromises)
+    const fieldErrorMapMap = await Promise.all(fieldValidationPromises)
+    return fieldErrorMapMap.flat()
   }
 
   // TODO: This code is copied from FieldApi, we should refactor to share

--- a/packages/form-core/src/tests/FieldApi.spec.ts
+++ b/packages/form-core/src/tests/FieldApi.spec.ts
@@ -208,7 +208,7 @@ describe('field api', () => {
       form,
       name: 'name',
       validators: {
-        onChange: (value) => {
+        onChange: ({ value }) => {
           if (value === 'other') return 'Please enter a different value'
           return
         },
@@ -238,7 +238,7 @@ describe('field api', () => {
       form,
       name: 'name',
       validators: {
-        onChangeAsync: async (value) => {
+        onChangeAsync: async ({ value }) => {
           await sleep(1000)
           if (value === 'other') return 'Please enter a different value'
           return
@@ -272,7 +272,7 @@ describe('field api', () => {
       name: 'name',
       validators: {
         onChangeAsyncDebounceMs: 1000,
-        onChangeAsync: async (value) => {
+        onChangeAsync: async ({ value }) => {
           await sleepMock(1000)
           if (value === 'other') return 'Please enter a different value'
           return
@@ -309,7 +309,7 @@ describe('field api', () => {
       name: 'name',
       asyncDebounceMs: 1000,
       validators: {
-        onChangeAsync: async (value) => {
+        onChangeAsync: async ({ value }) => {
           await sleepMock(1000)
           if (value === 'other') return 'Please enter a different value'
           return
@@ -342,7 +342,7 @@ describe('field api', () => {
       form,
       name: 'name',
       validators: {
-        onBlur: (value) => {
+        onBlur: ({ value }) => {
           if (value === 'other') return 'Please enter a different value'
           return
         },
@@ -372,7 +372,7 @@ describe('field api', () => {
       form,
       name: 'name',
       validators: {
-        onBlurAsync: async (value) => {
+        onBlurAsync: async ({ value }) => {
           await sleep(1000)
           if (value === 'other') return 'Please enter a different value'
           return
@@ -407,7 +407,7 @@ describe('field api', () => {
       name: 'name',
       validators: {
         onBlurAsyncDebounceMs: 1000,
-        onBlurAsync: async (value) => {
+        onBlurAsync: async ({ value }) => {
           await sleepMock(10)
           if (value === 'other') return 'Please enter a different value'
           return
@@ -445,7 +445,7 @@ describe('field api', () => {
       name: 'name',
       asyncDebounceMs: 1000,
       validators: {
-        onBlurAsync: async (value) => {
+        onBlurAsync: async ({ value }) => {
           await sleepMock(10)
           if (value === 'other') return 'Please enter a different value'
           return
@@ -481,7 +481,7 @@ describe('field api', () => {
       form,
       name: 'name',
       validators: {
-        onSubmitAsync: async (value) => {
+        onSubmitAsync: async ({ value }) => {
           await sleep(1000)
           if (value === 'other') return 'Please enter a different value'
           return
@@ -512,11 +512,11 @@ describe('field api', () => {
       form,
       name: 'name',
       validators: {
-        onBlur: (value) => {
+        onBlur: ({ value }) => {
           if (value === 'other') return 'Please enter a different value'
           return
         },
-        onChange: (value) => {
+        onChange: ({ value }) => {
           if (value === 'other') return 'Please enter a different value'
           return
         },
@@ -548,7 +548,7 @@ describe('field api', () => {
       form,
       name: 'name',
       validators: {
-        onChange: (value) => {
+        onChange: ({ value }) => {
           if (value === 'other') return 'Please enter a different value'
           return
         },
@@ -648,7 +648,8 @@ describe('field api', () => {
       form,
       name: 'firstName',
       validators: {
-        onSubmit: (v) => (v.length > 0 ? undefined : 'first name is required'),
+        onSubmit: ({ value }) =>
+          value.length > 0 ? undefined : 'first name is required',
       },
     })
 
@@ -669,7 +670,8 @@ describe('field api', () => {
       form,
       name: 'firstName',
       validators: {
-        onMount: (v) => (v.length > 0 ? undefined : 'first name is required'),
+        onMount: ({ value }) =>
+          value.length > 0 ? undefined : 'first name is required',
       },
     })
 

--- a/packages/form-core/src/tests/FieldApi.spec.ts
+++ b/packages/form-core/src/tests/FieldApi.spec.ts
@@ -207,9 +207,11 @@ describe('field api', () => {
     const field = new FieldApi({
       form,
       name: 'name',
-      onChange: (value) => {
-        if (value === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onChange: (value) => {
+          if (value === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
 
@@ -235,10 +237,12 @@ describe('field api', () => {
     const field = new FieldApi({
       form,
       name: 'name',
-      onChangeAsync: async (value) => {
-        await sleep(1000)
-        if (value === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onChangeAsync: async (value) => {
+          await sleep(1000)
+          if (value === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
 
@@ -266,11 +270,13 @@ describe('field api', () => {
     const field = new FieldApi({
       form,
       name: 'name',
-      onChangeAsyncDebounceMs: 1000,
-      onChangeAsync: async (value) => {
-        await sleepMock(1000)
-        if (value === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onChangeAsyncDebounceMs: 1000,
+        onChangeAsync: async (value) => {
+          await sleepMock(1000)
+          if (value === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
 
@@ -302,10 +308,12 @@ describe('field api', () => {
       form,
       name: 'name',
       asyncDebounceMs: 1000,
-      onChangeAsync: async (value) => {
-        await sleepMock(1000)
-        if (value === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onChangeAsync: async (value) => {
+          await sleepMock(1000)
+          if (value === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
 
@@ -333,9 +341,11 @@ describe('field api', () => {
     const field = new FieldApi({
       form,
       name: 'name',
-      onBlur: (value) => {
-        if (value === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onBlur: (value) => {
+          if (value === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
 
@@ -361,10 +371,12 @@ describe('field api', () => {
     const field = new FieldApi({
       form,
       name: 'name',
-      onBlurAsync: async (value) => {
-        await sleep(1000)
-        if (value === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onBlurAsync: async (value) => {
+          await sleep(1000)
+          if (value === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
 
@@ -393,11 +405,13 @@ describe('field api', () => {
     const field = new FieldApi({
       form,
       name: 'name',
-      onBlurAsyncDebounceMs: 1000,
-      onBlurAsync: async (value) => {
-        await sleepMock(10)
-        if (value === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onBlurAsyncDebounceMs: 1000,
+        onBlurAsync: async (value) => {
+          await sleepMock(10)
+          if (value === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
 
@@ -430,10 +444,12 @@ describe('field api', () => {
       form,
       name: 'name',
       asyncDebounceMs: 1000,
-      onBlurAsync: async (value) => {
-        await sleepMock(10)
-        if (value === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onBlurAsync: async (value) => {
+          await sleepMock(10)
+          if (value === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
 
@@ -464,10 +480,12 @@ describe('field api', () => {
     const field = new FieldApi({
       form,
       name: 'name',
-      onSubmitAsync: async (value) => {
-        await sleep(1000)
-        if (value === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onSubmitAsync: async (value) => {
+          await sleep(1000)
+          if (value === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
 
@@ -493,13 +511,15 @@ describe('field api', () => {
     const field = new FieldApi({
       form,
       name: 'name',
-      onBlur: (value) => {
-        if (value === 'other') return 'Please enter a different value'
-        return
-      },
-      onChange: (value) => {
-        if (value === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onBlur: (value) => {
+          if (value === 'other') return 'Please enter a different value'
+          return
+        },
+        onChange: (value) => {
+          if (value === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
 
@@ -527,9 +547,11 @@ describe('field api', () => {
     const field = new FieldApi({
       form,
       name: 'name',
-      onChange: (value) => {
-        if (value === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onChange: (value) => {
+          if (value === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
 
@@ -625,7 +647,9 @@ describe('field api', () => {
     const field = new FieldApi({
       form,
       name: 'firstName',
-      onSubmit: (v) => (v.length > 0 ? undefined : 'first name is required'),
+      validators: {
+        onSubmit: (v) => (v.length > 0 ? undefined : 'first name is required'),
+      },
     })
 
     field.mount()

--- a/packages/form-core/src/tests/FieldApi.spec.ts
+++ b/packages/form-core/src/tests/FieldApi.spec.ts
@@ -573,7 +573,7 @@ describe('field api', () => {
     interface Form {
       name: string
     }
-    const form = new FormApi<Form, unknown>()
+    const form = new FormApi<Form>()
 
     const field = new FieldApi({
       form,

--- a/packages/form-core/src/tests/FieldApi.spec.ts
+++ b/packages/form-core/src/tests/FieldApi.spec.ts
@@ -682,6 +682,7 @@ describe('field api', () => {
   })
 
   it('should cancel previous functions from an async validator with an abort signal', async () => {
+    vi.useRealTimers()
     const form = new FormApi({
       defaultValues: {
         firstName: '',
@@ -689,7 +690,7 @@ describe('field api', () => {
     })
 
     let resolve!: () => void
-    let promise = new Promise((r) => {
+    const promise = new Promise((r) => {
       resolve = r as never
     })
 

--- a/packages/form-core/src/tests/FieldApi.spec.ts
+++ b/packages/form-core/src/tests/FieldApi.spec.ts
@@ -657,4 +657,25 @@ describe('field api', () => {
     await form.handleSubmit()
     expect(field.getMeta().errors).toStrictEqual(['first name is required'])
   })
+
+  it('should show onMount errors', async () => {
+    const form = new FormApi({
+      defaultValues: {
+        firstName: '',
+      },
+    })
+
+    const field = new FieldApi({
+      form,
+      name: 'firstName',
+      validators: {
+        onMount: (v) => (v.length > 0 ? undefined : 'first name is required'),
+      },
+    })
+
+    form.mount()
+    field.mount()
+
+    expect(field.getMeta().errors).toStrictEqual(['first name is required'])
+  })
 })

--- a/packages/form-core/src/tests/FieldApi.test-d.ts
+++ b/packages/form-core/src/tests/FieldApi.test-d.ts
@@ -29,10 +29,12 @@ it('should type onChange properly', () => {
   const field = new FieldApi({
     form,
     name: 'name',
-    onChange: (value) => {
-      assertType<'test'>(value)
+    validators: {
+      onChange: (value) => {
+        assertType<'test'>(value)
 
-      return undefined
+        return undefined
+      },
     },
   })
 })
@@ -47,10 +49,12 @@ it('should type onChangeAsync properly', () => {
   const field = new FieldApi({
     form,
     name: 'name',
-    onChangeAsync: async (value) => {
-      assertType<'test'>(value)
+    validators: {
+      onChangeAsync: async (value) => {
+        assertType<'test'>(value)
 
-      return undefined
+        return undefined
+      },
     },
   })
 })

--- a/packages/form-core/src/tests/FieldApi.test-d.ts
+++ b/packages/form-core/src/tests/FieldApi.test-d.ts
@@ -30,7 +30,7 @@ it('should type onChange properly', () => {
     form,
     name: 'name',
     validators: {
-      onChange: (value) => {
+      onChange: ({ value }) => {
         assertType<'test'>(value)
 
         return undefined
@@ -50,7 +50,7 @@ it('should type onChangeAsync properly', () => {
     form,
     name: 'name',
     validators: {
-      onChangeAsync: async (value) => {
+      onChangeAsync: async ({ value }) => {
         assertType<'test'>(value)
 
         return undefined

--- a/packages/form-core/src/tests/FormApi.spec.ts
+++ b/packages/form-core/src/tests/FormApi.spec.ts
@@ -259,7 +259,7 @@ describe('form api', () => {
       employees: Partial<Employee>[]
     }
 
-    const form = new FormApi<Form, unknown>()
+    const form = new FormApi<Form>()
 
     const field = new FieldApi({
       form,
@@ -287,7 +287,7 @@ describe('form api', () => {
       employees: Partial<Employee>[]
     }
 
-    const form = new FormApi<Form, unknown>()
+    const form = new FormApi<Form>()
 
     const field = new FieldApi({
       form,

--- a/packages/form-core/src/tests/FormApi.spec.ts
+++ b/packages/form-core/src/tests/FormApi.spec.ts
@@ -388,7 +388,7 @@ describe('form api', () => {
       form,
       name: 'name',
       validators: {
-        onChange: (v) => (v.length > 0 ? undefined : 'required'),
+        onChange: ({ value }) => (value.length > 0 ? undefined : 'required'),
       },
     })
 
@@ -418,7 +418,7 @@ describe('form api', () => {
         name: 'test',
       },
       validators: {
-        onChange: (value) => {
+        onChange: ({ value }) => {
           if (value.name === 'other') return 'Please enter a different value'
           return
         },
@@ -448,7 +448,7 @@ describe('form api', () => {
         name: 'test',
       },
       validators: {
-        onChangeAsync: async (value) => {
+        onChangeAsync: async ({ value }) => {
           await sleep(1000)
           if (value.name === 'other') return 'Please enter a different value'
           return
@@ -482,7 +482,7 @@ describe('form api', () => {
       },
       validators: {
         onChangeAsyncDebounceMs: 1000,
-        onChangeAsync: async (value) => {
+        onChangeAsync: async ({ value }) => {
           await sleepMock(1000)
           if (value.name === 'other') return 'Please enter a different value'
           return
@@ -519,7 +519,7 @@ describe('form api', () => {
       },
       asyncDebounceMs: 1000,
       validators: {
-        onChangeAsync: async (value) => {
+        onChangeAsync: async ({ value }) => {
           await sleepMock(1000)
           if (value.name === 'other') return 'Please enter a different value'
           return
@@ -552,7 +552,7 @@ describe('form api', () => {
         name: 'other',
       },
       validators: {
-        onBlur: (value) => {
+        onBlur: ({ value }) => {
           if (value.name === 'other') return 'Please enter a different value'
           return
         },
@@ -582,7 +582,7 @@ describe('form api', () => {
         name: 'test',
       },
       validators: {
-        onBlurAsync: async (value) => {
+        onBlurAsync: async ({ value }) => {
           await sleep(1000)
           if (value.name === 'other') return 'Please enter a different value'
           return
@@ -616,7 +616,7 @@ describe('form api', () => {
       },
       validators: {
         onBlurAsyncDebounceMs: 1000,
-        onBlurAsync: async (value) => {
+        onBlurAsync: async ({ value }) => {
           await sleepMock(10)
           if (value.name === 'other') return 'Please enter a different value'
           return
@@ -654,7 +654,7 @@ describe('form api', () => {
       },
       asyncDebounceMs: 1000,
       validators: {
-        onBlurAsync: async (value) => {
+        onBlurAsync: async ({ value }) => {
           await sleepMock(10)
           if (value.name === 'other') return 'Please enter a different value'
           return
@@ -688,11 +688,11 @@ describe('form api', () => {
         name: 'other',
       },
       validators: {
-        onBlur: (value) => {
+        onBlur: ({ value }) => {
           if (value.name === 'other') return 'Please enter a different value'
           return
         },
-        onChange: (value) => {
+        onChange: ({ value }) => {
           if (value.name === 'other') return 'Please enter a different value'
           return
         },
@@ -724,7 +724,7 @@ describe('form api', () => {
         name: 'other',
       },
       validators: {
-        onChange: (value) => {
+        onChange: ({ value }) => {
           if (value.name === 'other') return 'Please enter a different value'
           return
         },
@@ -754,7 +754,7 @@ describe('form api', () => {
         name: 'other',
       },
       validators: {
-        onMount: (value) => {
+        onMount: ({ value }) => {
           if (value.name === 'other') return 'Please enter a different value'
           return
         },
@@ -786,7 +786,8 @@ describe('form api', () => {
       form,
       name: 'firstName',
       validators: {
-        onChange: (v) => (v.length > 0 ? undefined : 'first name is required'),
+        onChange: ({ value }) =>
+          value.length > 0 ? undefined : 'first name is required',
       },
     })
 
@@ -794,7 +795,8 @@ describe('form api', () => {
       form,
       name: 'lastName',
       validators: {
-        onChange: (v) => (v.length > 0 ? undefined : 'last name is required'),
+        onChange: ({ value }) =>
+          value.length > 0 ? undefined : 'last name is required',
       },
     })
 
@@ -824,9 +826,10 @@ describe('form api', () => {
       form,
       name: 'firstName',
       validators: {
-        onChange: (v) => (v.length > 0 ? undefined : 'first name is required'),
-        onBlur: (v) =>
-          v.length > 3
+        onChange: ({ value }) =>
+          value.length > 0 ? undefined : 'first name is required',
+        onBlur: ({ value }) =>
+          value.length > 3
             ? undefined
             : 'first name must be longer than 3 characters',
       },
@@ -854,7 +857,8 @@ describe('form api', () => {
       form,
       name: 'firstName',
       validators: {
-        onSubmit: (v) => (v.length > 0 ? undefined : 'first name is required'),
+        onSubmit: ({ value }) =>
+          value.length > 0 ? undefined : 'first name is required',
       },
     })
 
@@ -886,7 +890,8 @@ describe('form api', () => {
       form,
       name: 'firstName',
       validators: {
-        onChange: (v) => (v.length > 0 ? undefined : 'first name is required'),
+        onChange: ({ value }) =>
+          value.length > 0 ? undefined : 'first name is required',
       },
     })
 
@@ -905,8 +910,8 @@ describe('form api', () => {
         firstName: '',
       },
       validators: {
-        onSubmit: (v) =>
-          v.firstName.length > 0 ? undefined : 'first name is required',
+        onSubmit: ({ value }) =>
+          value.firstName.length > 0 ? undefined : 'first name is required',
       },
     })
 
@@ -927,8 +932,8 @@ describe('form api', () => {
         firstName: '',
       },
       validators: {
-        onChange: (v) =>
-          v.firstName.length > 0 ? undefined : 'first name is required',
+        onChange: ({ value }) =>
+          value.firstName.length > 0 ? undefined : 'first name is required',
       },
     })
 

--- a/packages/form-core/src/tests/FormApi.spec.ts
+++ b/packages/form-core/src/tests/FormApi.spec.ts
@@ -24,7 +24,12 @@ describe('form api', () => {
       isValid: true,
       isValidating: false,
       submissionAttempts: 0,
-      formValidationCount: 0,
+      validationMetaMap: {
+        onChange: undefined,
+        onBlur: undefined,
+        onSubmit: undefined,
+        onMount: undefined,
+      },
     })
   })
 
@@ -53,7 +58,12 @@ describe('form api', () => {
       isValid: true,
       isValidating: false,
       submissionAttempts: 0,
-      formValidationCount: 0,
+      validationMetaMap: {
+        onChange: undefined,
+        onBlur: undefined,
+        onSubmit: undefined,
+        onMount: undefined,
+      },
     })
   })
 
@@ -80,7 +90,12 @@ describe('form api', () => {
       isValid: true,
       isValidating: false,
       submissionAttempts: 30,
-      formValidationCount: 0,
+      validationMetaMap: {
+        onChange: undefined,
+        onBlur: undefined,
+        onSubmit: undefined,
+        onMount: undefined,
+      },
     })
   })
 
@@ -118,7 +133,12 @@ describe('form api', () => {
       isValid: true,
       isValidating: false,
       submissionAttempts: 300,
-      formValidationCount: 0,
+      validationMetaMap: {
+        onChange: undefined,
+        onBlur: undefined,
+        onSubmit: undefined,
+        onMount: undefined,
+      },
     })
   })
 
@@ -152,7 +172,12 @@ describe('form api', () => {
       isValid: true,
       isValidating: false,
       submissionAttempts: 0,
-      formValidationCount: 0,
+      validationMetaMap: {
+        onChange: undefined,
+        onBlur: undefined,
+        onSubmit: undefined,
+        onMount: undefined,
+      },
     })
   })
 

--- a/packages/form-core/src/tests/FormApi.spec.ts
+++ b/packages/form-core/src/tests/FormApi.spec.ts
@@ -873,4 +873,48 @@ describe('form api', () => {
     await form.validateAllFields('change')
     expect(field.getMeta().errorMap.onChange).toEqual('first name is required')
   })
+
+  it('should show onSubmit errors', async () => {
+    const form = new FormApi({
+      defaultValues: {
+        firstName: '',
+      },
+      validators: {
+        onSubmit: (v) =>
+          v.firstName.length > 0 ? undefined : 'first name is required',
+      },
+    })
+
+    const field = new FieldApi({
+      form,
+      name: 'firstName',
+    })
+
+    field.mount()
+
+    await form.handleSubmit()
+    expect(form.state.errors).toStrictEqual(['first name is required'])
+  })
+
+  it('should run onChange validation during submit', async () => {
+    const form = new FormApi({
+      defaultValues: {
+        firstName: '',
+      },
+      validators: {
+        onChange: (v) =>
+          v.firstName.length > 0 ? undefined : 'first name is required',
+      },
+    })
+
+    const field = new FieldApi({
+      form,
+      name: 'firstName',
+    })
+
+    field.mount()
+
+    await form.handleSubmit()
+    expect(form.state.errors).toStrictEqual(['first name is required'])
+  })
 })

--- a/packages/form-core/src/tests/FormApi.spec.ts
+++ b/packages/form-core/src/tests/FormApi.spec.ts
@@ -362,7 +362,9 @@ describe('form api', () => {
     const field = new FieldApi({
       form,
       name: 'name',
-      onChange: (v) => (v.length > 0 ? undefined : 'required'),
+      validators: {
+        onChange: (v) => (v.length > 0 ? undefined : 'required'),
+      },
     })
 
     form.mount()
@@ -390,9 +392,11 @@ describe('form api', () => {
       defaultValues: {
         name: 'test',
       },
-      onChange: (value) => {
-        if (value.name === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onChange: (value) => {
+          if (value.name === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
 
@@ -418,10 +422,12 @@ describe('form api', () => {
       defaultValues: {
         name: 'test',
       },
-      onChangeAsync: async (value) => {
-        await sleep(1000)
-        if (value.name === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onChangeAsync: async (value) => {
+          await sleep(1000)
+          if (value.name === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
     const field = new FieldApi({
@@ -449,11 +455,13 @@ describe('form api', () => {
       defaultValues: {
         name: 'test',
       },
-      onChangeAsyncDebounceMs: 1000,
-      onChangeAsync: async (value) => {
-        await sleepMock(1000)
-        if (value.name === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onChangeAsyncDebounceMs: 1000,
+        onChangeAsync: async (value) => {
+          await sleepMock(1000)
+          if (value.name === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
     const field = new FieldApi({
@@ -485,10 +493,12 @@ describe('form api', () => {
         name: 'test',
       },
       asyncDebounceMs: 1000,
-      onChangeAsync: async (value) => {
-        await sleepMock(1000)
-        if (value.name === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onChangeAsync: async (value) => {
+          await sleepMock(1000)
+          if (value.name === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
     const field = new FieldApi({
@@ -516,9 +526,11 @@ describe('form api', () => {
       defaultValues: {
         name: 'other',
       },
-      onBlur: (value) => {
-        if (value.name === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onBlur: (value) => {
+          if (value.name === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
     const field = new FieldApi({
@@ -544,10 +556,12 @@ describe('form api', () => {
       defaultValues: {
         name: 'test',
       },
-      onBlurAsync: async (value) => {
-        await sleep(1000)
-        if (value.name === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onBlurAsync: async (value) => {
+          await sleep(1000)
+          if (value.name === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
     const field = new FieldApi({
@@ -575,11 +589,13 @@ describe('form api', () => {
       defaultValues: {
         name: 'test',
       },
-      onBlurAsyncDebounceMs: 1000,
-      onBlurAsync: async (value) => {
-        await sleepMock(10)
-        if (value.name === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onBlurAsyncDebounceMs: 1000,
+        onBlurAsync: async (value) => {
+          await sleepMock(10)
+          if (value.name === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
     const field = new FieldApi({
@@ -612,10 +628,12 @@ describe('form api', () => {
         name: 'test',
       },
       asyncDebounceMs: 1000,
-      onBlurAsync: async (value) => {
-        await sleepMock(10)
-        if (value.name === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onBlurAsync: async (value) => {
+          await sleepMock(10)
+          if (value.name === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
     const field = new FieldApi({
@@ -644,13 +662,15 @@ describe('form api', () => {
       defaultValues: {
         name: 'other',
       },
-      onBlur: (value) => {
-        if (value.name === 'other') return 'Please enter a different value'
-        return
-      },
-      onChange: (value) => {
-        if (value.name === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onBlur: (value) => {
+          if (value.name === 'other') return 'Please enter a different value'
+          return
+        },
+        onChange: (value) => {
+          if (value.name === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
     const field = new FieldApi({
@@ -678,9 +698,11 @@ describe('form api', () => {
       defaultValues: {
         name: 'other',
       },
-      onChange: (value) => {
-        if (value.name === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onChange: (value) => {
+          if (value.name === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
     const field = new FieldApi({
@@ -706,9 +728,11 @@ describe('form api', () => {
       defaultValues: {
         name: 'other',
       },
-      onMount: (value) => {
-        if (value.name === 'other') return 'Please enter a different value'
-        return
+      validators: {
+        onMount: (value) => {
+          if (value.name === 'other') return 'Please enter a different value'
+          return
+        },
       },
     })
     const field = new FieldApi({
@@ -736,13 +760,17 @@ describe('form api', () => {
     const field = new FieldApi({
       form,
       name: 'firstName',
-      onChange: (v) => (v.length > 0 ? undefined : 'first name is required'),
+      validators: {
+        onChange: (v) => (v.length > 0 ? undefined : 'first name is required'),
+      },
     })
 
     const lastNameField = new FieldApi({
       form,
       name: 'lastName',
-      onChange: (v) => (v.length > 0 ? undefined : 'last name is required'),
+      validators: {
+        onChange: (v) => (v.length > 0 ? undefined : 'last name is required'),
+      },
     })
 
     field.mount()
@@ -770,11 +798,13 @@ describe('form api', () => {
     const field = new FieldApi({
       form,
       name: 'firstName',
-      onChange: (v) => (v.length > 0 ? undefined : 'first name is required'),
-      onBlur: (v) =>
-        v.length > 3
-          ? undefined
-          : 'first name must be longer than 3 characters',
+      validators: {
+        onChange: (v) => (v.length > 0 ? undefined : 'first name is required'),
+        onBlur: (v) =>
+          v.length > 3
+            ? undefined
+            : 'first name must be longer than 3 characters',
+      },
     })
 
     field.mount()
@@ -798,7 +828,9 @@ describe('form api', () => {
     const field = new FieldApi({
       form,
       name: 'firstName',
-      onSubmit: (v) => (v.length > 0 ? undefined : 'first name is required'),
+      validators: {
+        onSubmit: (v) => (v.length > 0 ? undefined : 'first name is required'),
+      },
     })
 
     field.mount()
@@ -828,7 +860,9 @@ describe('form api', () => {
     const field = new FieldApi({
       form,
       name: 'firstName',
-      onChange: (v) => (v.length > 0 ? undefined : 'first name is required'),
+      validators: {
+        onChange: (v) => (v.length > 0 ? undefined : 'first name is required'),
+      },
     })
 
     field.mount()

--- a/packages/form-core/src/tests/utils.ts
+++ b/packages/form-core/src/tests/utils.ts
@@ -1,5 +1,5 @@
 export function sleep(timeout: number): Promise<void> {
-  return new Promise((resolve, _reject) => {
+  return new Promise((resolve) => {
     setTimeout(resolve, timeout)
   })
 }

--- a/packages/form-core/src/types.ts
+++ b/packages/form-core/src/types.ts
@@ -2,8 +2,8 @@ export type ValidationError = undefined | false | null | string
 
 // If/when TypeScript supports higher-kinded types, this should not be `unknown` anymore
 export type Validator<Type, Fn = unknown> = () => {
-  validate(value: Type, fn: Fn): ValidationError
-  validateAsync(value: Type, fn: Fn): Promise<ValidationError>
+  validate(options: { value: Type }, fn: Fn): ValidationError
+  validateAsync(options: { value: Type }, fn: Fn): Promise<ValidationError>
 }
 
 export type ValidationCause = 'change' | 'blur' | 'submit' | 'mount'

--- a/packages/form-core/src/types.ts
+++ b/packages/form-core/src/types.ts
@@ -5,3 +5,11 @@ export type Validator<Type, Fn = unknown> = () => {
   validate(value: Type, fn: Fn): ValidationError
   validateAsync(value: Type, fn: Fn): Promise<ValidationError>
 }
+
+export type ValidationCause = 'change' | 'blur' | 'submit' | 'mount'
+
+export type ValidationErrorMapKeys = `on${Capitalize<ValidationCause>}`
+
+export type ValidationErrorMap = {
+  [K in ValidationErrorMapKeys]?: ValidationError
+}

--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -150,7 +150,7 @@ export function runValidatorOrAdapter<
   validateFn: unknown
   // Order matters, first is run first
   adapters: Array<Validator<any> | undefined>
-  value: TData
+  value: any
   methodName: M
 }): ReturnType<ReturnType<Validator<TData>>[M]> {
   for (const adapter of props.adapters) {

--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -145,29 +145,6 @@ export function isNonEmptyArray(obj: any) {
   return !(Array.isArray(obj) && obj.length === 0)
 }
 
-export function runValidatorOrAdapter<
-  TData,
-  M extends 'validate' | 'validateAsync',
->(props: {
-  validateFn: unknown
-  // Order matters, first is run first
-  adapters: Array<Validator<any> | undefined>
-  value: any
-  methodName: M
-}): ReturnType<ReturnType<Validator<TData>>[M]> {
-  for (const adapter of props.adapters) {
-    if (adapter && typeof props.validateFn !== 'function') {
-      return (adapter as Validator<TData>)()[props.methodName](
-        props.value,
-        props.validateFn,
-      ) as never
-    }
-  }
-
-  const validateFn: (...vals: any[]) => any = props.validateFn as never
-  return validateFn(props.value) as never
-}
-
 interface AsyncValidatorArrayPartialOptions<T> {
   validators?: T
   asyncDebounceMs?: number

--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -145,7 +145,6 @@ export function isNonEmptyArray(obj: any) {
 
 export function runValidatorOrAdapter<
   TData,
-  SuppliedThis,
   M extends 'validate' | 'validateAsync',
 >(props: {
   validateFn: unknown
@@ -153,7 +152,6 @@ export function runValidatorOrAdapter<
   adapters: Array<Validator<any> | undefined>
   value: TData
   methodName: M
-  suppliedThis: SuppliedThis
 }): ReturnType<ReturnType<Validator<TData>>[M]> {
   for (const adapter of props.adapters) {
     if (adapter && typeof props.validateFn !== 'function') {
@@ -165,7 +163,7 @@ export function runValidatorOrAdapter<
   }
 
   const validateFn: (...vals: any[]) => any = props.validateFn as never
-  return validateFn(props.value, props.suppliedThis) as never
+  return validateFn(props.value) as never
 }
 
 export type RequiredByKey<T, K extends keyof T> = Omit<T, K> &

--- a/packages/react-form/src/createFormFactory.ts
+++ b/packages/react-form/src/createFormFactory.ts
@@ -1,23 +1,29 @@
-import type { FormApi, FormOptions } from '@tanstack/form-core'
+import type { FormApi, FormOptions, Validator } from '@tanstack/form-core'
 
 import { type UseField, type FieldComponent, Field, useField } from './useField'
 import { useForm } from './useForm'
 
-export type FormFactory<TFormData, FormValidator> = {
+export type FormFactory<
+  TFormData,
+  TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
+> = {
   useForm: (
-    opts?: FormOptions<TFormData, FormValidator>,
-  ) => FormApi<TFormData, FormValidator>
+    opts?: FormOptions<TFormData, TFormValidator>,
+  ) => FormApi<TFormData, TFormValidator>
   useField: UseField<TFormData>
-  Field: FieldComponent<TFormData, FormValidator>
+  Field: FieldComponent<TFormData, TFormValidator>
 }
 
-export function createFormFactory<TFormData, FormValidator>(
-  defaultOpts?: FormOptions<TFormData, FormValidator>,
-): FormFactory<TFormData, FormValidator> {
+export function createFormFactory<
+  TFormData,
+  TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
+>(
+  defaultOpts?: FormOptions<TFormData, TFormValidator>,
+): FormFactory<TFormData, TFormValidator> {
   return {
     useForm: (opts) => {
       const formOptions = Object.assign({}, defaultOpts, opts)
-      return useForm<TFormData, FormValidator>(formOptions)
+      return useForm<TFormData, TFormValidator>(formOptions)
     },
     useField: useField as any,
     Field: Field as any,

--- a/packages/react-form/src/formContext.ts
+++ b/packages/react-form/src/formContext.ts
@@ -1,8 +1,8 @@
-import type { FormApi } from '@tanstack/form-core'
+import type { FormApi, Validator } from '@tanstack/form-core'
 import * as React from 'react'
 
 export const formContext = React.createContext<{
-  formApi: FormApi<any, unknown>
+  formApi: FormApi<any, Validator<any, unknown> | undefined>
   parentFieldName?: string
 } | null>(null!)
 

--- a/packages/react-form/src/tests/createFormFactory.test.tsx
+++ b/packages/react-form/src/tests/createFormFactory.test.tsx
@@ -11,7 +11,7 @@ describe('createFormFactory', () => {
       lastName: string
     }
 
-    const formFactory = createFormFactory<Person, unknown>({
+    const formFactory = createFormFactory<Person>({
       defaultValues: {
         firstName: 'FirstName',
         lastName: 'LastName',

--- a/packages/react-form/src/tests/useField.test-d.tsx
+++ b/packages/react-form/src/tests/useField.test-d.tsx
@@ -43,17 +43,21 @@ it('should type onChange properly', () => {
       <form.Provider>
         <form.Field
           name="firstName"
-          onChange={(val) => {
-            assertType<'test'>(val)
-            return null
+          validators={{
+            onChange: (val) => {
+              assertType<'test'>(val)
+              return null
+            },
           }}
           children={(field) => null}
         />
         <form.Field
           name="age"
-          onChange={(val) => {
-            assertType<84>(val)
-            return null
+          validators={{
+            onChange: (val) => {
+              assertType<84>(val)
+              return null
+            },
           }}
           children={(field) => null}
         />

--- a/packages/react-form/src/tests/useField.test-d.tsx
+++ b/packages/react-form/src/tests/useField.test-d.tsx
@@ -44,8 +44,8 @@ it('should type onChange properly', () => {
         <form.Field
           name="firstName"
           validators={{
-            onChange: (val) => {
-              assertType<'test'>(val)
+            onChange: ({ value }) => {
+              assertType<'test'>(value)
               return null
             },
           }}
@@ -54,8 +54,8 @@ it('should type onChange properly', () => {
         <form.Field
           name="age"
           validators={{
-            onChange: (val) => {
-              assertType<84>(val)
+            onChange: ({ value }) => {
+              assertType<84>(value)
               return null
             },
           }}

--- a/packages/react-form/src/tests/useField.test.tsx
+++ b/packages/react-form/src/tests/useField.test.tsx
@@ -106,7 +106,9 @@ describe('useField', () => {
         <form.Provider>
           <form.Field
             name="firstName"
-            onChange={(value) => (value === 'other' ? error : undefined)}
+            validators={{
+              onChange: (value) => (value === 'other' ? error : undefined),
+            }}
             children={(field) => (
               <div>
                 <input
@@ -147,7 +149,9 @@ describe('useField', () => {
           <form.Field
             name="firstName"
             defaultMeta={{ isTouched: true }}
-            onChange={(value) => (value === 'other' ? error : undefined)}
+            validators={{
+              onChange: (value) => (value === 'other' ? error : undefined),
+            }}
             children={(field) => (
               <div>
                 <input
@@ -190,10 +194,11 @@ describe('useField', () => {
           <form.Field
             name="firstName"
             defaultMeta={{ isTouched: true }}
-            onChange={(value) =>
-              value === 'other' ? onChangeError : undefined
-            }
-            onBlur={(value) => (value === 'other' ? onBlurError : undefined)}
+            validators={{
+              onChange: (value) =>
+                value === 'other' ? onChangeError : undefined,
+              onBlur: (value) => (value === 'other' ? onBlurError : undefined),
+            }}
             children={(field) => (
               <div>
                 <input
@@ -239,9 +244,11 @@ describe('useField', () => {
           <form.Field
             name="firstName"
             defaultMeta={{ isTouched: true }}
-            onChangeAsync={async () => {
-              await sleep(10)
-              return error
+            validators={{
+              onChangeAsync: async () => {
+                await sleep(10)
+                return error
+              },
             }}
             children={(field) => (
               <div>
@@ -286,13 +293,15 @@ describe('useField', () => {
           <form.Field
             name="firstName"
             defaultMeta={{ isTouched: true }}
-            onChangeAsync={async () => {
-              await sleep(10)
-              return onChangeError
-            }}
-            onBlurAsync={async () => {
-              await sleep(10)
-              return onBlurError
+            validators={{
+              onChangeAsync: async () => {
+                await sleep(10)
+                return onChangeError
+              },
+              onBlurAsync: async () => {
+                await sleep(10)
+                return onBlurError
+              },
             }}
             children={(field) => (
               <div>
@@ -342,11 +351,13 @@ describe('useField', () => {
           <form.Field
             name="firstName"
             defaultMeta={{ isTouched: true }}
-            onChangeAsyncDebounceMs={100}
-            onChangeAsync={async () => {
-              mockFn()
-              await sleep(10)
-              return error
+            validators={{
+              onChangeAsyncDebounceMs: 100,
+              onChangeAsync: async () => {
+                mockFn()
+                await sleep(10)
+                return error
+              },
             }}
             children={(field) => (
               <div>

--- a/packages/react-form/src/tests/useField.test.tsx
+++ b/packages/react-form/src/tests/useField.test.tsx
@@ -15,7 +15,7 @@ describe('useField', () => {
       lastName: string
     }
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.useForm({
@@ -55,7 +55,7 @@ describe('useField', () => {
       lastName: string
     }
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.useForm({
@@ -97,7 +97,7 @@ describe('useField', () => {
     }
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.useForm()
@@ -139,7 +139,7 @@ describe('useField', () => {
     }
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.useForm()
@@ -184,7 +184,7 @@ describe('useField', () => {
     const onChangeError = 'Please enter a different value (onChangeError)'
     const onBlurError = 'Please enter a different value (onBlurError)'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.useForm()
@@ -235,7 +235,7 @@ describe('useField', () => {
     }
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.useForm()
@@ -284,7 +284,7 @@ describe('useField', () => {
     const onChangeError = 'Please enter a different value (onChangeError)'
     const onBlurError = 'Please enter a different value (onBlurError)'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.useForm()
@@ -342,7 +342,7 @@ describe('useField', () => {
     }
     const mockFn = vi.fn()
     const error = 'Please enter a different value'
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.useForm()
@@ -391,8 +391,8 @@ describe('useField', () => {
       firstName: string
       lastName: string
     }
-    const formFactory = createFormFactory<Person, unknown>()
-    let form: FormApi<Person, unknown> | null = null
+    const formFactory = createFormFactory<Person>()
+    let form: FormApi<Person> | null = null
     function Comp() {
       form = formFactory.useForm()
       return (
@@ -429,8 +429,8 @@ describe('useField', () => {
       firstName: string
       lastName: string
     }
-    const formFactory = createFormFactory<Person, unknown>()
-    let form: FormApi<Person, unknown> | null = null
+    const formFactory = createFormFactory<Person>()
+    let form: FormApi<Person> | null = null
     function Comp() {
       form = formFactory.useForm()
       return (

--- a/packages/react-form/src/tests/useField.test.tsx
+++ b/packages/react-form/src/tests/useField.test.tsx
@@ -107,7 +107,7 @@ describe('useField', () => {
           <form.Field
             name="firstName"
             validators={{
-              onChange: (value) => (value === 'other' ? error : undefined),
+              onChange: ({ value }) => (value === 'other' ? error : undefined),
             }}
             children={(field) => (
               <div>
@@ -150,7 +150,7 @@ describe('useField', () => {
             name="firstName"
             defaultMeta={{ isTouched: true }}
             validators={{
-              onChange: (value) => (value === 'other' ? error : undefined),
+              onChange: ({ value }) => (value === 'other' ? error : undefined),
             }}
             children={(field) => (
               <div>
@@ -195,9 +195,10 @@ describe('useField', () => {
             name="firstName"
             defaultMeta={{ isTouched: true }}
             validators={{
-              onChange: (value) =>
+              onChange: ({ value }) =>
                 value === 'other' ? onChangeError : undefined,
-              onBlur: (value) => (value === 'other' ? onBlurError : undefined),
+              onBlur: ({ value }) =>
+                value === 'other' ? onBlurError : undefined,
             }}
             children={(field) => (
               <div>

--- a/packages/react-form/src/tests/useForm.test-d.tsx
+++ b/packages/react-form/src/tests/useForm.test-d.tsx
@@ -1,0 +1,36 @@
+import { assertType } from 'vitest'
+import * as React from 'react'
+import { useForm } from '../useForm'
+
+it('should type onSubmit properly', () => {
+  function Comp() {
+    const form = useForm({
+      defaultValues: {
+        firstName: 'test',
+        age: 84,
+        // as const is required here
+      } as const,
+      onSubmit({ value }) {
+        assertType<84>(value.age)
+      },
+    })
+  }
+})
+
+it('should type a validator properly', () => {
+  function Comp() {
+    const form = useForm({
+      defaultValues: {
+        firstName: 'test',
+        age: 84,
+        // as const is required here
+      } as const,
+      validators: {
+        onChange({ value }) {
+          assertType<84>(value.age)
+          return undefined
+        },
+      },
+    })
+  }
+})

--- a/packages/react-form/src/tests/useForm.test.tsx
+++ b/packages/react-form/src/tests/useForm.test.tsx
@@ -135,9 +135,11 @@ describe('useForm', () => {
         defaultValues: {
           firstName: 'FirstName',
         },
-        onMount: () => {
-          setFormMounted(true)
-          return undefined
+        validators: {
+          onMount: () => {
+            setFormMounted(true)
+            return undefined
+          },
         },
       })
 
@@ -170,8 +172,10 @@ describe('useForm', () => {
 
     function Comp() {
       const form = formFactory.useForm({
-        onChange() {
-          return error
+        validators: {
+          onChange() {
+            return error
+          },
         },
       })
       return (
@@ -214,7 +218,10 @@ describe('useForm', () => {
 
     function Comp() {
       const form = formFactory.useForm({
-        onChange: (value) => (value.firstName === 'other' ? error : undefined),
+        validators: {
+          onChange: (value) =>
+            value.firstName === 'other' ? error : undefined,
+        },
       })
 
       const errors = form.useStore((s) => s.errors)
@@ -256,7 +263,10 @@ describe('useForm', () => {
 
     function Comp() {
       const form = formFactory.useForm({
-        onChange: (value) => (value.firstName === 'other' ? error : undefined),
+        validators: {
+          onChange: (value) =>
+            value.firstName === 'other' ? error : undefined,
+        },
       })
       const errors = form.useStore((s) => s.errorMap)
       return (
@@ -297,13 +307,15 @@ describe('useForm', () => {
         defaultValues: {
           firstName: '',
         },
-        onChange: (vals) => {
-          if (vals.firstName === 'other') return onChangeError
-          return undefined
-        },
-        onBlur: (vals) => {
-          if (vals.firstName === 'other') return onBlurError
-          return undefined
+        validators: {
+          onChange: (vals) => {
+            if (vals.firstName === 'other') return onChangeError
+            return undefined
+          },
+          onBlur: (vals) => {
+            if (vals.firstName === 'other') return onBlurError
+            return undefined
+          },
         },
       })
 
@@ -351,9 +363,11 @@ describe('useForm', () => {
 
     function Comp() {
       const form = formFactory.useForm({
-        onChangeAsync: async () => {
-          await sleep(10)
-          return error
+        validators: {
+          onChangeAsync: async () => {
+            await sleep(10)
+            return error
+          },
         },
       })
       const errors = form.useStore((s) => s.errorMap)
@@ -399,13 +413,15 @@ describe('useForm', () => {
 
     function Comp() {
       const form = formFactory.useForm({
-        onChangeAsync: async () => {
-          await sleep(10)
-          return onChangeError
-        },
-        onBlurAsync: async () => {
-          await sleep(10)
-          return onBlurError
+        validators: {
+          onChangeAsync: async () => {
+            await sleep(10)
+            return onChangeError
+          },
+          onBlurAsync: async () => {
+            await sleep(10)
+            return onBlurError
+          },
         },
       })
       const errors = form.useStore((s) => s.errorMap)
@@ -457,11 +473,13 @@ describe('useForm', () => {
 
     function Comp() {
       const form = formFactory.useForm({
-        onChangeAsyncDebounceMs: 100,
-        onChangeAsync: async () => {
-          mockFn()
-          await sleep(10)
-          return error
+        validators: {
+          onChangeAsyncDebounceMs: 100,
+          onChangeAsync: async () => {
+            mockFn()
+            await sleep(10)
+            return error
+          },
         },
       })
       const errors = form.useStore((s) => s.errors)

--- a/packages/react-form/src/tests/useForm.test.tsx
+++ b/packages/react-form/src/tests/useForm.test.tsx
@@ -219,7 +219,7 @@ describe('useForm', () => {
     function Comp() {
       const form = formFactory.useForm({
         validators: {
-          onChange: (value) =>
+          onChange: ({ value }) =>
             value.firstName === 'other' ? error : undefined,
         },
       })
@@ -264,7 +264,7 @@ describe('useForm', () => {
     function Comp() {
       const form = formFactory.useForm({
         validators: {
-          onChange: (value) =>
+          onChange: ({ value }) =>
             value.firstName === 'other' ? error : undefined,
         },
       })
@@ -308,12 +308,12 @@ describe('useForm', () => {
           firstName: '',
         },
         validators: {
-          onChange: (vals) => {
-            if (vals.firstName === 'other') return onChangeError
+          onChange: ({ value }) => {
+            if (value.firstName === 'other') return onChangeError
             return undefined
           },
-          onBlur: (vals) => {
-            if (vals.firstName === 'other') return onBlurError
+          onBlur: ({ value }) => {
+            if (value.firstName === 'other') return onBlurError
             return undefined
           },
         },

--- a/packages/react-form/src/tests/useForm.test.tsx
+++ b/packages/react-form/src/tests/useForm.test.tsx
@@ -90,8 +90,8 @@ describe('useForm', () => {
         defaultValues: {
           firstName: 'FirstName',
         },
-        onSubmit: (data) => {
-          setSubmittedData(data)
+        onSubmit: ({ value }) => {
+          setSubmittedData(value)
         },
       })
 

--- a/packages/react-form/src/tests/useForm.test.tsx
+++ b/packages/react-form/src/tests/useForm.test.tsx
@@ -15,7 +15,7 @@ describe('useForm', () => {
       lastName: string
     }
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.useForm()
@@ -53,7 +53,7 @@ describe('useForm', () => {
       lastName: string
     }
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.useForm({
@@ -168,7 +168,7 @@ describe('useForm', () => {
     }
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.useForm({
@@ -214,7 +214,7 @@ describe('useForm', () => {
     }
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.useForm({
@@ -259,7 +259,7 @@ describe('useForm', () => {
     }
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.useForm({
@@ -359,7 +359,7 @@ describe('useForm', () => {
     }
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.useForm({
@@ -409,7 +409,7 @@ describe('useForm', () => {
     const onChangeError = 'Please enter a different value (onChangeError)'
     const onBlurError = 'Please enter a different value (onBlurError)'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.useForm({
@@ -469,7 +469,7 @@ describe('useForm', () => {
     }
     const mockFn = vi.fn()
     const error = 'Please enter a different value'
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.useForm({

--- a/packages/react-form/src/types.ts
+++ b/packages/react-form/src/types.ts
@@ -1,11 +1,20 @@
-import type { FieldOptions, DeepKeys, DeepValue } from '@tanstack/form-core'
+import type {
+  FieldOptions,
+  DeepKeys,
+  DeepValue,
+  Validator,
+} from '@tanstack/form-core'
 
 export type UseFieldOptions<
   TParentData,
   TName extends DeepKeys<TParentData>,
-  ValidatorType,
-  FormValidator,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
-> = FieldOptions<TParentData, TName, ValidatorType, FormValidator, TData> & {
+> = FieldOptions<TParentData, TName, TFieldValidator, TFormValidator, TData> & {
   mode?: 'value' | 'array'
 }

--- a/packages/react-form/src/useField.tsx
+++ b/packages/react-form/src/useField.tsx
@@ -24,7 +24,7 @@ declare module '@tanstack/form-core' {
       | undefined = undefined,
     TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
   > {
-    Field: FieldComponent<TData, TFormValidator>
+    Field: FieldComponent<TParentData, TFormValidator>
   }
 }
 

--- a/packages/react-form/src/useField.tsx
+++ b/packages/react-form/src/useField.tsx
@@ -70,7 +70,7 @@ export function useField<
       ...opts,
       form: formApi,
       // TODO: Fix typings to include `index` and `parentFieldName`, if present
-      name: name as typeof opts.name,
+      name: name as typeof opts.name as never,
     })
 
     api.Field = Field as never
@@ -97,7 +97,7 @@ export function useField<
   // Instantiates field meta and removes it when unrendered
   useIsomorphicLayoutEffect(() => fieldApi.mount(), [fieldApi])
 
-  return fieldApi
+  return fieldApi as never
 }
 
 type FieldComponentProps<

--- a/packages/react-form/src/useForm.tsx
+++ b/packages/react-form/src/useForm.tsx
@@ -2,7 +2,7 @@ import type { FormState, FormOptions, Validator } from '@tanstack/form-core'
 import { FormApi, functionalUpdate } from '@tanstack/form-core'
 import type { NoInfer } from '@tanstack/react-store'
 import { useStore } from '@tanstack/react-store'
-import React, { type ReactNode, useState } from 'react'
+import React, { type PropsWithChildren, type ReactNode, useState } from 'react'
 import { type UseField, type FieldComponent, Field, useField } from './useField'
 import { formContext } from './formContext'
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
@@ -10,7 +10,7 @@ import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 declare module '@tanstack/form-core' {
   // eslint-disable-next-line no-shadow
   interface FormApi<TFormData, TFormValidator> {
-    Provider: (props: { children: any }) => any
+    Provider: (props: PropsWithChildren) => JSX.Element
     Field: FieldComponent<TFormData, TFormValidator>
     useField: UseField<TFormData>
     useStore: <TSelected = NoInfer<FormState<TFormData>>>(
@@ -19,7 +19,7 @@ declare module '@tanstack/form-core' {
     Subscribe: <TSelected = NoInfer<FormState<TFormData>>>(props: {
       selector?: (state: NoInfer<FormState<TFormData>>) => TSelected
       children: ((state: NoInfer<TSelected>) => ReactNode) | ReactNode
-    }) => any
+    }) => JSX.Element
   }
 }
 

--- a/packages/solid-form/src/createField.tsx
+++ b/packages/solid-form/src/createField.tsx
@@ -92,7 +92,7 @@ export function createField<
   const fieldApi = new FieldApi({
     ...options,
     form: formApi,
-    name: name as typeof options.name,
+    name: name as typeof options.name as never,
   })
   fieldApi.Field = Field as never
 
@@ -102,12 +102,12 @@ export function createField<
    *
    * createComputed to make sure this effect runs before render effects
    */
-  createComputed(() => fieldApi.update({ ...opts(), form: formApi }))
+  createComputed(() => fieldApi.update({ ...opts(), form: formApi } as never))
 
   // Instantiates field meta and removes it when unrendered
   onMount(() => onCleanup(fieldApi.mount()))
 
-  return makeFieldReactive(fieldApi)
+  return makeFieldReactive(fieldApi) as never
 }
 
 type FieldComponentProps<

--- a/packages/solid-form/src/createField.tsx
+++ b/packages/solid-form/src/createField.tsx
@@ -26,7 +26,7 @@ declare module '@tanstack/form-core' {
       | undefined = undefined,
     TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
   > {
-    Field: FieldComponent<TData, TFormValidator>
+    Field: FieldComponent<TParentData, TFormValidator>
   }
 }
 

--- a/packages/solid-form/src/createForm.tsx
+++ b/packages/solid-form/src/createForm.tsx
@@ -15,7 +15,7 @@ type NoInfer<T> = [T][T extends any ? 0 : never]
 declare module '@tanstack/form-core' {
   // eslint-disable-next-line no-shadow
   interface FormApi<TFormData, TFormValidator> {
-    Provider: (props: { children: any }) => any
+    Provider: (props: { children: any }) => JSXElement
     Field: FieldComponent<TFormData, TFormValidator>
     createField: CreateField<TFormData>
     useStore: <TSelected = NoInfer<FormState<TFormData>>>(
@@ -24,7 +24,7 @@ declare module '@tanstack/form-core' {
     Subscribe: <TSelected = NoInfer<FormState<TFormData>>>(props: {
       selector?: (state: NoInfer<FormState<TFormData>>) => TSelected
       children: ((state: () => NoInfer<TSelected>) => JSXElement) | JSXElement
-    }) => any
+    }) => JSXElement
   }
 }
 

--- a/packages/solid-form/src/createFormFactory.ts
+++ b/packages/solid-form/src/createFormFactory.ts
@@ -1,4 +1,4 @@
-import type { FormApi, FormOptions } from '@tanstack/form-core'
+import type { FormApi, FormOptions, Validator } from '@tanstack/form-core'
 
 import {
   type CreateField,
@@ -9,20 +9,26 @@ import {
 import { createForm } from './createForm'
 import { mergeProps } from 'solid-js'
 
-export type FormFactory<TFormData, FormValidator> = {
+export type FormFactory<
+  TFormData,
+  TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
+> = {
   createForm: (
-    opts?: () => FormOptions<TFormData, FormValidator>,
-  ) => FormApi<TFormData, FormValidator>
+    opts?: () => FormOptions<TFormData, TFormValidator>,
+  ) => FormApi<TFormData, TFormValidator>
   createField: CreateField<TFormData>
-  Field: FieldComponent<TFormData, FormValidator>
+  Field: FieldComponent<TFormData, TFormValidator>
 }
 
-export function createFormFactory<TFormData, FormValidator>(
-  defaultOpts?: () => FormOptions<TFormData, FormValidator>,
-): FormFactory<TFormData, FormValidator> {
+export function createFormFactory<
+  TFormData,
+  TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
+>(
+  defaultOpts?: () => FormOptions<TFormData, TFormValidator>,
+): FormFactory<TFormData, TFormValidator> {
   return {
     createForm: (opts) =>
-      createForm<TFormData, FormValidator>(() =>
+      createForm<TFormData, TFormValidator>(() =>
         mergeProps(defaultOpts?.() ?? {}, opts?.() ?? {}),
       ),
     createField,

--- a/packages/solid-form/src/formContext.ts
+++ b/packages/solid-form/src/formContext.ts
@@ -1,10 +1,10 @@
 import { createContext, useContext } from 'solid-js'
-import type { FormApi } from '@tanstack/form-core'
+import type { FormApi, Validator } from '@tanstack/form-core'
 
 type FormContextType =
   | undefined
   | {
-      formApi: FormApi<any, any>
+      formApi: FormApi<any, Validator<any, unknown> | undefined>
       parentFieldName?: string
     }
 

--- a/packages/solid-form/src/tests/createField.test-d.tsx
+++ b/packages/solid-form/src/tests/createField.test-d.tsx
@@ -48,17 +48,21 @@ it('should type onChange properly', () => {
       <form.Provider>
         <form.Field
           name="firstName"
-          onChange={(val) => {
-            assertType<'test'>(val)
-            return null
+          validators={{
+            onChange: (val) => {
+              assertType<'test'>(val)
+              return null
+            },
           }}
           children={(field) => null}
         />
         <form.Field
           name="age"
-          onChange={(val) => {
-            assertType<84>(val)
-            return null
+          validators={{
+            onChange: (val) => {
+              assertType<84>(val)
+              return null
+            },
           }}
           children={(field) => null}
         />

--- a/packages/solid-form/src/tests/createField.test-d.tsx
+++ b/packages/solid-form/src/tests/createField.test-d.tsx
@@ -1,3 +1,4 @@
+/// <reference lib="dom" />
 import { assertType } from 'vitest'
 import { createForm } from '../createForm'
 
@@ -19,12 +20,14 @@ it('should type state.value properly', () => {
           name="firstName"
           children={(field) => {
             assertType<'test'>(field().state.value)
+            return null
           }}
         />
         <form.Field
           name="age"
           children={(field) => {
             assertType<84>(field().state.value)
+            return null
           }}
         />
       </form.Provider>

--- a/packages/solid-form/src/tests/createField.test-d.tsx
+++ b/packages/solid-form/src/tests/createField.test-d.tsx
@@ -49,8 +49,8 @@ it('should type onChange properly', () => {
         <form.Field
           name="firstName"
           validators={{
-            onChange: (val) => {
-              assertType<'test'>(val)
+            onChange: ({ value }) => {
+              assertType<'test'>(value)
               return null
             },
           }}
@@ -59,8 +59,8 @@ it('should type onChange properly', () => {
         <form.Field
           name="age"
           validators={{
-            onChange: (val) => {
-              assertType<84>(val)
+            onChange: ({ value }) => {
+              assertType<84>(value)
               return null
             },
           }}

--- a/packages/solid-form/src/tests/createField.test.tsx
+++ b/packages/solid-form/src/tests/createField.test.tsx
@@ -1,3 +1,4 @@
+/// <reference lib="dom" />
 import { render, waitFor } from '@solidjs/testing-library'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
@@ -79,7 +80,7 @@ describe('createField', () => {
       )
     }
 
-    const { getByTestId } = render(<Comp />)
+    const { getByTestId } = render(() => <Comp />)
     const input = getByTestId('fieldinput')
     expect(input).toHaveValue('otherName')
   })
@@ -222,7 +223,6 @@ describe('createField', () => {
     expect(queryByText(onBlurError)).not.toBeInTheDocument()
     await user.type(input, 'other')
     expect(getByText(onChangeError)).toBeInTheDocument()
-    // @ts-expect-error unsure why the 'vitest/globals' in tsconfig doesnt work here
     await user.click(document.body)
     expect(queryByText(onBlurError)).toBeInTheDocument()
   })
@@ -329,7 +329,6 @@ describe('createField', () => {
     await user.type(input, 'other')
     await waitFor(() => getByText(onChangeError))
     expect(getByText(onChangeError)).toBeInTheDocument()
-    // @ts-expect-error unsure why the 'vitest/globals' in tsconfig doesnt work here
     await user.click(document.body)
     await waitFor(() => getByText(onBlurError))
     expect(getByText(onBlurError)).toBeInTheDocument()

--- a/packages/solid-form/src/tests/createField.test.tsx
+++ b/packages/solid-form/src/tests/createField.test.tsx
@@ -101,7 +101,7 @@ describe('createField', () => {
           <form.Field
             name="firstName"
             validators={{
-              onChange: (value) =>
+              onChange: ({ value }) =>
                 value.includes('other') ? error : undefined,
             }}
             children={(field) => (
@@ -145,7 +145,7 @@ describe('createField', () => {
             name="firstName"
             defaultMeta={{ isTouched: true }}
             validators={{
-              onChange: (value) =>
+              onChange: ({ value }) =>
                 value.includes('other') ? error : undefined,
             }}
             children={(field) => {
@@ -193,9 +193,9 @@ describe('createField', () => {
             name="firstName"
             defaultMeta={{ isTouched: true }}
             validators={{
-              onChange: (value) =>
+              onChange: ({ value }) =>
                 value.includes('other') ? onChangeError : undefined,
-              onBlur: (value) =>
+              onBlur: ({ value }) =>
                 value.includes('other') ? onBlurError : undefined,
             }}
             children={(field) => (

--- a/packages/solid-form/src/tests/createField.test.tsx
+++ b/packages/solid-form/src/tests/createField.test.tsx
@@ -100,7 +100,10 @@ describe('createField', () => {
         <form.Provider>
           <form.Field
             name="firstName"
-            onChange={(value) => (value.includes('other') ? error : undefined)}
+            validators={{
+              onChange: (value) =>
+                value.includes('other') ? error : undefined,
+            }}
             children={(field) => (
               <div>
                 <input
@@ -141,7 +144,10 @@ describe('createField', () => {
           <form.Field
             name="firstName"
             defaultMeta={{ isTouched: true }}
-            onChange={(value) => (value.includes('other') ? error : undefined)}
+            validators={{
+              onChange: (value) =>
+                value.includes('other') ? error : undefined,
+            }}
             children={(field) => {
               return (
                 <div>
@@ -186,12 +192,12 @@ describe('createField', () => {
           <form.Field
             name="firstName"
             defaultMeta={{ isTouched: true }}
-            onChange={(value) =>
-              value.includes('other') ? onChangeError : undefined
-            }
-            onBlur={(value) =>
-              value.includes('other') ? onBlurError : undefined
-            }
+            validators={{
+              onChange: (value) =>
+                value.includes('other') ? onChangeError : undefined,
+              onBlur: (value) =>
+                value.includes('other') ? onBlurError : undefined,
+            }}
             children={(field) => (
               <div>
                 <input
@@ -238,9 +244,11 @@ describe('createField', () => {
           <form.Field
             name="firstName"
             defaultMeta={{ isTouched: true }}
-            onChangeAsync={async () => {
-              await sleep(10)
-              return error
+            validators={{
+              onChangeAsync: async () => {
+                await sleep(10)
+                return error
+              },
             }}
             children={(field) => (
               <div>
@@ -285,13 +293,15 @@ describe('createField', () => {
           <form.Field
             name="firstName"
             defaultMeta={{ isTouched: true }}
-            onChangeAsync={async () => {
-              await sleep(10)
-              return onChangeError
-            }}
-            onBlurAsync={async () => {
-              await sleep(10)
-              return onBlurError
+            validators={{
+              onChangeAsync: async () => {
+                await sleep(10)
+                return onChangeError
+              },
+              onBlurAsync: async () => {
+                await sleep(10)
+                return onBlurError
+              },
             }}
             children={(field) => (
               <div>
@@ -342,11 +352,13 @@ describe('createField', () => {
           <form.Field
             name="firstName"
             defaultMeta={{ isTouched: true }}
-            onChangeAsyncDebounceMs={100}
-            onChangeAsync={async () => {
-              mockFn()
-              await sleep(10)
-              return error
+            validators={{
+              onChangeAsyncDebounceMs: 100,
+              onChangeAsync: async () => {
+                mockFn()
+                await sleep(10)
+                return error
+              },
             }}
             children={(field) => (
               <div>

--- a/packages/solid-form/src/tests/createField.test.tsx
+++ b/packages/solid-form/src/tests/createField.test.tsx
@@ -13,7 +13,7 @@ describe('createField', () => {
       lastName: string
     }
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.createForm()
@@ -49,7 +49,7 @@ describe('createField', () => {
       lastName: string
     }
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.createForm(() => ({
@@ -91,7 +91,7 @@ describe('createField', () => {
     }
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.createForm()
@@ -134,7 +134,7 @@ describe('createField', () => {
     }
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.createForm()
@@ -182,7 +182,7 @@ describe('createField', () => {
     const onChangeError = 'Please enter a different value (onChangeError)'
     const onBlurError = 'Please enter a different value (onBlurError)'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.createForm()
@@ -234,7 +234,7 @@ describe('createField', () => {
     }
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.createForm()
@@ -283,7 +283,7 @@ describe('createField', () => {
     const onChangeError = 'Please enter a different value (onChangeError)'
     const onBlurError = 'Please enter a different value (onBlurError)'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.createForm()
@@ -342,7 +342,7 @@ describe('createField', () => {
     }
     const mockFn = vi.fn()
     const error = 'Please enter a different value'
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.createForm()

--- a/packages/solid-form/src/tests/createForm.test.tsx
+++ b/packages/solid-form/src/tests/createForm.test.tsx
@@ -125,9 +125,11 @@ describe('createForm', () => {
         defaultValues: {
           firstName: 'FirstName',
         },
-        onMount: () => {
-          setFormMounted(true)
-          return undefined
+        validators: {
+          onMount: () => {
+            setFormMounted(true)
+            return undefined
+          },
         },
       }))
 
@@ -161,8 +163,10 @@ describe('createForm', () => {
 
     function Comp() {
       const form = formFactory.createForm(() => ({
-        onChange: (value) =>
-          value.firstName.includes('other') ? error : undefined,
+        validators: {
+          onChange: (value) =>
+            value.firstName.includes('other') ? error : undefined,
+        },
       }))
 
       return (
@@ -203,8 +207,10 @@ describe('createForm', () => {
 
     function Comp() {
       const form = formFactory.createForm(() => ({
-        onChange: (value) =>
-          value.firstName.includes('other') ? error : undefined,
+        validators: {
+          onChange: (value) =>
+            value.firstName.includes('other') ? error : undefined,
+        },
       }))
 
       const [errors, setErrors] = createSignal<ValidationErrorMap>()
@@ -253,10 +259,12 @@ describe('createForm', () => {
 
     function Comp() {
       const form = formFactory.createForm(() => ({
-        onChange: (value) =>
-          value.firstName.includes('other') ? onChangeError : undefined,
-        onBlur: (value) =>
-          value.firstName.includes('other') ? onBlurError : undefined,
+        validators: {
+          onChange: (value) =>
+            value.firstName.includes('other') ? onChangeError : undefined,
+          onBlur: (value) =>
+            value.firstName.includes('other') ? onBlurError : undefined,
+        },
       }))
 
       const [errors, setErrors] = createSignal<ValidationErrorMap>()
@@ -307,9 +315,11 @@ describe('createForm', () => {
 
     function Comp() {
       const form = formFactory.createForm(() => ({
-        onChangeAsync: async () => {
-          await sleep(10)
-          return error
+        validators: {
+          onChangeAsync: async () => {
+            await sleep(10)
+            return error
+          },
         },
       }))
 
@@ -358,13 +368,15 @@ describe('createForm', () => {
 
     function Comp() {
       const form = formFactory.createForm(() => ({
-        async onChangeAsync() {
-          await sleep(10)
-          return onChangeError
-        },
-        async onBlurAsync() {
-          await sleep(10)
-          return onBlurError
+        validators: {
+          async onChangeAsync() {
+            await sleep(10)
+            return onChangeError
+          },
+          async onBlurAsync() {
+            await sleep(10)
+            return onBlurError
+          },
         },
       }))
 
@@ -419,11 +431,13 @@ describe('createForm', () => {
 
     function Comp() {
       const form = formFactory.createForm(() => ({
-        onChangeAsyncDebounceMs: 100,
-        onChangeAsync: async () => {
-          mockFn()
-          await sleep(10)
-          return error
+        validators: {
+          onChangeAsyncDebounceMs: 100,
+          onChangeAsync: async () => {
+            mockFn()
+            await sleep(10)
+            return error
+          },
         },
       }))
 

--- a/packages/solid-form/src/tests/createForm.test.tsx
+++ b/packages/solid-form/src/tests/createForm.test.tsx
@@ -84,8 +84,8 @@ describe('createForm', () => {
         defaultValues: {
           firstName: 'FirstName',
         },
-        onSubmit: (data) => {
-          submittedData = data
+        onSubmit: ({ value }) => {
+          submittedData = value
         },
       }))
 

--- a/packages/solid-form/src/tests/createForm.test.tsx
+++ b/packages/solid-form/src/tests/createForm.test.tsx
@@ -164,7 +164,7 @@ describe('createForm', () => {
     function Comp() {
       const form = formFactory.createForm(() => ({
         validators: {
-          onChange: (value) =>
+          onChange: ({ value }) =>
             value.firstName.includes('other') ? error : undefined,
         },
       }))
@@ -208,7 +208,7 @@ describe('createForm', () => {
     function Comp() {
       const form = formFactory.createForm(() => ({
         validators: {
-          onChange: (value) =>
+          onChange: ({ value }) =>
             value.firstName.includes('other') ? error : undefined,
         },
       }))
@@ -260,9 +260,9 @@ describe('createForm', () => {
     function Comp() {
       const form = formFactory.createForm(() => ({
         validators: {
-          onChange: (value) =>
+          onChange: ({ value }) =>
             value.firstName.includes('other') ? onChangeError : undefined,
-          onBlur: (value) =>
+          onBlur: ({ value }) =>
             value.firstName.includes('other') ? onBlurError : undefined,
         },
       }))

--- a/packages/solid-form/src/tests/createForm.test.tsx
+++ b/packages/solid-form/src/tests/createForm.test.tsx
@@ -15,7 +15,7 @@ describe('createForm', () => {
       lastName: string
     }
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.createForm()
@@ -50,7 +50,7 @@ describe('createForm', () => {
       lastName: string
     }
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.createForm(() => ({
@@ -159,7 +159,7 @@ describe('createForm', () => {
     }
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.createForm(() => ({
@@ -203,7 +203,7 @@ describe('createForm', () => {
     }
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.createForm(() => ({
@@ -255,7 +255,7 @@ describe('createForm', () => {
     const onChangeError = 'Please enter a different value (onChangeError)'
     const onBlurError = 'Please enter a different value (onBlurError)'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.createForm(() => ({
@@ -311,7 +311,7 @@ describe('createForm', () => {
     }
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.createForm(() => ({
@@ -364,7 +364,7 @@ describe('createForm', () => {
     const onChangeError = 'Please enter a different value (onChangeError)'
     const onBlurError = 'Please enter a different value (onBlurError)'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.createForm(() => ({
@@ -427,7 +427,7 @@ describe('createForm', () => {
     }
     const mockFn = vi.fn()
     const error = 'Please enter a different value'
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     function Comp() {
       const form = formFactory.createForm(() => ({

--- a/packages/solid-form/src/tests/createForm.test.tsx
+++ b/packages/solid-form/src/tests/createForm.test.tsx
@@ -1,3 +1,4 @@
+/// <reference lib="dom" />
 import { render, screen, waitFor } from '@solidjs/testing-library'
 import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
@@ -169,6 +170,8 @@ describe('createForm', () => {
         },
       }))
 
+      const errors = form.useStore((s) => s.errors)
+
       return (
         <form.Provider>
           <form.Field
@@ -182,7 +185,7 @@ describe('createForm', () => {
                   onBlur={field().handleBlur}
                   onInput={(e) => field().setValue(e.currentTarget.value)}
                 />
-                <p>{form.useStore((s) => s.errors)}</p>
+                <p>{errors().join(',')}</p>
               </div>
             )}
           />
@@ -299,7 +302,6 @@ describe('createForm', () => {
     expect(queryByText(onBlurError)).not.toBeInTheDocument()
     await user.type(input, 'other')
     expect(getByText(onChangeError)).toBeInTheDocument()
-    // @ts-expect-error unsure why the 'vitest/globals' in tsconfig doesnt work here
     await user.click(document.body)
     expect(queryByText(onBlurError)).toBeInTheDocument()
   })
@@ -414,7 +416,6 @@ describe('createForm', () => {
     await user.type(input, 'other')
     await waitFor(() => getByText(onChangeError))
     expect(getByText(onChangeError)).toBeInTheDocument()
-    // @ts-expect-error unsure why the 'vitest/globals' in tsconfig doesnt work here
     await user.click(document.body)
     await waitFor(() => getByText(onBlurError))
     expect(getByText(onBlurError)).toBeInTheDocument()

--- a/packages/solid-form/src/tests/createFormFactory.test.tsx
+++ b/packages/solid-form/src/tests/createFormFactory.test.tsx
@@ -9,7 +9,7 @@ describe('createFormFactory', () => {
       lastName: string
     }
 
-    const formFactory = createFormFactory<Person, unknown>(() => ({
+    const formFactory = createFormFactory<Person>(() => ({
       defaultValues: {
         firstName: 'FirstName',
         lastName: 'LastName',

--- a/packages/solid-form/src/tests/createFormFactory.test.tsx
+++ b/packages/solid-form/src/tests/createFormFactory.test.tsx
@@ -1,3 +1,4 @@
+/// <reference lib="dom" />
 import { render } from '@solidjs/testing-library'
 import '@testing-library/jest-dom'
 import { createFormFactory } from '..'

--- a/packages/solid-form/src/types.ts
+++ b/packages/solid-form/src/types.ts
@@ -1,11 +1,20 @@
-import type { FieldOptions, DeepKeys, DeepValue } from '@tanstack/form-core'
+import type {
+  FieldOptions,
+  DeepKeys,
+  DeepValue,
+  Validator,
+} from '@tanstack/form-core'
 
 export type CreateFieldOptions<
   TParentData,
   TName extends DeepKeys<TParentData>,
-  ValidatorType,
-  FormValidator,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
-> = FieldOptions<TParentData, TName, ValidatorType, FormValidator, TData> & {
+> = FieldOptions<TParentData, TName, TFieldValidator, TFormValidator, TData> & {
   mode?: 'value' | 'array'
 }

--- a/packages/valibot-form-adapter/src/tests/FieldApi.spec.ts
+++ b/packages/valibot-form-adapter/src/tests/FieldApi.spec.ts
@@ -17,7 +17,11 @@ describe('valibot field api', () => {
       form,
       validator: valibotValidator,
       name: 'name',
-      onChange: string([minLength(3, 'You must have a length of at least 3')]),
+      validators: {
+        onChange: string([
+          minLength(3, 'You must have a length of at least 3'),
+        ]),
+      },
     })
 
     field.mount()
@@ -42,7 +46,9 @@ describe('valibot field api', () => {
       form,
       validator: valibotValidator,
       name: 'name',
-      onChange: (val) => (val === 'a' ? 'Test' : undefined),
+      validators: {
+        onChange: (val) => (val === 'a' ? 'Test' : undefined),
+      },
     })
 
     field.mount()
@@ -65,10 +71,12 @@ describe('valibot field api', () => {
       form,
       validator: valibotValidator,
       name: 'name',
-      onChangeAsync: stringAsync([
-        customAsync(async (val) => val.length > 3, 'Testing 123'),
-      ]),
-      onChangeAsyncDebounceMs: 0,
+      validators: {
+        onChangeAsync: stringAsync([
+          customAsync(async (val) => val.length > 3, 'Testing 123'),
+        ]),
+        onChangeAsyncDebounceMs: 0,
+      },
     })
 
     field.mount()
@@ -93,8 +101,10 @@ describe('valibot field api', () => {
       form,
       validator: valibotValidator,
       name: 'name',
-      onChangeAsync: async (val) => (val === 'a' ? 'Test' : undefined),
-      onChangeAsyncDebounceMs: 0,
+      validators: {
+        onChangeAsync: async (val) => (val === 'a' ? 'Test' : undefined),
+        onChangeAsyncDebounceMs: 0,
+      },
     })
 
     field.mount()

--- a/packages/valibot-form-adapter/src/tests/FieldApi.spec.ts
+++ b/packages/valibot-form-adapter/src/tests/FieldApi.spec.ts
@@ -102,7 +102,8 @@ describe('valibot field api', () => {
       validatorAdapter: valibotValidator,
       name: 'name',
       validators: {
-        onChangeAsync: async ({ value }) => (value === 'a' ? 'Test' : undefined),
+        onChangeAsync: async ({ value }) =>
+          value === 'a' ? 'Test' : undefined,
         onChangeAsyncDebounceMs: 0,
       },
     })

--- a/packages/valibot-form-adapter/src/tests/FieldApi.spec.ts
+++ b/packages/valibot-form-adapter/src/tests/FieldApi.spec.ts
@@ -15,7 +15,7 @@ describe('valibot field api', () => {
 
     const field = new FieldApi({
       form,
-      validator: valibotValidator,
+      validatorAdapter: valibotValidator,
       name: 'name',
       validators: {
         onChange: string([
@@ -44,7 +44,7 @@ describe('valibot field api', () => {
 
     const field = new FieldApi({
       form,
-      validator: valibotValidator,
+      validatorAdapter: valibotValidator,
       name: 'name',
       validators: {
         onChange: (val) => (val === 'a' ? 'Test' : undefined),
@@ -69,7 +69,7 @@ describe('valibot field api', () => {
 
     const field = new FieldApi({
       form,
-      validator: valibotValidator,
+      validatorAdapter: valibotValidator,
       name: 'name',
       validators: {
         onChangeAsync: stringAsync([
@@ -99,7 +99,7 @@ describe('valibot field api', () => {
 
     const field = new FieldApi({
       form,
-      validator: valibotValidator,
+      validatorAdapter: valibotValidator,
       name: 'name',
       validators: {
         onChangeAsync: async (val) => (val === 'a' ? 'Test' : undefined),

--- a/packages/valibot-form-adapter/src/tests/FieldApi.spec.ts
+++ b/packages/valibot-form-adapter/src/tests/FieldApi.spec.ts
@@ -47,7 +47,7 @@ describe('valibot field api', () => {
       validatorAdapter: valibotValidator,
       name: 'name',
       validators: {
-        onChange: (val) => (val === 'a' ? 'Test' : undefined),
+        onChange: ({ value }) => (value === 'a' ? 'Test' : undefined),
       },
     })
 
@@ -102,7 +102,7 @@ describe('valibot field api', () => {
       validatorAdapter: valibotValidator,
       name: 'name',
       validators: {
-        onChangeAsync: async (val) => (val === 'a' ? 'Test' : undefined),
+        onChangeAsync: async ({ value }) => (value === 'a' ? 'Test' : undefined),
         onChangeAsyncDebounceMs: 0,
       },
     })

--- a/packages/valibot-form-adapter/src/tests/FieldApi.test-d.ts
+++ b/packages/valibot-form-adapter/src/tests/FieldApi.test-d.ts
@@ -13,7 +13,7 @@ it('should allow a Valibot validator to be passed in', () => {
   const field = new FieldApi({
     form,
     name: 'name',
-    validator: valibotValidator,
+    validatorAdapter: valibotValidator,
   } as const)
 })
 
@@ -27,7 +27,7 @@ it('should allow a Valibot validator to handle the correct Valibot type', () => 
   const field = new FieldApi({
     form,
     name: 'name',
-    validator: valibotValidator,
+    validatorAdapter: valibotValidator,
     validators: {
       onChange: string(),
     },
@@ -44,7 +44,7 @@ it('should allow a Valibot validator to handle the correct Valibot type for an a
   const field = new FieldApi({
     form,
     name: 'name',
-    validator: valibotValidator,
+    validatorAdapter: valibotValidator,
     validators: {
       onChangeAsync: string(),
     },
@@ -61,7 +61,7 @@ it('should allow a functional onChange to be passed when using a validator', () 
   const field = new FieldApi({
     form,
     name: 'name',
-    validator: valibotValidator,
+    validatorAdapter: valibotValidator,
     validators: {
       onChange: (val) => {
         assertType<'test'>(val)
@@ -97,7 +97,7 @@ it.skip('should allow not a Valibot validator with the wrong Valibot type', () =
   const field = new FieldApi({
     form,
     name: 'name',
-    validator: valibotValidator,
+    validatorAdapter: valibotValidator,
     validators: {
       onChange: object({}),
     },

--- a/packages/valibot-form-adapter/src/tests/FieldApi.test-d.ts
+++ b/packages/valibot-form-adapter/src/tests/FieldApi.test-d.ts
@@ -28,7 +28,9 @@ it('should allow a Valibot validator to handle the correct Valibot type', () => 
     form,
     name: 'name',
     validator: valibotValidator,
-    onChange: string(),
+    validators: {
+      onChange: string(),
+    },
   } as const)
 })
 
@@ -43,7 +45,9 @@ it('should allow a Valibot validator to handle the correct Valibot type for an a
     form,
     name: 'name',
     validator: valibotValidator,
-    onChangeAsync: string(),
+    validators: {
+      onChangeAsync: string(),
+    },
   } as const)
 })
 
@@ -58,9 +62,11 @@ it('should allow a functional onChange to be passed when using a validator', () 
     form,
     name: 'name',
     validator: valibotValidator,
-    onChange: (val) => {
-      assertType<'test'>(val)
-      return undefined
+    validators: {
+      onChange: (val) => {
+        assertType<'test'>(val)
+        return undefined
+      },
     },
   } as const)
 })
@@ -92,6 +98,8 @@ it.skip('should allow not a Valibot validator with the wrong Valibot type', () =
     form,
     name: 'name',
     validator: valibotValidator,
-    onChange: object({}),
+    validators: {
+      onChange: object({}),
+    },
   } as const)
 })

--- a/packages/valibot-form-adapter/src/tests/FieldApi.test-d.ts
+++ b/packages/valibot-form-adapter/src/tests/FieldApi.test-d.ts
@@ -56,7 +56,7 @@ it('should allow a functional onChange to be passed when using a validator', () 
     defaultValues: {
       name: 'test',
     },
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
@@ -68,7 +68,7 @@ it('should allow a functional onChange to be passed when using a validator', () 
         return undefined
       },
     },
-  } as const)
+  })
 })
 
 it('should not allow a validator onChange to be passed when not using a validator', () => {

--- a/packages/valibot-form-adapter/src/tests/FieldApi.test-d.ts
+++ b/packages/valibot-form-adapter/src/tests/FieldApi.test-d.ts
@@ -63,8 +63,8 @@ it('should allow a functional onChange to be passed when using a validator', () 
     name: 'name',
     validatorAdapter: valibotValidator,
     validators: {
-      onChange: (val) => {
-        assertType<'test'>(val)
+      onChange: ({ value }) => {
+        assertType<'test'>(value)
         return undefined
       },
     },

--- a/packages/valibot-form-adapter/src/tests/FormApi.spec.ts
+++ b/packages/valibot-form-adapter/src/tests/FormApi.spec.ts
@@ -46,7 +46,7 @@ describe('valibot form api', () => {
       form,
       name: 'name',
       validators: {
-        onChange: (val) => (val === 'a' ? 'Test' : undefined),
+        onChange: ({ value }) => (value === 'a' ? 'Test' : undefined),
       },
     })
 

--- a/packages/valibot-form-adapter/src/tests/FormApi.spec.ts
+++ b/packages/valibot-form-adapter/src/tests/FormApi.spec.ts
@@ -16,7 +16,11 @@ describe('valibot form api', () => {
     const field = new FieldApi({
       form,
       name: 'name',
-      onChange: string([minLength(3, 'You must have a length of at least 3')]),
+      validators: {
+        onChange: string([
+          minLength(3, 'You must have a length of at least 3'),
+        ]),
+      },
     })
 
     field.mount()
@@ -41,7 +45,9 @@ describe('valibot form api', () => {
     const field = new FieldApi({
       form,
       name: 'name',
-      onChange: (val) => (val === 'a' ? 'Test' : undefined),
+      validators: {
+        onChange: (val) => (val === 'a' ? 'Test' : undefined),
+      },
     })
 
     field.mount()

--- a/packages/valibot-form-adapter/src/tests/FormApi.spec.ts
+++ b/packages/valibot-form-adapter/src/tests/FormApi.spec.ts
@@ -10,7 +10,7 @@ describe('valibot form api', () => {
       defaultValues: {
         name: '',
       },
-      validator: valibotValidator,
+      validatorAdapter: valibotValidator,
     })
 
     const field = new FieldApi({
@@ -39,7 +39,7 @@ describe('valibot form api', () => {
       defaultValues: {
         name: '',
       },
-      validator: valibotValidator,
+      validatorAdapter: valibotValidator,
     })
 
     const field = new FieldApi({

--- a/packages/valibot-form-adapter/src/tests/FormApi.test-d.ts
+++ b/packages/valibot-form-adapter/src/tests/FormApi.test-d.ts
@@ -58,8 +58,8 @@ it('should allow a functional onChange to be passed when using a validator', () 
     form,
     name: 'name',
     validators: {
-      onChange: (val) => {
-        assertType<'test'>(val)
+      onChange: ({ value }) => {
+        assertType<'test'>(value)
         return undefined
       },
     },

--- a/packages/valibot-form-adapter/src/tests/FormApi.test-d.ts
+++ b/packages/valibot-form-adapter/src/tests/FormApi.test-d.ts
@@ -18,7 +18,7 @@ it('should allow a Valibot validator to handle the correct Valibot type', () => 
       name: 'test',
     },
     validatorAdapter: valibotValidator,
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
@@ -26,7 +26,7 @@ it('should allow a Valibot validator to handle the correct Valibot type', () => 
     validators: {
       onChange: string(),
     },
-  } as const)
+  })
 })
 
 it('should allow a Valibot validator to handle the correct Valibot type on async methods', () => {
@@ -35,7 +35,7 @@ it('should allow a Valibot validator to handle the correct Valibot type on async
       name: 'test',
     },
     validatorAdapter: valibotValidator,
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
@@ -43,7 +43,7 @@ it('should allow a Valibot validator to handle the correct Valibot type on async
     validators: {
       onChangeAsync: string(),
     },
-  } as const)
+  })
 })
 
 it('should allow a functional onChange to be passed when using a validator', () => {
@@ -52,7 +52,7 @@ it('should allow a functional onChange to be passed when using a validator', () 
       name: 'test',
     },
     validatorAdapter: valibotValidator,
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
@@ -63,7 +63,7 @@ it('should allow a functional onChange to be passed when using a validator', () 
         return undefined
       },
     },
-  } as const)
+  })
 })
 
 it('should not allow a validator onChange to be passed when not using a validator', () => {
@@ -71,14 +71,14 @@ it('should not allow a validator onChange to be passed when not using a validato
     defaultValues: {
       name: 'test',
     },
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
     name: 'name',
     // @ts-expect-error Requires a validator
     onChange: string(),
-  } as const)
+  })
 })
 
 // This is not possible without higher-kinded types AFAIK
@@ -87,7 +87,7 @@ it.skip('should allow not a Valibot validator with the wrong Valibot type', () =
     defaultValues: {
       name: 'test',
     },
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
@@ -96,5 +96,5 @@ it.skip('should allow not a Valibot validator with the wrong Valibot type', () =
     validators: {
       onChange: object({}),
     },
-  } as const)
+  })
 })

--- a/packages/valibot-form-adapter/src/tests/FormApi.test-d.ts
+++ b/packages/valibot-form-adapter/src/tests/FormApi.test-d.ts
@@ -23,7 +23,9 @@ it('should allow a Valibot validator to handle the correct Valibot type', () => 
   const field = new FieldApi({
     form,
     name: 'name',
-    onChange: string(),
+    validators: {
+      onChange: string(),
+    },
   } as const)
 })
 
@@ -38,7 +40,9 @@ it('should allow a Valibot validator to handle the correct Valibot type on async
   const field = new FieldApi({
     form,
     name: 'name',
-    onChangeAsync: string(),
+    validators: {
+      onChangeAsync: string(),
+    },
   } as const)
 })
 
@@ -53,9 +57,11 @@ it('should allow a functional onChange to be passed when using a validator', () 
   const field = new FieldApi({
     form,
     name: 'name',
-    onChange: (val) => {
-      assertType<'test'>(val)
-      return undefined
+    validators: {
+      onChange: (val) => {
+        assertType<'test'>(val)
+        return undefined
+      },
     },
   } as const)
 })
@@ -87,6 +93,8 @@ it.skip('should allow not a Valibot validator with the wrong Valibot type', () =
     form,
     name: 'name',
     validator: valibotValidator,
-    onChange: object({}),
+    validators: {
+      onChange: object({}),
+    },
   } as const)
 })

--- a/packages/valibot-form-adapter/src/tests/FormApi.test-d.ts
+++ b/packages/valibot-form-adapter/src/tests/FormApi.test-d.ts
@@ -8,7 +8,7 @@ it('should allow a Valibot validator to be passed in', () => {
     defaultValues: {
       name: 'test',
     },
-    validator: valibotValidator,
+    validatorAdapter: valibotValidator,
   } as const)
 })
 
@@ -17,7 +17,7 @@ it('should allow a Valibot validator to handle the correct Valibot type', () => 
     defaultValues: {
       name: 'test',
     },
-    validator: valibotValidator,
+    validatorAdapter: valibotValidator,
   })
 
   const field = new FieldApi({
@@ -34,7 +34,7 @@ it('should allow a Valibot validator to handle the correct Valibot type on async
     defaultValues: {
       name: 'test',
     },
-    validator: valibotValidator,
+    validatorAdapter: valibotValidator,
   })
 
   const field = new FieldApi({
@@ -51,7 +51,7 @@ it('should allow a functional onChange to be passed when using a validator', () 
     defaultValues: {
       name: 'test',
     },
-    validator: valibotValidator,
+    validatorAdapter: valibotValidator,
   })
 
   const field = new FieldApi({
@@ -92,7 +92,7 @@ it.skip('should allow not a Valibot validator with the wrong Valibot type', () =
   const field = new FieldApi({
     form,
     name: 'name',
-    validator: valibotValidator,
+    validatorAdapter: valibotValidator,
     validators: {
       onChange: object({}),
     },

--- a/packages/valibot-form-adapter/src/validator.ts
+++ b/packages/valibot-form-adapter/src/validator.ts
@@ -6,13 +6,16 @@ export const valibotValidator = (<
   Fn extends BaseSchema | BaseSchemaAsync = BaseSchema | BaseSchemaAsync,
 >() => {
   return {
-    validate(value: unknown, fn: Fn): ValidationError {
+    validate({ value }: { value: unknown }, fn: Fn): ValidationError {
       if (fn.async) return
       const result = safeParse(fn, value)
       if (result.success) return
       return result.issues.map((i) => i.message).join(', ')
     },
-    async validateAsync(value: unknown, fn: Fn): Promise<ValidationError> {
+    async validateAsync(
+      { value }: { value: unknown },
+      fn: Fn,
+    ): Promise<ValidationError> {
       const result = await safeParseAsync(fn, value)
       if (result.success) return
       return result.issues.map((i) => i.message).join(', ')

--- a/packages/valibot-form-adapter/src/validator.ts
+++ b/packages/valibot-form-adapter/src/validator.ts
@@ -1,24 +1,19 @@
 import { safeParse, safeParseAsync } from 'valibot'
 import type { BaseSchema, BaseSchemaAsync } from 'valibot'
-import type { ValidationError, Validator } from '@tanstack/form-core'
+import type { Validator } from '@tanstack/form-core'
 
-export const valibotValidator = (<
-  Fn extends BaseSchema | BaseSchemaAsync = BaseSchema | BaseSchemaAsync,
->() => {
+export const valibotValidator = (() => {
   return {
-    validate({ value }: { value: unknown }, fn: Fn): ValidationError {
+    validate({ value }, fn) {
       if (fn.async) return
       const result = safeParse(fn, value)
       if (result.success) return
       return result.issues.map((i) => i.message).join(', ')
     },
-    async validateAsync(
-      { value }: { value: unknown },
-      fn: Fn,
-    ): Promise<ValidationError> {
+    async validateAsync({ value }, fn) {
       const result = await safeParseAsync(fn, value)
       if (result.success) return
       return result.issues.map((i) => i.message).join(', ')
     },
   }
-}) satisfies Validator<unknown>
+}) as Validator<unknown, BaseSchema | BaseSchemaAsync>

--- a/packages/vue-form/src/createFormFactory.ts
+++ b/packages/vue-form/src/createFormFactory.ts
@@ -1,23 +1,29 @@
-import type { FormApi, FormOptions } from '@tanstack/form-core'
+import type { FormApi, FormOptions, Validator } from '@tanstack/form-core'
 
 import { type UseField, type FieldComponent, Field, useField } from './useField'
 import { useForm } from './useForm'
 
-export type FormFactory<TFormData, FormValidator> = {
+export type FormFactory<
+  TFormData,
+  TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
+> = {
   useForm: (
-    opts?: FormOptions<TFormData, FormValidator>,
-  ) => FormApi<TFormData, FormValidator>
-  useField: UseField<TFormData, FormValidator>
-  Field: FieldComponent<TFormData, FormValidator>
+    opts?: FormOptions<TFormData, TFormValidator>,
+  ) => FormApi<TFormData, TFormValidator>
+  useField: UseField<TFormData, TFormValidator>
+  Field: FieldComponent<TFormData, TFormValidator>
 }
 
-export function createFormFactory<TFormData, FormValidator>(
-  defaultOpts?: FormOptions<TFormData, FormValidator>,
-): FormFactory<TFormData, FormValidator> {
+export function createFormFactory<
+  TFormData,
+  TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
+>(
+  defaultOpts?: FormOptions<TFormData, TFormValidator>,
+): FormFactory<TFormData, TFormValidator> {
   return {
     useForm: (opts) => {
       const formOptions = Object.assign({}, defaultOpts, opts)
-      return useForm<TFormData, FormValidator>(formOptions)
+      return useForm<TFormData, TFormValidator>(formOptions)
     },
     useField: useField as any,
     Field: Field as any,

--- a/packages/vue-form/src/formContext.ts
+++ b/packages/vue-form/src/formContext.ts
@@ -1,14 +1,20 @@
-import type { FormApi } from '@tanstack/form-core'
+import type { FormApi, Validator } from '@tanstack/form-core'
 import { inject, provide } from 'vue'
 
-export type FormContext = {
-  formApi: FormApi<any, unknown>
+export type FormContext<
+  TFormData = any,
+  TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
+> = {
+  formApi: FormApi<TFormData, TFormValidator>
   parentFieldName?: string
 } | null
 
 export const formContext = Symbol('FormContext')
 
-export function provideFormContext(val: FormContext) {
+export function provideFormContext<
+  TFormData = any,
+  TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
+>(val: FormContext<TFormData, TFormValidator>) {
   provide(formContext, val)
 }
 

--- a/packages/vue-form/src/tests/useField.test.tsx
+++ b/packages/vue-form/src/tests/useField.test.tsx
@@ -15,7 +15,7 @@ describe('useField', () => {
       lastName: string
     }
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     const Comp = defineComponent(() => {
       const form = formFactory.useForm()
@@ -54,7 +54,7 @@ describe('useField', () => {
     }
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     const Comp = defineComponent(() => {
       const form = formFactory.useForm()
@@ -103,7 +103,7 @@ describe('useField', () => {
     }
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     const Comp = defineComponent(() => {
       const form = formFactory.useForm()
@@ -153,7 +153,7 @@ describe('useField', () => {
     }
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     const Comp = defineComponent(() => {
       const form = formFactory.useForm()
@@ -209,7 +209,7 @@ describe('useField', () => {
 
     const mockFn = vi.fn()
     const error = 'Please enter a different value'
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     const Comp = defineComponent(() => {
       const form = formFactory.useForm()

--- a/packages/vue-form/src/tests/useField.test.tsx
+++ b/packages/vue-form/src/tests/useField.test.tsx
@@ -64,7 +64,9 @@ describe('useField', () => {
       return () => (
         <form.Field
           name="firstName"
-          onChange={(value) => (value === 'other' ? error : undefined)}
+          validators={{
+            onChange: (value) => (value === 'other' ? error : undefined),
+          }}
         >
           {({
             field,
@@ -111,7 +113,9 @@ describe('useField', () => {
       return () => (
         <form.Field
           name="firstName"
-          onChange={(value) => (value === 'other' ? error : undefined)}
+          validators={{
+            onChange: (value) => (value === 'other' ? error : undefined),
+          }}
         >
           {({
             field,
@@ -160,9 +164,11 @@ describe('useField', () => {
         <form.Field
           name="firstName"
           defaultMeta={{ isTouched: true }}
-          onChangeAsync={async () => {
-            await sleep(10)
-            return error
+          validators={{
+            onChangeAsync: async () => {
+              await sleep(10)
+              return error
+            },
           }}
         >
           {({
@@ -214,11 +220,13 @@ describe('useField', () => {
         <form.Field
           name="firstName"
           defaultMeta={{ isTouched: true }}
-          onChangeAsyncDebounceMs={100}
-          onChangeAsync={async () => {
-            mockFn()
-            await sleep(10)
-            return error
+          validators={{
+            onChangeAsyncDebounceMs: 100,
+            onChangeAsync: async () => {
+              mockFn()
+              await sleep(10)
+              return error
+            },
           }}
         >
           {({

--- a/packages/vue-form/src/tests/useField.test.tsx
+++ b/packages/vue-form/src/tests/useField.test.tsx
@@ -65,7 +65,7 @@ describe('useField', () => {
         <form.Field
           name="firstName"
           validators={{
-            onChange: (value) => (value === 'other' ? error : undefined),
+            onChange: ({ value }) => (value === 'other' ? error : undefined),
           }}
         >
           {({
@@ -114,7 +114,7 @@ describe('useField', () => {
         <form.Field
           name="firstName"
           validators={{
-            onChange: (value) => (value === 'other' ? error : undefined),
+            onChange: ({ value }) => (value === 'other' ? error : undefined),
           }}
         >
           {({

--- a/packages/vue-form/src/tests/useForm.test.tsx
+++ b/packages/vue-form/src/tests/useForm.test.tsx
@@ -22,7 +22,7 @@ type Person = {
 
 describe('useForm', () => {
   it('preserved field state', async () => {
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     const Comp = defineComponent(() => {
       const form = formFactory.useForm()
@@ -57,7 +57,7 @@ describe('useForm', () => {
   })
 
   it('should allow default values to be set', async () => {
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     const Comp = defineComponent(() => {
       const form = formFactory.useForm({
@@ -173,7 +173,7 @@ describe('useForm', () => {
   it('should validate async on change for the form', async () => {
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     const Comp = defineComponent(() => {
       const form = formFactory.useForm({
@@ -222,7 +222,7 @@ describe('useForm', () => {
   it('should not validate on change if isTouched is false', async () => {
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     const Comp = defineComponent(() => {
       const form = formFactory.useForm({
@@ -271,7 +271,7 @@ describe('useForm', () => {
   it('should validate on change if isTouched is true', async () => {
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     const Comp = defineComponent(() => {
       const form = formFactory.useForm({
@@ -382,7 +382,7 @@ describe('useForm', () => {
   it('should validate async on change', async () => {
     const error = 'Please enter a different value'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     const Comp = defineComponent(() => {
       const form = formFactory.useForm({
@@ -436,7 +436,7 @@ describe('useForm', () => {
     const onChangeError = 'Please enter a different value (onChangeError)'
     const onBlurError = 'Please enter a different value (onBlurError)'
 
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     const Comp = defineComponent(() => {
       const form = formFactory.useForm({
@@ -498,7 +498,7 @@ describe('useForm', () => {
   it('should validate async on change with debounce', async () => {
     const mockFn = vi.fn()
     const error = 'Please enter a different value'
-    const formFactory = createFormFactory<Person, unknown>()
+    const formFactory = createFormFactory<Person>()
 
     const Comp = defineComponent(() => {
       const form = formFactory.useForm({

--- a/packages/vue-form/src/tests/useForm.test.tsx
+++ b/packages/vue-form/src/tests/useForm.test.tsx
@@ -145,9 +145,11 @@ describe('useForm', () => {
         defaultValues: {
           firstName: 'FirstName',
         },
-        onMount: () => {
-          formMounted.value = true
-          return undefined
+        validators: {
+          onMount: () => {
+            formMounted.value = true
+            return undefined
+          },
         },
       })
 
@@ -175,8 +177,10 @@ describe('useForm', () => {
 
     const Comp = defineComponent(() => {
       const form = formFactory.useForm({
-        onChange() {
-          return error
+        validators: {
+          onChange() {
+            return error
+          },
         },
       })
 
@@ -222,7 +226,10 @@ describe('useForm', () => {
 
     const Comp = defineComponent(() => {
       const form = formFactory.useForm({
-        onChange: (value) => (value.firstName === 'other' ? error : undefined),
+        validators: {
+          onChange: (value) =>
+            value.firstName === 'other' ? error : undefined,
+        },
       })
 
       const errors = form.useStore((s) => s.errors)
@@ -268,7 +275,10 @@ describe('useForm', () => {
 
     const Comp = defineComponent(() => {
       const form = formFactory.useForm({
-        onChange: (value) => (value.firstName === 'other' ? error : undefined),
+        validators: {
+          onChange: (value) =>
+            value.firstName === 'other' ? error : undefined,
+        },
       })
 
       const errors = form.useStore((s) => s.errorMap)
@@ -317,13 +327,15 @@ describe('useForm', () => {
         defaultValues: {
           firstName: '',
         },
-        onChange: (vals) => {
-          if (vals.firstName === 'other') return onChangeError
-          return undefined
-        },
-        onBlur: (vals) => {
-          if (vals.firstName === 'other') return onBlurError
-          return undefined
+        validators: {
+          onChange: (vals) => {
+            if (vals.firstName === 'other') return onChangeError
+            return undefined
+          },
+          onBlur: (vals) => {
+            if (vals.firstName === 'other') return onBlurError
+            return undefined
+          },
         },
       })
 
@@ -374,9 +386,11 @@ describe('useForm', () => {
 
     const Comp = defineComponent(() => {
       const form = formFactory.useForm({
-        onChangeAsync: async () => {
-          await sleep(10)
-          return error
+        validators: {
+          onChangeAsync: async () => {
+            await sleep(10)
+            return error
+          },
         },
       })
 
@@ -426,13 +440,15 @@ describe('useForm', () => {
 
     const Comp = defineComponent(() => {
       const form = formFactory.useForm({
-        onChangeAsync: async () => {
-          await sleep(10)
-          return onChangeError
-        },
-        onBlurAsync: async () => {
-          await sleep(10)
-          return onBlurError
+        validators: {
+          onChangeAsync: async () => {
+            await sleep(10)
+            return onChangeError
+          },
+          onBlurAsync: async () => {
+            await sleep(10)
+            return onBlurError
+          },
         },
       })
       const errors = form.useStore((s) => s.errorMap)
@@ -486,11 +502,13 @@ describe('useForm', () => {
 
     const Comp = defineComponent(() => {
       const form = formFactory.useForm({
-        onChangeAsyncDebounceMs: 100,
-        onChangeAsync: async () => {
-          mockFn()
-          await sleep(10)
-          return error
+        validators: {
+          onChangeAsyncDebounceMs: 100,
+          onChangeAsync: async () => {
+            mockFn()
+            await sleep(10)
+            return error
+          },
         },
       })
       const errors = form.useStore((s) => s.errors)

--- a/packages/vue-form/src/tests/useForm.test.tsx
+++ b/packages/vue-form/src/tests/useForm.test.tsx
@@ -227,7 +227,7 @@ describe('useForm', () => {
     const Comp = defineComponent(() => {
       const form = formFactory.useForm({
         validators: {
-          onChange: (value) =>
+          onChange: ({ value }) =>
             value.firstName === 'other' ? error : undefined,
         },
       })
@@ -276,7 +276,7 @@ describe('useForm', () => {
     const Comp = defineComponent(() => {
       const form = formFactory.useForm({
         validators: {
-          onChange: (value) =>
+          onChange: ({ value }) =>
             value.firstName === 'other' ? error : undefined,
         },
       })
@@ -328,12 +328,12 @@ describe('useForm', () => {
           firstName: '',
         },
         validators: {
-          onChange: (vals) => {
-            if (vals.firstName === 'other') return onChangeError
+          onChange: ({ value }) => {
+            if (value.firstName === 'other') return onChangeError
             return undefined
           },
-          onBlur: (vals) => {
-            if (vals.firstName === 'other') return onBlurError
+          onBlur: ({ value }) => {
+            if (value.firstName === 'other') return onBlurError
             return undefined
           },
         },

--- a/packages/vue-form/src/tests/useForm.test.tsx
+++ b/packages/vue-form/src/tests/useForm.test.tsx
@@ -92,8 +92,8 @@ describe('useForm', () => {
         defaultValues: {
           firstName: 'FirstName',
         },
-        onSubmit: (data) => {
-          submittedData.value = data
+        onSubmit: ({ value }) => {
+          submittedData.value = value
         },
       })
       form.provideFormContext()

--- a/packages/vue-form/src/types.ts
+++ b/packages/vue-form/src/types.ts
@@ -1,11 +1,20 @@
-import type { FieldOptions, DeepKeys, DeepValue } from '@tanstack/form-core'
+import type {
+  FieldOptions,
+  DeepKeys,
+  DeepValue,
+  Validator,
+} from '@tanstack/form-core'
 
 export type UseFieldOptions<
   TParentData,
   TName extends DeepKeys<TParentData>,
-  ValidatorType,
-  FormValidator,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
-> = FieldOptions<TParentData, TName, ValidatorType, FormValidator, TData> & {
+> = FieldOptions<TParentData, TName, TFieldValidator, TFormValidator, TData> & {
   mode?: 'value' | 'array'
 }

--- a/packages/vue-form/src/useField.tsx
+++ b/packages/vue-form/src/useField.tsx
@@ -1,4 +1,4 @@
-import { FieldApi } from '@tanstack/form-core'
+import { FieldApi, type Validator } from '@tanstack/form-core'
 import type { DeepKeys, DeepValue, Narrow } from '@tanstack/form-core'
 import { useStore } from '@tanstack/vue-store'
 import { defineComponent, onMounted, onUnmounted, watch } from 'vue'
@@ -11,53 +11,68 @@ declare module '@tanstack/form-core' {
   interface FieldApi<
     TParentData,
     TName extends DeepKeys<TParentData>,
-    ValidatorType,
-    FormValidator,
+    TFieldValidator extends
+      | Validator<DeepValue<TParentData, TName>, unknown>
+      | undefined = undefined,
+    TFormValidator extends
+      | Validator<TParentData, unknown>
+      | undefined = undefined,
     TData = DeepValue<TParentData, TName>,
   > {
-    Field: FieldComponent<TData, FormValidator>
+    Field: FieldComponent<TData, TFormValidator>
   }
 }
 
-export type UseField<TParentData, FormValidator> = <
+export type UseField<
+  TParentData,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
+> = <
   TName extends DeepKeys<TParentData>,
-  ValidatorType,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
 >(
   opts?: { name: Narrow<TName> } & UseFieldOptions<
     TParentData,
     TName,
-    ValidatorType,
-    FormValidator,
+    TFieldValidator,
+    TFormValidator,
     DeepValue<TParentData, TName>
   >,
 ) => FieldApi<
   TParentData,
   TName,
-  ValidatorType,
-  FormValidator,
+  TFieldValidator,
+  TFormValidator,
   DeepValue<TParentData, TName>
 >
 
 export function useField<
   TParentData,
   TName extends DeepKeys<TParentData>,
-  ValidatorType,
-  FormValidator,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 >(
   opts: UseFieldOptions<
     TParentData,
     TName,
-    ValidatorType,
-    FormValidator,
+    TFieldValidator,
+    TFormValidator,
     TData
   >,
 ): {
   api: FieldApi<
     TParentData,
     TName,
-    ValidatorType,
-    FormValidator,
+    TFieldValidator,
+    TFormValidator,
     TData
     // Omit<typeof opts, 'onMount'> & {
     //   form: FormApi<TParentData>
@@ -68,12 +83,9 @@ export function useField<
       FieldApi<
         TParentData,
         TName,
-        ValidatorType,
-        FormValidator,
+        TFieldValidator,
+        TFormValidator,
         TData
-        // Omit<typeof opts, 'onMount'> & {
-        //   form: FormApi<TParentData>
-        // }
       >['state']
     >
   >
@@ -124,8 +136,12 @@ export type FieldValue<TParentData, TName> = TParentData extends any[]
 type FieldComponentProps<
   TParentData,
   TName extends DeepKeys<TParentData>,
-  ValidatorType,
-  FormValidator,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
 > = (TParentData extends any[]
   ? {
       name?: TName
@@ -136,31 +152,44 @@ type FieldComponentProps<
       index?: never
     }) &
   Omit<
-    UseFieldOptions<TParentData, TName, ValidatorType, FormValidator>,
+    UseFieldOptions<TParentData, TName, TFieldValidator, TFormValidator>,
     'name' | 'index'
   >
 
-export type FieldComponent<TParentData, FormValidator> = <
+export type FieldComponent<
+  TParentData,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
+> = <
   TName extends DeepKeys<TParentData>,
-  ValidatorType,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 >(
   fieldOptions: FieldComponentProps<
     TParentData,
     TName,
-    ValidatorType,
-    FormValidator
+    TFieldValidator,
+    TFormValidator
   >,
   context: SetupContext<
     {},
     SlotsType<{
       default: {
-        field: FieldApi<TParentData, TName, ValidatorType, FormValidator, TData>
+        field: FieldApi<
+          TParentData,
+          TName,
+          TFieldValidator,
+          TFormValidator,
+          TData
+        >
         state: FieldApi<
           TParentData,
           TName,
-          ValidatorType,
-          FormValidator,
+          TFieldValidator,
+          TFormValidator,
           TData
         >['state']
       }
@@ -172,14 +201,18 @@ export const Field = defineComponent(
   <
     TParentData,
     TName extends DeepKeys<TParentData>,
-    ValidatorType,
-    FormValidator,
+    TFieldValidator extends
+      | Validator<DeepValue<TParentData, TName>, unknown>
+      | undefined = undefined,
+    TFormValidator extends
+      | Validator<TParentData, unknown>
+      | undefined = undefined,
   >(
     fieldOptions: UseFieldOptions<
       TParentData,
       TName,
-      ValidatorType,
-      FormValidator
+      TFieldValidator,
+      TFormValidator
     >,
     context: SetupContext,
   ) => {

--- a/packages/vue-form/src/useField.tsx
+++ b/packages/vue-form/src/useField.tsx
@@ -19,7 +19,7 @@ declare module '@tanstack/form-core' {
       | undefined = undefined,
     TData = DeepValue<TParentData, TName>,
   > {
-    Field: FieldComponent<TData, TFormValidator>
+    Field: FieldComponent<TParentData, TFormValidator>
   }
 }
 

--- a/packages/vue-form/src/useForm.tsx
+++ b/packages/vue-form/src/useForm.tsx
@@ -1,4 +1,9 @@
-import { FormApi, type FormState, type FormOptions } from '@tanstack/form-core'
+import {
+  FormApi,
+  type FormState,
+  type FormOptions,
+  type Validator,
+} from '@tanstack/form-core'
 import { type NoInfer, useStore } from '@tanstack/vue-store'
 import { type UseField, type FieldComponent, Field, useField } from './useField'
 import { provideFormContext } from './formContext'
@@ -13,11 +18,11 @@ import {
 
 declare module '@tanstack/form-core' {
   // eslint-disable-next-line no-shadow
-  interface FormApi<TFormData, ValidatorType> {
+  interface FormApi<TFormData, TFormValidator> {
     Provider: (props: Record<string, any> & {}) => any
     provideFormContext: () => void
-    Field: FieldComponent<TFormData, ValidatorType>
-    useField: UseField<TFormData, ValidatorType>
+    Field: FieldComponent<TFormData, TFormValidator>
+    useField: UseField<TFormData, TFormValidator>
     useStore: <TSelected = NoInfer<FormState<TFormData>>>(
       selector?: (state: NoInfer<FormState<TFormData>>) => TSelected,
     ) => Readonly<Ref<TSelected>>
@@ -33,11 +38,14 @@ declare module '@tanstack/form-core' {
   }
 }
 
-export function useForm<TData, FormValidator>(
-  opts?: FormOptions<TData, FormValidator>,
-): FormApi<TData, FormValidator> {
+export function useForm<
+  TFormData,
+  TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
+>(
+  opts?: FormOptions<TFormData, TFormValidator>,
+): FormApi<TFormData, TFormValidator> {
   const formApi = (() => {
-    const api = new FormApi<TData, FormValidator>(opts)
+    const api = new FormApi<TFormData, TFormValidator>(opts)
 
     api.Provider = defineComponent(
       (_, context) => {

--- a/packages/yup-form-adapter/src/tests/FieldApi.spec.ts
+++ b/packages/yup-form-adapter/src/tests/FieldApi.spec.ts
@@ -17,7 +17,9 @@ describe('yup field api', () => {
       form,
       validator: yupValidator,
       name: 'name',
-      onChange: yup.string().min(3, 'You must have a length of at least 3'),
+      validators: {
+        onChange: yup.string().min(3, 'You must have a length of at least 3'),
+      },
     })
 
     field.mount()
@@ -42,7 +44,9 @@ describe('yup field api', () => {
       form,
       validator: yupValidator,
       name: 'name',
-      onChange: (val) => (val === 'a' ? 'Test' : undefined),
+      validators: {
+        onChange: (val) => (val === 'a' ? 'Test' : undefined),
+      },
     })
 
     field.mount()
@@ -65,12 +69,14 @@ describe('yup field api', () => {
       form,
       validator: yupValidator,
       name: 'name',
-      onChangeAsync: yup
-        .string()
-        .test('Testing 123', 'Testing 123', async (val) =>
-          typeof val === 'string' ? val.length > 3 : false,
-        ),
-      onChangeAsyncDebounceMs: 0,
+      validators: {
+        onChangeAsync: yup
+          .string()
+          .test('Testing 123', 'Testing 123', async (val) =>
+            typeof val === 'string' ? val.length > 3 : false,
+          ),
+        onChangeAsyncDebounceMs: 0,
+      },
     })
 
     field.mount()
@@ -95,8 +101,10 @@ describe('yup field api', () => {
       form,
       validator: yupValidator,
       name: 'name',
-      onChangeAsync: async (val) => (val === 'a' ? 'Test' : undefined),
-      onChangeAsyncDebounceMs: 0,
+      validators: {
+        onChangeAsync: async (val) => (val === 'a' ? 'Test' : undefined),
+        onChangeAsyncDebounceMs: 0,
+      }
     })
 
     field.mount()

--- a/packages/yup-form-adapter/src/tests/FieldApi.spec.ts
+++ b/packages/yup-form-adapter/src/tests/FieldApi.spec.ts
@@ -102,7 +102,8 @@ describe('yup field api', () => {
       validatorAdapter: yupValidator,
       name: 'name',
       validators: {
-        onChangeAsync: async ({ value }) => (value === 'a' ? 'Test' : undefined),
+        onChangeAsync: async ({ value }) =>
+          value === 'a' ? 'Test' : undefined,
         onChangeAsyncDebounceMs: 0,
       },
     })

--- a/packages/yup-form-adapter/src/tests/FieldApi.spec.ts
+++ b/packages/yup-form-adapter/src/tests/FieldApi.spec.ts
@@ -104,7 +104,7 @@ describe('yup field api', () => {
       validators: {
         onChangeAsync: async (val) => (val === 'a' ? 'Test' : undefined),
         onChangeAsyncDebounceMs: 0,
-      }
+      },
     })
 
     field.mount()

--- a/packages/yup-form-adapter/src/tests/FieldApi.spec.ts
+++ b/packages/yup-form-adapter/src/tests/FieldApi.spec.ts
@@ -45,7 +45,7 @@ describe('yup field api', () => {
       validatorAdapter: yupValidator,
       name: 'name',
       validators: {
-        onChange: (val) => (val === 'a' ? 'Test' : undefined),
+        onChange: ({ value }) => (value === 'a' ? 'Test' : undefined),
       },
     })
 
@@ -102,7 +102,7 @@ describe('yup field api', () => {
       validatorAdapter: yupValidator,
       name: 'name',
       validators: {
-        onChangeAsync: async (val) => (val === 'a' ? 'Test' : undefined),
+        onChangeAsync: async ({ value }) => (value === 'a' ? 'Test' : undefined),
         onChangeAsyncDebounceMs: 0,
       },
     })

--- a/packages/yup-form-adapter/src/tests/FieldApi.spec.ts
+++ b/packages/yup-form-adapter/src/tests/FieldApi.spec.ts
@@ -15,7 +15,7 @@ describe('yup field api', () => {
 
     const field = new FieldApi({
       form,
-      validator: yupValidator,
+      validatorAdapter: yupValidator,
       name: 'name',
       validators: {
         onChange: yup.string().min(3, 'You must have a length of at least 3'),
@@ -42,7 +42,7 @@ describe('yup field api', () => {
 
     const field = new FieldApi({
       form,
-      validator: yupValidator,
+      validatorAdapter: yupValidator,
       name: 'name',
       validators: {
         onChange: (val) => (val === 'a' ? 'Test' : undefined),
@@ -67,7 +67,7 @@ describe('yup field api', () => {
 
     const field = new FieldApi({
       form,
-      validator: yupValidator,
+      validatorAdapter: yupValidator,
       name: 'name',
       validators: {
         onChangeAsync: yup
@@ -99,7 +99,7 @@ describe('yup field api', () => {
 
     const field = new FieldApi({
       form,
-      validator: yupValidator,
+      validatorAdapter: yupValidator,
       name: 'name',
       validators: {
         onChangeAsync: async (val) => (val === 'a' ? 'Test' : undefined),

--- a/packages/yup-form-adapter/src/tests/FieldApi.test-d.ts
+++ b/packages/yup-form-adapter/src/tests/FieldApi.test-d.ts
@@ -28,7 +28,9 @@ it('should allow a Zod validator to handle the correct Zod type', () => {
     form,
     name: 'name',
     validator: yupValidator,
-    onChange: yup.string(),
+    validators: {
+      onChange: yup.string(),
+    },
   } as const)
 })
 
@@ -43,9 +45,11 @@ it('should allow a functional onChange to be passed when using a validator', () 
     form,
     name: 'name',
     validator: yupValidator,
-    onChange: (val) => {
-      assertType<'test'>(val)
-      return undefined
+    validators: {
+      onChange: (val) => {
+        assertType<'test'>(val)
+        return undefined
+      },
     },
   } as const)
 })
@@ -77,6 +81,8 @@ it.skip('should allow not a Zod validator with the wrong Zod type', () => {
     form,
     name: 'name',
     validator: yupValidator,
-    onChange: yup.object({}),
+    validators: {
+      onChange: yup.object({}),
+    },
   } as const)
 })

--- a/packages/yup-form-adapter/src/tests/FieldApi.test-d.ts
+++ b/packages/yup-form-adapter/src/tests/FieldApi.test-d.ts
@@ -13,7 +13,7 @@ it('should allow a Zod validator to be passed in', () => {
   const field = new FieldApi({
     form,
     name: 'name',
-    validator: yupValidator,
+    validatorAdapter: yupValidator,
   } as const)
 })
 
@@ -27,7 +27,7 @@ it('should allow a Zod validator to handle the correct Zod type', () => {
   const field = new FieldApi({
     form,
     name: 'name',
-    validator: yupValidator,
+    validatorAdapter: yupValidator,
     validators: {
       onChange: yup.string(),
     },
@@ -44,7 +44,7 @@ it('should allow a functional onChange to be passed when using a validator', () 
   const field = new FieldApi({
     form,
     name: 'name',
-    validator: yupValidator,
+    validatorAdapter: yupValidator,
     validators: {
       onChange: (val) => {
         assertType<'test'>(val)
@@ -80,7 +80,7 @@ it.skip('should allow not a Zod validator with the wrong Zod type', () => {
   const field = new FieldApi({
     form,
     name: 'name',
-    validator: yupValidator,
+    validatorAdapter: yupValidator,
     validators: {
       onChange: yup.object({}),
     },

--- a/packages/yup-form-adapter/src/tests/FieldApi.test-d.ts
+++ b/packages/yup-form-adapter/src/tests/FieldApi.test-d.ts
@@ -46,8 +46,8 @@ it('should allow a functional onChange to be passed when using a validator', () 
     name: 'name',
     validatorAdapter: yupValidator,
     validators: {
-      onChange: (val) => {
-        assertType<'test'>(val)
+      onChange: ({ value }) => {
+        assertType<'test'>(value)
         return undefined
       },
     },

--- a/packages/yup-form-adapter/src/tests/FieldApi.test-d.ts
+++ b/packages/yup-form-adapter/src/tests/FieldApi.test-d.ts
@@ -39,7 +39,7 @@ it('should allow a functional onChange to be passed when using a validator', () 
     defaultValues: {
       name: 'test',
     },
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
@@ -51,7 +51,7 @@ it('should allow a functional onChange to be passed when using a validator', () 
         return undefined
       },
     },
-  } as const)
+  })
 })
 
 it('should not allow a validator onChange to be passed when not using a validator', () => {
@@ -59,14 +59,14 @@ it('should not allow a validator onChange to be passed when not using a validato
     defaultValues: {
       name: 'test',
     },
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
     name: 'name',
     // @ts-expect-error Requires a validator
     onChange: z.string(),
-  } as const)
+  })
 })
 
 // This is not possible without higher-kinded types AFAIK
@@ -75,7 +75,7 @@ it.skip('should allow not a Zod validator with the wrong Zod type', () => {
     defaultValues: {
       name: 'test',
     },
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
@@ -84,5 +84,5 @@ it.skip('should allow not a Zod validator with the wrong Zod type', () => {
     validators: {
       onChange: yup.object({}),
     },
-  } as const)
+  })
 })

--- a/packages/yup-form-adapter/src/tests/FormApi.spec.ts
+++ b/packages/yup-form-adapter/src/tests/FormApi.spec.ts
@@ -16,7 +16,9 @@ describe('yup form api', () => {
     const field = new FieldApi({
       form,
       name: 'name',
-      onChange: yup.string().min(3, 'You must have a length of at least 3'),
+      validators: {
+        onChange: yup.string().min(3, 'You must have a length of at least 3'),
+      },
     })
 
     field.mount()
@@ -41,7 +43,9 @@ describe('yup form api', () => {
     const field = new FieldApi({
       form,
       name: 'name',
-      onChange: (val) => (val === 'a' ? 'Test' : undefined),
+      validators: {
+        onChange: (val) => (val === 'a' ? 'Test' : undefined),
+      },
     })
 
     field.mount()

--- a/packages/yup-form-adapter/src/tests/FormApi.spec.ts
+++ b/packages/yup-form-adapter/src/tests/FormApi.spec.ts
@@ -10,7 +10,7 @@ describe('yup form api', () => {
       defaultValues: {
         name: '',
       },
-      validator: yupValidator,
+      validatorAdapter: yupValidator,
     })
 
     const field = new FieldApi({
@@ -37,7 +37,7 @@ describe('yup form api', () => {
       defaultValues: {
         name: '',
       },
-      validator: yupValidator,
+      validatorAdapter: yupValidator,
     })
 
     const field = new FieldApi({

--- a/packages/yup-form-adapter/src/tests/FormApi.spec.ts
+++ b/packages/yup-form-adapter/src/tests/FormApi.spec.ts
@@ -44,7 +44,7 @@ describe('yup form api', () => {
       form,
       name: 'name',
       validators: {
-        onChange: (val) => (val === 'a' ? 'Test' : undefined),
+        onChange: ({ value }) => (value === 'a' ? 'Test' : undefined),
       },
     })
 

--- a/packages/yup-form-adapter/src/tests/FormApi.test-d.ts
+++ b/packages/yup-form-adapter/src/tests/FormApi.test-d.ts
@@ -18,7 +18,7 @@ it('should allow a Zod validator to handle the correct Zod type', () => {
       name: 'test',
     },
     validatorAdapter: yupValidator,
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
@@ -26,7 +26,7 @@ it('should allow a Zod validator to handle the correct Zod type', () => {
     validators: {
       onChange: yup.string(),
     },
-  } as const)
+  })
 })
 
 it('should allow a functional onChange to be passed when using a validator', () => {
@@ -35,7 +35,7 @@ it('should allow a functional onChange to be passed when using a validator', () 
       name: 'test',
     },
     validatorAdapter: yupValidator,
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
@@ -46,7 +46,7 @@ it('should allow a functional onChange to be passed when using a validator', () 
         return undefined
       },
     },
-  } as const)
+  })
 })
 
 it('should not allow a validator onChange to be passed when not using a validator', () => {
@@ -54,14 +54,14 @@ it('should not allow a validator onChange to be passed when not using a validato
     defaultValues: {
       name: 'test',
     },
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
     name: 'name',
     // @ts-expect-error Requires a validator
     onChange: yup.string(),
-  } as const)
+  })
 })
 
 // This is not possible without higher-kinded types AFAIK
@@ -70,7 +70,7 @@ it.skip('should allow not a Zod validator with the wrong Zod type', () => {
     defaultValues: {
       name: 'test',
     },
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
@@ -79,5 +79,5 @@ it.skip('should allow not a Zod validator with the wrong Zod type', () => {
     validators: {
       onChange: yup.object({}),
     },
-  } as const)
+  })
 })

--- a/packages/yup-form-adapter/src/tests/FormApi.test-d.ts
+++ b/packages/yup-form-adapter/src/tests/FormApi.test-d.ts
@@ -41,8 +41,8 @@ it('should allow a functional onChange to be passed when using a validator', () 
     form,
     name: 'name',
     validators: {
-      onChange: (val) => {
-        assertType<'test'>(val)
+      onChange: ({ value }) => {
+        assertType<'test'>(value)
         return undefined
       },
     },

--- a/packages/yup-form-adapter/src/tests/FormApi.test-d.ts
+++ b/packages/yup-form-adapter/src/tests/FormApi.test-d.ts
@@ -23,7 +23,9 @@ it('should allow a Zod validator to handle the correct Zod type', () => {
   const field = new FieldApi({
     form,
     name: 'name',
-    onChange: yup.string(),
+    validators: {
+      onChange: yup.string(),
+    },
   } as const)
 })
 
@@ -38,9 +40,11 @@ it('should allow a functional onChange to be passed when using a validator', () 
   const field = new FieldApi({
     form,
     name: 'name',
-    onChange: (val) => {
-      assertType<'test'>(val)
-      return undefined
+    validators: {
+      onChange: (val) => {
+        assertType<'test'>(val)
+        return undefined
+      },
     },
   } as const)
 })
@@ -72,6 +76,8 @@ it.skip('should allow not a Zod validator with the wrong Zod type', () => {
     form,
     name: 'name',
     validator: yupValidator,
-    onChange: yup.object({}),
+    validators: {
+      onChange: yup.object({}),
+    },
   } as const)
 })

--- a/packages/yup-form-adapter/src/tests/FormApi.test-d.ts
+++ b/packages/yup-form-adapter/src/tests/FormApi.test-d.ts
@@ -8,7 +8,7 @@ it('should allow a Zod validator to be passed in', () => {
     defaultValues: {
       name: 'test',
     },
-    validator: yupValidator,
+    validatorAdapter: yupValidator,
   } as const)
 })
 
@@ -17,7 +17,7 @@ it('should allow a Zod validator to handle the correct Zod type', () => {
     defaultValues: {
       name: 'test',
     },
-    validator: yupValidator,
+    validatorAdapter: yupValidator,
   })
 
   const field = new FieldApi({
@@ -34,7 +34,7 @@ it('should allow a functional onChange to be passed when using a validator', () 
     defaultValues: {
       name: 'test',
     },
-    validator: yupValidator,
+    validatorAdapter: yupValidator,
   })
 
   const field = new FieldApi({
@@ -75,7 +75,7 @@ it.skip('should allow not a Zod validator with the wrong Zod type', () => {
   const field = new FieldApi({
     form,
     name: 'name',
-    validator: yupValidator,
+    validatorAdapter: yupValidator,
     validators: {
       onChange: yup.object({}),
     },

--- a/packages/yup-form-adapter/src/validator.ts
+++ b/packages/yup-form-adapter/src/validator.ts
@@ -1,9 +1,9 @@
 import type { ValidationError as YupError, AnySchema } from 'yup'
 import type { ValidationError, Validator } from '@tanstack/form-core'
 
-export const yupValidator = (<Fn extends AnySchema = AnySchema>() => {
+export const yupValidator = (() => {
   return {
-    validate({ value }: { value: unknown }, fn: Fn): ValidationError {
+    validate({ value }: { value: unknown }, fn: AnySchema): ValidationError {
       try {
         fn.validateSync(value)
         return
@@ -14,7 +14,7 @@ export const yupValidator = (<Fn extends AnySchema = AnySchema>() => {
     },
     async validateAsync(
       { value }: { value: unknown },
-      fn: Fn,
+      fn: AnySchema,
     ): Promise<ValidationError> {
       try {
         await fn.validate(value)

--- a/packages/yup-form-adapter/src/validator.ts
+++ b/packages/yup-form-adapter/src/validator.ts
@@ -3,7 +3,7 @@ import type { ValidationError, Validator } from '@tanstack/form-core'
 
 export const yupValidator = (<Fn extends AnySchema = AnySchema>() => {
   return {
-    validate(value: unknown, fn: Fn): ValidationError {
+    validate({ value }: { value: unknown }, fn: Fn): ValidationError {
       try {
         fn.validateSync(value)
         return
@@ -12,7 +12,10 @@ export const yupValidator = (<Fn extends AnySchema = AnySchema>() => {
         return e.errors.join(', ')
       }
     },
-    async validateAsync(value: unknown, fn: Fn): Promise<ValidationError> {
+    async validateAsync(
+      { value }: { value: unknown },
+      fn: Fn,
+    ): Promise<ValidationError> {
       try {
         await fn.validate(value)
         return

--- a/packages/zod-form-adapter/src/tests/FieldApi.spec.ts
+++ b/packages/zod-form-adapter/src/tests/FieldApi.spec.ts
@@ -17,7 +17,9 @@ describe('zod field api', () => {
       form,
       validator: zodValidator,
       name: 'name',
-      onChange: z.string().min(3, 'You must have a length of at least 3'),
+      validators: {
+        onChange: z.string().min(3, 'You must have a length of at least 3'),
+      },
     })
 
     field.mount()
@@ -42,7 +44,9 @@ describe('zod field api', () => {
       form,
       validator: zodValidator,
       name: 'name',
-      onChange: (val) => (val === 'a' ? 'Test' : undefined),
+      validators: {
+        onChange: (val) => (val === 'a' ? 'Test' : undefined),
+      },
     })
 
     field.mount()
@@ -65,10 +69,12 @@ describe('zod field api', () => {
       form,
       validator: zodValidator,
       name: 'name',
-      onChangeAsync: z.string().refine(async (val) => val.length > 3, {
-        message: 'Testing 123',
-      }),
-      onChangeAsyncDebounceMs: 0,
+      validators: {
+        onChangeAsync: z.string().refine(async (val) => val.length > 3, {
+          message: 'Testing 123',
+        }),
+        onChangeAsyncDebounceMs: 0,
+      },
     })
 
     field.mount()
@@ -93,8 +99,10 @@ describe('zod field api', () => {
       form,
       validator: zodValidator,
       name: 'name',
-      onChangeAsync: async (val) => (val === 'a' ? 'Test' : undefined),
-      onChangeAsyncDebounceMs: 0,
+      validators: {
+        onChangeAsync: async (val) => (val === 'a' ? 'Test' : undefined),
+        onChangeAsyncDebounceMs: 0,
+      },
     })
 
     field.mount()

--- a/packages/zod-form-adapter/src/tests/FieldApi.spec.ts
+++ b/packages/zod-form-adapter/src/tests/FieldApi.spec.ts
@@ -15,7 +15,7 @@ describe('zod field api', () => {
 
     const field = new FieldApi({
       form,
-      validator: zodValidator,
+      validatorAdapter: zodValidator,
       name: 'name',
       validators: {
         onChange: z.string().min(3, 'You must have a length of at least 3'),
@@ -42,7 +42,7 @@ describe('zod field api', () => {
 
     const field = new FieldApi({
       form,
-      validator: zodValidator,
+      validatorAdapter: zodValidator,
       name: 'name',
       validators: {
         onChange: (val) => (val === 'a' ? 'Test' : undefined),
@@ -67,7 +67,7 @@ describe('zod field api', () => {
 
     const field = new FieldApi({
       form,
-      validator: zodValidator,
+      validatorAdapter: zodValidator,
       name: 'name',
       validators: {
         onChangeAsync: z.string().refine(async (val) => val.length > 3, {
@@ -97,7 +97,7 @@ describe('zod field api', () => {
 
     const field = new FieldApi({
       form,
-      validator: zodValidator,
+      validatorAdapter: zodValidator,
       name: 'name',
       validators: {
         onChangeAsync: async (val) => (val === 'a' ? 'Test' : undefined),

--- a/packages/zod-form-adapter/src/tests/FieldApi.spec.ts
+++ b/packages/zod-form-adapter/src/tests/FieldApi.spec.ts
@@ -100,7 +100,8 @@ describe('zod field api', () => {
       validatorAdapter: zodValidator,
       name: 'name',
       validators: {
-        onChangeAsync: async ({ value }) => (value === 'a' ? 'Test' : undefined),
+        onChangeAsync: async ({ value }) =>
+          value === 'a' ? 'Test' : undefined,
         onChangeAsyncDebounceMs: 0,
       },
     })

--- a/packages/zod-form-adapter/src/tests/FieldApi.spec.ts
+++ b/packages/zod-form-adapter/src/tests/FieldApi.spec.ts
@@ -45,7 +45,7 @@ describe('zod field api', () => {
       validatorAdapter: zodValidator,
       name: 'name',
       validators: {
-        onChange: (val) => (val === 'a' ? 'Test' : undefined),
+        onChange: ({ value }) => (value === 'a' ? 'Test' : undefined),
       },
     })
 
@@ -100,7 +100,7 @@ describe('zod field api', () => {
       validatorAdapter: zodValidator,
       name: 'name',
       validators: {
-        onChangeAsync: async (val) => (val === 'a' ? 'Test' : undefined),
+        onChangeAsync: async ({ value }) => (value === 'a' ? 'Test' : undefined),
         onChangeAsyncDebounceMs: 0,
       },
     })

--- a/packages/zod-form-adapter/src/tests/FieldApi.test-d.ts
+++ b/packages/zod-form-adapter/src/tests/FieldApi.test-d.ts
@@ -28,7 +28,9 @@ it('should allow a Zod validator to handle the correct Zod type', () => {
     form,
     name: 'name',
     validator: zodValidator,
-    onChange: z.string(),
+    validators: {
+      onChange: z.string(),
+    },
   } as const)
 })
 
@@ -43,7 +45,9 @@ it('should allow a Zod validator to handle the correct Zod type for an async met
     form,
     name: 'name',
     validator: zodValidator,
-    onChangeAsync: z.string(),
+    validators: {
+      onChangeAsync: z.string(),
+    },
   } as const)
 })
 
@@ -58,9 +62,11 @@ it('should allow a functional onChange to be passed when using a validator', () 
     form,
     name: 'name',
     validator: zodValidator,
-    onChange: (val) => {
-      assertType<'test'>(val)
-      return undefined
+    validators: {
+      onChange: (val) => {
+        assertType<'test'>(val)
+        return undefined
+      },
     },
   } as const)
 })
@@ -92,6 +98,8 @@ it.skip('should allow not a Zod validator with the wrong Zod type', () => {
     form,
     name: 'name',
     validator: zodValidator,
-    onChange: z.object({}),
+    validators: {
+      onChange: z.object({}),
+    },
   } as const)
 })

--- a/packages/zod-form-adapter/src/tests/FieldApi.test-d.ts
+++ b/packages/zod-form-adapter/src/tests/FieldApi.test-d.ts
@@ -13,7 +13,7 @@ it('should allow a Zod validator to be passed in', () => {
   const field = new FieldApi({
     form,
     name: 'name',
-    validator: zodValidator,
+    validatorAdapter: zodValidator,
   } as const)
 })
 
@@ -27,7 +27,7 @@ it('should allow a Zod validator to handle the correct Zod type', () => {
   const field = new FieldApi({
     form,
     name: 'name',
-    validator: zodValidator,
+    validatorAdapter: zodValidator,
     validators: {
       onChange: z.string(),
     },
@@ -44,7 +44,7 @@ it('should allow a Zod validator to handle the correct Zod type for an async met
   const field = new FieldApi({
     form,
     name: 'name',
-    validator: zodValidator,
+    validatorAdapter: zodValidator,
     validators: {
       onChangeAsync: z.string(),
     },
@@ -61,7 +61,7 @@ it('should allow a functional onChange to be passed when using a validator', () 
   const field = new FieldApi({
     form,
     name: 'name',
-    validator: zodValidator,
+    validatorAdapter: zodValidator,
     validators: {
       onChange: (val) => {
         assertType<'test'>(val)
@@ -97,7 +97,7 @@ it.skip('should allow not a Zod validator with the wrong Zod type', () => {
   const field = new FieldApi({
     form,
     name: 'name',
-    validator: zodValidator,
+    validatorAdapter: zodValidator,
     validators: {
       onChange: z.object({}),
     },

--- a/packages/zod-form-adapter/src/tests/FieldApi.test-d.ts
+++ b/packages/zod-form-adapter/src/tests/FieldApi.test-d.ts
@@ -14,7 +14,7 @@ it('should allow a Zod validator to be passed in', () => {
     form,
     name: 'name',
     validatorAdapter: zodValidator,
-  } as const)
+  })
 })
 
 it('should allow a Zod validator to handle the correct Zod type', () => {
@@ -22,7 +22,7 @@ it('should allow a Zod validator to handle the correct Zod type', () => {
     defaultValues: {
       name: 'test',
     },
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
@@ -31,7 +31,7 @@ it('should allow a Zod validator to handle the correct Zod type', () => {
     validators: {
       onChange: z.string(),
     },
-  } as const)
+  })
 })
 
 it('should allow a Zod validator to handle the correct Zod type for an async method', () => {
@@ -39,7 +39,7 @@ it('should allow a Zod validator to handle the correct Zod type for an async met
     defaultValues: {
       name: 'test',
     },
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
@@ -48,7 +48,7 @@ it('should allow a Zod validator to handle the correct Zod type for an async met
     validators: {
       onChangeAsync: z.string(),
     },
-  } as const)
+  })
 })
 
 it('should allow a functional onChange to be passed when using a validator', () => {
@@ -56,7 +56,7 @@ it('should allow a functional onChange to be passed when using a validator', () 
     defaultValues: {
       name: 'test',
     },
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
@@ -68,7 +68,7 @@ it('should allow a functional onChange to be passed when using a validator', () 
         return undefined
       },
     },
-  } as const)
+  })
 })
 
 it('should not allow a validator onChange to be passed when not using a validator', () => {
@@ -76,14 +76,14 @@ it('should not allow a validator onChange to be passed when not using a validato
     defaultValues: {
       name: 'test',
     },
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
     name: 'name',
     // @ts-expect-error Requires a validator
     onChange: z.string(),
-  } as const)
+  })
 })
 
 // This is not possible without higher-kinded types AFAIK
@@ -92,7 +92,7 @@ it.skip('should allow not a Zod validator with the wrong Zod type', () => {
     defaultValues: {
       name: 'test',
     },
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
@@ -101,5 +101,5 @@ it.skip('should allow not a Zod validator with the wrong Zod type', () => {
     validators: {
       onChange: z.object({}),
     },
-  } as const)
+  })
 })

--- a/packages/zod-form-adapter/src/tests/FieldApi.test-d.ts
+++ b/packages/zod-form-adapter/src/tests/FieldApi.test-d.ts
@@ -63,8 +63,8 @@ it('should allow a functional onChange to be passed when using a validator', () 
     name: 'name',
     validatorAdapter: zodValidator,
     validators: {
-      onChange: (val) => {
-        assertType<'test'>(val)
+      onChange: ({ value }) => {
+        assertType<'test'>(value)
         return undefined
       },
     },

--- a/packages/zod-form-adapter/src/tests/FormApi.spec.ts
+++ b/packages/zod-form-adapter/src/tests/FormApi.spec.ts
@@ -10,7 +10,7 @@ describe('zod form api', () => {
       defaultValues: {
         name: '',
       },
-      validator: zodValidator,
+      validatorAdapter: zodValidator,
     })
 
     const field = new FieldApi({
@@ -37,7 +37,7 @@ describe('zod form api', () => {
       defaultValues: {
         name: '',
       },
-      validator: zodValidator,
+      validatorAdapter: zodValidator,
     })
 
     const field = new FieldApi({

--- a/packages/zod-form-adapter/src/tests/FormApi.spec.ts
+++ b/packages/zod-form-adapter/src/tests/FormApi.spec.ts
@@ -16,7 +16,9 @@ describe('zod form api', () => {
     const field = new FieldApi({
       form,
       name: 'name',
-      onChange: z.string().min(3, 'You must have a length of at least 3'),
+      validators: {
+        onChange: z.string().min(3, 'You must have a length of at least 3'),
+      },
     })
 
     field.mount()
@@ -41,7 +43,9 @@ describe('zod form api', () => {
     const field = new FieldApi({
       form,
       name: 'name',
-      onChange: (val) => (val === 'a' ? 'Test' : undefined),
+      validators: {
+        onChange: (val) => (val === 'a' ? 'Test' : undefined),
+      },
     })
 
     field.mount()

--- a/packages/zod-form-adapter/src/tests/FormApi.spec.ts
+++ b/packages/zod-form-adapter/src/tests/FormApi.spec.ts
@@ -44,7 +44,7 @@ describe('zod form api', () => {
       form,
       name: 'name',
       validators: {
-        onChange: (val) => (val === 'a' ? 'Test' : undefined),
+        onChange: ({ value }) => (value === 'a' ? 'Test' : undefined),
       },
     })
 

--- a/packages/zod-form-adapter/src/tests/FormApi.test-d.ts
+++ b/packages/zod-form-adapter/src/tests/FormApi.test-d.ts
@@ -18,7 +18,7 @@ it('should allow a Zod validator to handle the correct Zod type', () => {
       name: 'test',
     },
     validatorAdapter: zodValidator,
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
@@ -26,7 +26,7 @@ it('should allow a Zod validator to handle the correct Zod type', () => {
     validators: {
       onChange: z.string(),
     },
-  } as const)
+  })
 })
 
 it('should allow a Zod validator to handle the correct Zod type on async methods', () => {
@@ -35,7 +35,7 @@ it('should allow a Zod validator to handle the correct Zod type on async methods
       name: 'test',
     },
     validatorAdapter: zodValidator,
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
@@ -43,7 +43,7 @@ it('should allow a Zod validator to handle the correct Zod type on async methods
     validators: {
       onChangeAsync: z.string(),
     },
-  } as const)
+  })
 })
 
 it('should allow a functional onChange to be passed when using a validator', () => {
@@ -52,7 +52,7 @@ it('should allow a functional onChange to be passed when using a validator', () 
       name: 'test',
     },
     validatorAdapter: zodValidator,
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
@@ -63,7 +63,7 @@ it('should allow a functional onChange to be passed when using a validator', () 
         return undefined
       },
     },
-  } as const)
+  })
 })
 
 it('should not allow a validator onChange to be passed when not using a validator', () => {
@@ -71,14 +71,14 @@ it('should not allow a validator onChange to be passed when not using a validato
     defaultValues: {
       name: 'test',
     },
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
     name: 'name',
     // @ts-expect-error Requires a validator
     onChange: z.string(),
-  } as const)
+  })
 })
 
 // This is not possible without higher-kinded types AFAIK
@@ -87,7 +87,7 @@ it.skip('should allow not a Zod validator with the wrong Zod type', () => {
     defaultValues: {
       name: 'test',
     },
-  })
+  } as const)
 
   const field = new FieldApi({
     form,
@@ -96,5 +96,5 @@ it.skip('should allow not a Zod validator with the wrong Zod type', () => {
     validators: {
       onChange: z.object({}),
     },
-  } as const)
+  })
 })

--- a/packages/zod-form-adapter/src/tests/FormApi.test-d.ts
+++ b/packages/zod-form-adapter/src/tests/FormApi.test-d.ts
@@ -23,7 +23,9 @@ it('should allow a Zod validator to handle the correct Zod type', () => {
   const field = new FieldApi({
     form,
     name: 'name',
-    onChange: z.string(),
+    validators: {
+      onChange: z.string(),
+    },
   } as const)
 })
 
@@ -38,7 +40,9 @@ it('should allow a Zod validator to handle the correct Zod type on async methods
   const field = new FieldApi({
     form,
     name: 'name',
-    onChangeAsync: z.string(),
+    validators: {
+      onChangeAsync: z.string(),
+    },
   } as const)
 })
 
@@ -53,9 +57,11 @@ it('should allow a functional onChange to be passed when using a validator', () 
   const field = new FieldApi({
     form,
     name: 'name',
-    onChange: (val) => {
-      assertType<'test'>(val)
-      return undefined
+    validators: {
+      onChange: (val) => {
+        assertType<'test'>(val)
+        return undefined
+      },
     },
   } as const)
 })
@@ -87,6 +93,8 @@ it.skip('should allow not a Zod validator with the wrong Zod type', () => {
     form,
     name: 'name',
     validator: zodValidator,
-    onChange: z.object({}),
+    validators: {
+      onChange: z.object({}),
+    },
   } as const)
 })

--- a/packages/zod-form-adapter/src/tests/FormApi.test-d.ts
+++ b/packages/zod-form-adapter/src/tests/FormApi.test-d.ts
@@ -8,7 +8,7 @@ it('should allow a Zod validator to be passed in', () => {
     defaultValues: {
       name: 'test',
     },
-    validator: zodValidator,
+    validatorAdapter: zodValidator,
   } as const)
 })
 
@@ -17,7 +17,7 @@ it('should allow a Zod validator to handle the correct Zod type', () => {
     defaultValues: {
       name: 'test',
     },
-    validator: zodValidator,
+    validatorAdapter: zodValidator,
   })
 
   const field = new FieldApi({
@@ -34,7 +34,7 @@ it('should allow a Zod validator to handle the correct Zod type on async methods
     defaultValues: {
       name: 'test',
     },
-    validator: zodValidator,
+    validatorAdapter: zodValidator,
   })
 
   const field = new FieldApi({
@@ -51,7 +51,7 @@ it('should allow a functional onChange to be passed when using a validator', () 
     defaultValues: {
       name: 'test',
     },
-    validator: zodValidator,
+    validatorAdapter: zodValidator,
   })
 
   const field = new FieldApi({
@@ -92,7 +92,7 @@ it.skip('should allow not a Zod validator with the wrong Zod type', () => {
   const field = new FieldApi({
     form,
     name: 'name',
-    validator: zodValidator,
+    validatorAdapter: zodValidator,
     validators: {
       onChange: z.object({}),
     },

--- a/packages/zod-form-adapter/src/tests/FormApi.test-d.ts
+++ b/packages/zod-form-adapter/src/tests/FormApi.test-d.ts
@@ -58,8 +58,8 @@ it('should allow a functional onChange to be passed when using a validator', () 
     form,
     name: 'name',
     validators: {
-      onChange: (val) => {
-        assertType<'test'>(val)
+      onChange: ({ value }) => {
+        assertType<'test'>(value)
         return undefined
       },
     },

--- a/packages/zod-form-adapter/src/validator.ts
+++ b/packages/zod-form-adapter/src/validator.ts
@@ -3,7 +3,7 @@ import type { ValidationError, Validator } from '@tanstack/form-core'
 
 export const zodValidator = (<Fn extends ZodType = ZodType>() => {
   return {
-    validate(value: unknown, fn: Fn): ValidationError {
+    validate({ value }: { value: unknown }, fn: Fn): ValidationError {
       // Call Zod on the value here and return the error message
       const result = (fn as ZodTypeAny).safeParse(value)
       if (!result.success) {
@@ -11,7 +11,10 @@ export const zodValidator = (<Fn extends ZodType = ZodType>() => {
       }
       return
     },
-    async validateAsync(value: unknown, fn: Fn): Promise<ValidationError> {
+    async validateAsync(
+      { value }: { value: unknown },
+      fn: Fn,
+    ): Promise<ValidationError> {
       // Call Zod on the value here and return the error message
       const result = await (fn as ZodTypeAny).safeParseAsync(value)
       if (!result.success) {

--- a/packages/zod-form-adapter/src/validator.ts
+++ b/packages/zod-form-adapter/src/validator.ts
@@ -1,9 +1,9 @@
 import type { ZodType, ZodTypeAny } from 'zod'
 import type { ValidationError, Validator } from '@tanstack/form-core'
 
-export const zodValidator = (<Fn extends ZodType = ZodType>() => {
+export const zodValidator = (() => {
   return {
-    validate({ value }: { value: unknown }, fn: Fn): ValidationError {
+    validate({ value }: { value: unknown }, fn: ZodType): ValidationError {
       // Call Zod on the value here and return the error message
       const result = (fn as ZodTypeAny).safeParse(value)
       if (!result.success) {
@@ -13,7 +13,7 @@ export const zodValidator = (<Fn extends ZodType = ZodType>() => {
     },
     async validateAsync(
       { value }: { value: unknown },
-      fn: Fn,
+      fn: ZodType,
     ): Promise<ValidationError> {
       // Call Zod on the value here and return the error message
       const result = await (fn as ZodTypeAny).safeParseAsync(value)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,8 +83,8 @@ importers:
         specifier: ^2.3.1
         version: 2.3.2
       '@types/node':
-        specifier: ^17.0.25
-        version: 17.0.45
+        specifier: ^18.15.3
+        version: 18.19.2
       '@types/react':
         specifier: ^18.0.14
         version: 18.0.15
@@ -216,7 +216,7 @@ importers:
         version: 2.3.0
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@17.0.45)(typescript@5.2.2)
+        version: 10.9.1(@types/node@18.19.2)(typescript@5.2.2)
       tsup:
         specifier: 7.2.0
         version: 7.2.0(patch_hash=gwbgl3s5ycyzg75lofcbklamcy)(ts-node@10.9.1)(typescript@5.2.2)
@@ -268,7 +268,7 @@ importers:
         version: 4.0.4(vite@4.4.9)
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@17.0.45)
+        version: 4.4.9(@types/node@18.19.2)
 
   examples/react/valibot:
     dependencies:
@@ -308,7 +308,7 @@ importers:
         version: 4.0.4(vite@4.4.9)
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@17.0.45)
+        version: 4.4.9(@types/node@18.19.2)
 
   examples/react/yup:
     dependencies:
@@ -348,7 +348,7 @@ importers:
         version: 4.0.4(vite@4.4.9)
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@17.0.45)
+        version: 4.4.9(@types/node@18.19.2)
 
   examples/react/zod:
     dependencies:
@@ -388,7 +388,7 @@ importers:
         version: 4.0.4(vite@4.4.9)
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@17.0.45)
+        version: 4.4.9(@types/node@18.19.2)
 
   examples/solid/simple:
     dependencies:
@@ -422,7 +422,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.4.5
-        version: 4.4.9(@types/node@17.0.45)
+        version: 4.4.9(@types/node@18.19.2)
       vite-plugin-solid:
         specifier: ^2.7.0
         version: 2.7.0(solid-js@1.7.8)(vite@4.4.9)
@@ -462,7 +462,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.4.5
-        version: 4.4.9(@types/node@17.0.45)
+        version: 4.4.9(@types/node@18.19.2)
       vite-plugin-solid:
         specifier: ^2.7.0
         version: 2.7.0(solid-js@1.7.12)(vite@4.4.9)
@@ -502,7 +502,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.4.5
-        version: 4.4.9(@types/node@17.0.45)
+        version: 4.4.9(@types/node@18.19.2)
       vite-plugin-solid:
         specifier: ^2.7.0
         version: 2.7.0(solid-js@1.7.8)(vite@4.4.9)
@@ -542,7 +542,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.4.5
-        version: 4.4.9(@types/node@17.0.45)
+        version: 4.4.9(@types/node@18.19.2)
       vite-plugin-solid:
         specifier: ^2.7.0
         version: 2.7.0(solid-js@1.7.8)(vite@4.4.9)
@@ -582,7 +582,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@17.0.45)
+        version: 4.4.9(@types/node@18.19.2)
       vue-tsc:
         specifier: ^1.8.10
         version: 1.8.10(typescript@5.2.2)
@@ -625,7 +625,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@17.0.45)
+        version: 4.4.9(@types/node@18.19.2)
       vue-tsc:
         specifier: ^1.8.10
         version: 1.8.10(typescript@5.2.2)
@@ -668,7 +668,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@17.0.45)
+        version: 4.4.9(@types/node@18.19.2)
       vue-tsc:
         specifier: ^1.8.10
         version: 1.8.10(typescript@5.2.2)
@@ -711,7 +711,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@17.0.45)
+        version: 4.4.9(@types/node@18.19.2)
       vue-tsc:
         specifier: ^1.8.10
         version: 1.8.10(typescript@5.2.2)
@@ -2519,7 +2519,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 17.0.45
+      '@types/node': 18.19.2
       jest-mock: 29.7.0
     dev: false
 
@@ -2529,7 +2529,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 17.0.45
+      '@types/node': 18.19.2
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -2570,7 +2570,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 17.0.45
+      '@types/node': 18.19.2
       '@types/yargs': 15.0.15
       chalk: 4.1.2
 
@@ -2580,7 +2580,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 17.0.45
+      '@types/node': 18.19.2
       '@types/yargs': 16.0.5
       chalk: 4.1.2
 
@@ -2591,7 +2591,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 17.0.45
+      '@types/node': 18.19.2
       '@types/yargs': 17.0.29
       chalk: 4.1.2
     dev: false
@@ -3360,7 +3360,7 @@ packages:
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 18.19.2
     dev: true
 
   /@types/istanbul-lib-coverage@2.0.4:
@@ -3401,7 +3401,7 @@ packages:
   /@types/jsonfile@6.1.1:
     resolution: {integrity: sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 18.19.2
     dev: true
 
   /@types/luxon@2.3.2:
@@ -3412,8 +3412,10 @@ packages:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
     dev: true
 
-  /@types/node@17.0.45:
-    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+  /@types/node@18.19.2:
+    resolution: {integrity: sha512-6wzfBdbWpe8QykUkXBjtmO3zITA0A3FIjoy+in0Y2K4KrCiRhNYJIdwAPDffZ3G6GnaKaSLSEa9ZuORLfEoiwg==}
+    dependencies:
+      undici-types: 5.26.5
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -3460,7 +3462,7 @@ packages:
   /@types/stream-to-array@2.3.1:
     resolution: {integrity: sha512-OqV/DIumEm5pT+m4LYGpDFRRLZ0VJRvrz58C8q8rjLGVgP5gRHxThG8eLZfhmK3GVAq9iq3eSvZ0vkZJ5ZH/Pg==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 18.19.2
     dev: true
 
   /@types/testing-library__jest-dom@5.14.5(patch_hash=d573maxasnl5kxwdyzebcnmhpm):
@@ -3634,7 +3636,7 @@ packages:
       '@babel/plugin-transform-react-jsx-self': 7.22.5(@babel/core@7.22.10)
       '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.22.10)
       react-refresh: 0.14.0
-      vite: 4.4.9(@types/node@17.0.45)
+      vite: 4.4.9(@types/node@18.19.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3646,7 +3648,7 @@ packages:
       vite: ^4.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 4.4.9(@types/node@17.0.45)
+      vite: 4.4.9(@types/node@18.19.2)
       vue: 3.3.4
     dev: true
 
@@ -6936,7 +6938,7 @@ packages:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 17.0.45
+      '@types/node': 18.19.2
       jest-mock: 29.7.0
       jest-util: 29.7.0
     dev: false
@@ -6957,7 +6959,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.6
-      '@types/node': 17.0.45
+      '@types/node': 18.19.2
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -6991,7 +6993,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 17.0.45
+      '@types/node': 18.19.2
       jest-util: 29.7.0
     dev: false
 
@@ -7003,7 +7005,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 18.19.2
       graceful-fs: 4.2.11
     dev: true
 
@@ -7012,7 +7014,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 17.0.45
+      '@types/node': 18.19.2
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -7023,7 +7025,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 17.0.45
+      '@types/node': 18.19.2
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -7046,7 +7048,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 18.19.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -8588,7 +8590,7 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.1.0
-      ts-node: 10.9.1(@types/node@17.0.45)(typescript@5.2.2)
+      ts-node: 10.9.1(@types/node@18.19.2)(typescript@5.2.2)
       yaml: 2.3.1
     dev: true
 
@@ -9923,7 +9925,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-node@10.9.1(@types/node@17.0.45)(typescript@5.2.2):
+  /ts-node@10.9.1(@types/node@18.19.2)(typescript@5.2.2):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -9942,7 +9944,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 17.0.45
+      '@types/node': 18.19.2
       acorn: 8.10.0
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -10143,6 +10145,9 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: true
 
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
     engines: {node: '>=4'}
@@ -10264,7 +10269,7 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
-  /vite-node@0.34.3(@types/node@17.0.45):
+  /vite-node@0.34.3(@types/node@18.19.2):
     resolution: {integrity: sha512-+0TzJf1g0tYXj6tR2vEyiA42OPq68QkRZCu/ERSo2PtsDJfBpDyEfuKbRvLmZqi/CgC7SCBtyC+WjTGNMRIaig==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -10274,7 +10279,7 @@ packages:
       mlly: 1.4.1
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.4.9(@types/node@17.0.45)
+      vite: 4.4.9(@types/node@18.19.2)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -10299,7 +10304,7 @@ packages:
       merge-anything: 5.1.7
       solid-js: 1.7.12
       solid-refresh: 0.5.3(solid-js@1.7.12)
-      vite: 4.4.9(@types/node@17.0.45)
+      vite: 4.4.9(@types/node@18.19.2)
       vitefu: 0.2.4(vite@4.4.9)
     transitivePeerDependencies:
       - supports-color
@@ -10318,13 +10323,13 @@ packages:
       merge-anything: 5.1.7
       solid-js: 1.7.8
       solid-refresh: 0.5.3(solid-js@1.7.8)
-      vite: 4.4.9(@types/node@17.0.45)
+      vite: 4.4.9(@types/node@18.19.2)
       vitefu: 0.2.4(vite@4.4.9)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite@4.4.9(@types/node@17.0.45):
+  /vite@4.4.9(@types/node@18.19.2):
     resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -10352,7 +10357,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 18.19.2
       esbuild: 0.18.20
       postcss: 8.4.28
       rollup: 3.28.1
@@ -10368,7 +10373,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 4.4.9(@types/node@17.0.45)
+      vite: 4.4.9(@types/node@18.19.2)
     dev: true
 
   /vitest@0.34.3(jsdom@22.0.0):
@@ -10404,7 +10409,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
-      '@types/node': 17.0.45
+      '@types/node': 18.19.2
       '@vitest/expect': 0.34.3
       '@vitest/runner': 0.34.3
       '@vitest/snapshot': 0.34.3
@@ -10424,8 +10429,8 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.5.0
       tinypool: 0.7.0
-      vite: 4.4.9(@types/node@17.0.45)
-      vite-node: 0.34.3(@types/node@17.0.45)
+      vite: 4.4.9(@types/node@18.19.2)
+      vite-node: 0.34.3(@types/node@18.19.2)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
This PR:

- [x] Renames `onChange`/`onBlur`/other validators to a `validators={{onChange: () => void 0}}` prefixed prop name
    - [x] Update examples
    - [x] Update tests
    - [x] Update docs
- [x] Change validators to pass object instead of two arguments
    - [x] Update docs
- [x] Renames `validator` (singular) to `validatorAdapter`
    - [x] Update tests
    - [x] Update docs
- [x] Updates `onMount` to match the other APIs
    - [x] Update tests
- [x] Adds a `createForm({validators: submit: () => void 0})` API
    - [x] Write tests
- [x] Add async `onSubmit` validation (so that it calls `onChange`/`onBlur`)
    - [x] Write tests
- [x] Add abort signal to async validators
    - [x] Write tests
    - [x] Write docs
- [x] Refactor FormAPI and FieldAPI `validate` and `validateAsync` to share code

Closes #491