### PR TITLE
Demo: Build with `tsc`

### DIFF
--- a/packages/form-core/package.json
+++ b/packages/form-core/package.json
@@ -44,7 +44,7 @@
     "test:lib": "vitest run --coverage",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",
-    "build": "tsup"
+    "build": "tsc"
   },
   "dependencies": {
     "@tanstack/store": "0.1.3"

--- a/packages/form-core/tsconfig.json
+++ b/packages/form-core/tsconfig.json
@@ -1,8 +1,14 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "noEmit": true,
+    "outDir": "dist",
     "types": ["vitest/globals"]
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".eslintrc.cjs",
+    "tsup.config.js",
+    "vite.config.ts"
+  ]
 }


### PR DESCRIPTION
Part of the effort to address `tsup` issues.

Pros:
- The output is simply the TS stripped types, no bundling occurs
- Easy to transpile to target older ES spec

Cons:
- Only generates `.js` and `.d.ts` for ESM _or_ for CJS, not both at once
- To generate both, it would require a lot more config (is CJS still necessary?)