### PR TITLE
chore: Avoid running Vitest twice

### DIFF
--- a/packages/form-core/package.json
+++ b/packages/form-core/package.json
@@ -39,8 +39,8 @@
     "test:types:versions50": "../../node_modules/typescript50/bin/tsc --noEmit",
     "test:types:versions51": "../../node_modules/typescript51/bin/tsc --noEmit",
     "test:types:versions52": "tsc --noEmit",
-    "test:types": "pnpm run \"/^test:types:versions.*/\" && vitest --typecheck",
-    "test:lib": "vitest run --coverage",
+    "test:types": "pnpm run \"/^test:types:versions.*/\"",
+    "test:lib": "vitest",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",
     "build": "vite build"

--- a/packages/form-core/vite.config.ts
+++ b/packages/form-core/vite.config.ts
@@ -12,7 +12,8 @@ export default mergeConfig(
       watch: false,
       environment: 'jsdom',
       globals: true,
-      coverage: { provider: 'istanbul' },
+      coverage: { enabled: true, provider: 'istanbul', include: ['src/**/*'] },
+      typecheck: { enabled: true },
     },
   }),
 )

--- a/packages/react-form/package.json
+++ b/packages/react-form/package.json
@@ -19,7 +19,7 @@
     "test:types:versions51": "../../node_modules/typescript51/bin/tsc --noEmit",
     "test:types:versions52": "tsc --noEmit",
     "test:types": "pnpm run \"/^test:types:versions.*/\"",
-    "test:lib": "vitest run --coverage",
+    "test:lib": "vitest",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",
     "build": "vite build"

--- a/packages/react-form/vite.config.ts
+++ b/packages/react-form/vite.config.ts
@@ -10,7 +10,8 @@ export default mergeConfig(
       watch: false,
       environment: 'jsdom',
       globals: true,
-      coverage: { provider: 'istanbul' },
+      coverage: { enabled: true, provider: 'istanbul', include: ['src/**/*'] },
+      typecheck: { enabled: true },
     },
   }),
 )

--- a/packages/solid-form/package.json
+++ b/packages/solid-form/package.json
@@ -19,7 +19,7 @@
     "test:types:versions51": "../../node_modules/typescript51/bin/tsc --noEmit",
     "test:types:versions52": "tsc --noEmit",
     "test:types": "pnpm run \"/^test:types:versions.*/\"",
-    "test:lib": "vitest run --coverage",
+    "test:lib": "vitest",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",
     "build": "vite build"

--- a/packages/solid-form/vite.config.ts
+++ b/packages/solid-form/vite.config.ts
@@ -13,7 +13,8 @@ export default mergeConfig(
       setupFiles: [],
       environment: 'jsdom',
       globals: true,
-      coverage: { provider: 'istanbul' },
+      coverage: { enabled: true, provider: 'istanbul', include: ['src/**/*'] },
+      typecheck: { enabled: true },
       server: {
         deps: {
           // https://github.com/solidjs/solid-testing-library#known-issues

--- a/packages/valibot-form-adapter/package.json
+++ b/packages/valibot-form-adapter/package.json
@@ -39,7 +39,7 @@
     "test:types:versions50": "../../node_modules/typescript50/bin/tsc --noEmit",
     "test:types:versions51": "../../node_modules/typescript51/bin/tsc --noEmit",
     "test:types:versions52": "tsc --noEmit",
-    "test:types": "pnpm run \"/^test:types:versions.*/\" && vitest --typecheck",
+    "test:types": "pnpm run \"/^test:types:versions.*/\"",
     "test:lib": "vitest",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",

--- a/packages/valibot-form-adapter/package.json
+++ b/packages/valibot-form-adapter/package.json
@@ -40,7 +40,7 @@
     "test:types:versions51": "../../node_modules/typescript51/bin/tsc --noEmit",
     "test:types:versions52": "tsc --noEmit",
     "test:types": "pnpm run \"/^test:types:versions.*/\" && vitest --typecheck",
-    "test:lib": "vitest run --coverage",
+    "test:lib": "vitest",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",
     "build": "vite build"

--- a/packages/valibot-form-adapter/vite.config.ts
+++ b/packages/valibot-form-adapter/vite.config.ts
@@ -10,7 +10,8 @@ export default mergeConfig(
       watch: false,
       environment: 'jsdom',
       globals: true,
-      coverage: { provider: 'istanbul' },
+      coverage: { enabled: true, provider: 'istanbul', include: ['src/**/*'] },
+      typecheck: { enabled: true },
     },
   }),
 )

--- a/packages/vue-form/vite.config.ts
+++ b/packages/vue-form/vite.config.ts
@@ -11,7 +11,8 @@ export default mergeConfig(
       environment: 'jsdom',
       globals: true,
       setupFiles: [],
-      coverage: { provider: 'istanbul' },
+      coverage: { enabled: true, provider: 'istanbul', include: ['src/**/*'] },
+      typecheck: { enabled: true },
     },
     esbuild: {
       jsxFactory: 'h',

--- a/packages/yup-form-adapter/package.json
+++ b/packages/yup-form-adapter/package.json
@@ -40,7 +40,7 @@
     "test:types:versions51": "../../node_modules/typescript51/bin/tsc --noEmit",
     "test:types:versions52": "tsc",
     "test:types": "pnpm run \"/^test:types:versions.*/\" && vitest --typecheck",
-    "test:lib": "vitest run --coverage",
+    "test:lib": "vitest",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",
     "build": "vite build"

--- a/packages/yup-form-adapter/package.json
+++ b/packages/yup-form-adapter/package.json
@@ -39,7 +39,7 @@
     "test:types:versions50": "../../node_modules/typescript50/bin/tsc --noEmit",
     "test:types:versions51": "../../node_modules/typescript51/bin/tsc --noEmit",
     "test:types:versions52": "tsc",
-    "test:types": "pnpm run \"/^test:types:versions.*/\" && vitest --typecheck",
+    "test:types": "pnpm run \"/^test:types:versions.*/\"",
     "test:lib": "vitest",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",

--- a/packages/yup-form-adapter/vite.config.ts
+++ b/packages/yup-form-adapter/vite.config.ts
@@ -10,7 +10,8 @@ export default mergeConfig(
       watch: false,
       environment: 'jsdom',
       globals: true,
-      coverage: { provider: 'istanbul' },
+      coverage: { enabled: true, provider: 'istanbul', include: ['src/**/*'] },
+      typecheck: { enabled: true },
     },
   }),
 )

--- a/packages/zod-form-adapter/package.json
+++ b/packages/zod-form-adapter/package.json
@@ -40,7 +40,7 @@
     "test:types:versions51": "../../node_modules/typescript51/bin/tsc --noEmit",
     "test:types:versions52": "tsc",
     "test:types": "pnpm run \"/^test:types:versions.*/\"",
-    "test:lib": "vitest run --coverage",
+    "test:lib": "vitest",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",
     "build": "vite build"

--- a/packages/zod-form-adapter/vite.config.ts
+++ b/packages/zod-form-adapter/vite.config.ts
@@ -10,7 +10,8 @@ export default mergeConfig(
       watch: false,
       environment: 'jsdom',
       globals: true,
-      coverage: { provider: 'istanbul' },
+      coverage: { enabled: true, provider: 'istanbul', include: ['src/**/*'] },
+      typecheck: { enabled: true },
     },
   }),
 )


### PR DESCRIPTION
`vitest --typecheck` runs all type tests _and_ all normal tests. It makes more sense to run these as a single task under `test:lib`. The Vite config has been updated to enable coverage and type tests without needing CLI flags.