### PR TITLE
fix: delete non-existent fields without errors

### DIFF
--- a/packages/form-core/src/tests/utils.spec.ts
+++ b/packages/form-core/src/tests/utils.spec.ts
@@ -70,4 +70,11 @@ describe('deleteBy', () => {
     expect(deleteBy(structure, 'kids.0.name').kids[0].name).not.toBeDefined()
     expect(deleteBy(structure, 'kids.0.age').kids[0].age).not.toBeDefined()
   })
+
+  it('should delete non-existent paths like a noop', () => {
+    expect(deleteBy(structure, 'nonexistent')).toEqual(structure)
+    expect(deleteBy(structure, 'nonexistent.nonexistent')).toEqual(structure)
+    expect(deleteBy(structure, 'kids.3.name')).toEqual(structure)
+    expect(deleteBy(structure, 'nonexistent.3.nonexistent')).toEqual(structure)
+  })
 })

--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -76,6 +76,7 @@ export function deleteBy(obj: any, _path: any) {
   const path = makePathArray(_path)
 
   function doDelete(parent: any): any {
+    if (!parent) return;
     if (path.length === 1) {
       const finalPath = path[0]!
       const { [finalPath]: remove, ...rest } = parent
@@ -95,6 +96,9 @@ export function deleteBy(obj: any, _path: any) {
 
     if (typeof key === 'number') {
       if (Array.isArray(parent)) {
+        if (key >= parent.length) {
+          return parent
+        }
         const prefix = parent.slice(0, key)
         return [
           ...(prefix.length ? prefix : new Array(key)),


### PR DESCRIPTION
Hit this issue when I had a nested field on a field that didn't have a default value set up.