### PR TITLE
feat: support escaped paths in field name

### DIFF
--- a/packages/form-core/src/tests/FieldApi.spec.ts
+++ b/packages/form-core/src/tests/FieldApi.spec.ts
@@ -90,7 +90,7 @@ describe('field api', () => {
     const form = new FormApi({
       defaultValues: {
         name: {
-          nested: 'test'
+          nested: 'test',
         },
       },
     })

--- a/packages/form-core/src/tests/FieldApi.spec.ts
+++ b/packages/form-core/src/tests/FieldApi.spec.ts
@@ -115,13 +115,16 @@ describe('field api', () => {
 
     const field = new FieldApi({
       form,
-      name: 'name.withdot',
+      name: '["name.withdot"]',
     })
 
     field.setValue('other')
 
     expect(field.getValue()).toBe('other')
     expect(form.state.values['name.withdot']).toBe('other')
+    expect(form.state.values).toMatchObject({
+      'name.withdot': 'other',
+    })
   })
 
   it('should push an array value correctly', () => {

--- a/packages/form-core/src/tests/FieldApi.spec.ts
+++ b/packages/form-core/src/tests/FieldApi.spec.ts
@@ -86,6 +86,44 @@ describe('field api', () => {
     expect(field.getValue()).toBe('other')
   })
 
+  it('should set a nested value correctly', () => {
+    const form = new FormApi({
+      defaultValues: {
+        name: {
+          nested: 'test'
+        },
+      },
+    })
+
+    const field = new FieldApi({
+      form,
+      name: 'name.nested',
+    })
+
+    field.setValue('other')
+
+    expect(field.getValue()).toBe('other')
+    expect(form.state.values.name.nested).toBe('other')
+  })
+
+  it('should set a value with dot correctly', () => {
+    const form = new FormApi({
+      defaultValues: {
+        'name.withdot': 'test',
+      },
+    })
+
+    const field = new FieldApi({
+      form,
+      name: 'name.withdot',
+    })
+
+    field.setValue('other')
+
+    expect(field.getValue()).toBe('other')
+    expect(form.state.values['name.withdot']).toBe('other')
+  })
+
   it('should push an array value correctly', () => {
     const form = new FormApi({
       defaultValues: {

--- a/packages/form-core/src/tests/FieldApi.test-d.ts
+++ b/packages/form-core/src/tests/FieldApi.test-d.ts
@@ -78,7 +78,7 @@ it('should type onChange properly', () => {
 it('should type onChangeAsync properly', () => {
   const form = new FormApi({
     defaultValues: {
-      'name': 'test',
+      name: 'test',
     },
   } as const)
 

--- a/packages/form-core/src/tests/FieldApi.test-d.ts
+++ b/packages/form-core/src/tests/FieldApi.test-d.ts
@@ -78,7 +78,7 @@ it('should type onChange properly', () => {
 it('should type onChangeAsync properly', () => {
   const form = new FormApi({
     defaultValues: {
-      name: 'test',
+      'name': 'test',
     },
   } as const)
 

--- a/packages/form-core/src/tests/FieldApi.test-d.ts
+++ b/packages/form-core/src/tests/FieldApi.test-d.ts
@@ -19,6 +19,42 @@ it('should type value properly', () => {
   assertType<'test'>(field.getValue())
 })
 
+it('should type nested value properly', () => {
+  const form = new FormApi({
+    defaultValues: {
+      name: {
+        nested: 'test',
+      },
+    },
+  } as const)
+
+  const field = new FieldApi({
+    form,
+    name: 'name.nested',
+  })
+
+  assertType<'test'>(field.state.value)
+  assertType<'name.nested'>(field.options.name)
+  assertType<'test'>(field.getValue())
+})
+
+it('should type properties with dot properly', () => {
+  const form = new FormApi({
+    defaultValues: {
+      'name.withdot': 'test',
+    },
+  } as const)
+
+  const field = new FieldApi({
+    form,
+    name: 'name.withdot',
+  })
+
+  assertType<'test'>(field.state.value)
+  assertType<'name.withdot'>(field.options.name)
+  assertType<'test'>(field.getValue())
+})
+
 it('should type onChange properly', () => {
   const form = new FormApi({
     defaultValues: {

--- a/packages/form-core/src/tests/FieldApi.test-d.ts
+++ b/packages/form-core/src/tests/FieldApi.test-d.ts
@@ -34,7 +34,7 @@ it('should type nested value properly', () => {
   })
 
   assertType<'test'>(field.state.value)
-  assertType<'name.nested'>(field.options.name)
+  assertType<'name' | 'name.nested'>(field.options.name)
   assertType<'test'>(field.getValue())
 })
 

--- a/packages/form-core/src/tests/FieldApi.test-d.ts
+++ b/packages/form-core/src/tests/FieldApi.test-d.ts
@@ -47,11 +47,11 @@ it('should type properties with dot properly', () => {
 
   const field = new FieldApi({
     form,
-    name: 'name.withdot',
+    name: '["name.withdot"]',
   })
 
   assertType<'test'>(field.state.value)
-  assertType<'name.withdot'>(field.options.name)
+  assertType<'["name.withdot"]' | "['name.withdot']">(field.options.name)
   assertType<'test'>(field.getValue())
 })
 

--- a/packages/form-core/src/tests/FieldApi.test-d.ts
+++ b/packages/form-core/src/tests/FieldApi.test-d.ts
@@ -31,10 +31,10 @@ it('should type nested value properly', () => {
   const field = new FieldApi({
     form,
     name: 'name.nested',
-  })
+  } as const)
 
   assertType<'test'>(field.state.value)
-  assertType<'name' | 'name.nested'>(field.options.name)
+  assertType<'name.nested'>(field.options.name)
   assertType<'test'>(field.getValue())
 })
 

--- a/packages/form-core/src/tests/utils.spec.ts
+++ b/packages/form-core/src/tests/utils.spec.ts
@@ -11,11 +11,17 @@ describe('getBy', () => {
     mother: {
       name: 'Lisa',
     },
+    'key.with.dot': 'value',
+    'key.with.dot.2': {
+      'key.with.dot.3': 'value2'
+    },
   }
 
   it('should get subfields by path', () => {
     expect(getBy(structure, 'name')).toBe(structure.name)
     expect(getBy(structure, 'mother.name')).toBe(structure.mother.name)
+    expect(getBy(structure, "['key.with.dot']")).toBe(structure['key.with.dot'])
+    expect(getBy(structure, "['key.with.dot.2']['key.with.dot.3']")).toBe(structure['key.with.dot.2']['key.with.dot.3'])
   })
 
   it('should get array subfields by path', () => {

--- a/packages/form-core/src/tests/utils.spec.ts
+++ b/packages/form-core/src/tests/utils.spec.ts
@@ -13,7 +13,7 @@ describe('getBy', () => {
     },
     'key.with.dot': 'value',
     'key.with.dot.2': {
-      'key.with.dot.3': 'value2'
+      'key.with.dot.3': 'value2',
     },
   }
 
@@ -21,7 +21,9 @@ describe('getBy', () => {
     expect(getBy(structure, 'name')).toBe(structure.name)
     expect(getBy(structure, 'mother.name')).toBe(structure.mother.name)
     expect(getBy(structure, "['key.with.dot']")).toBe(structure['key.with.dot'])
-    expect(getBy(structure, "['key.with.dot.2']['key.with.dot.3']")).toBe(structure['key.with.dot.2']['key.with.dot.3'])
+    expect(getBy(structure, "['key.with.dot.2']['key.with.dot.3']")).toBe(
+      structure['key.with.dot.2']['key.with.dot.3'],
+    )
   })
 
   it('should get array subfields by path', () => {

--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -131,6 +131,7 @@ const rePropName = RegExp(
   // Or match "" as the space between consecutive dots or empty brackets.
   '(?=(?:\\.|\\[\\])(?:\\.|\\[\\]|$))'
   , 'g')
+const reFindNumber = /^\d+$/
 
 function makePathArray(str: string) {
   if (typeof str !== 'string') {
@@ -150,7 +151,7 @@ function makePathArray(str: string) {
       key = expression.trim()
     }
     // key difference from lodash string to path algoritm
-    if ((/^\d+$/).test(key)) {
+    if (reFindNumber.test(key)) {
       key = parseInt(key, 10);
     }
     result.push(key)

--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -335,11 +335,17 @@ type DeepKeysPrefix<
   ? `${TPrefix}.${DeepKeys<T[TPrefix], [...TDepth, any]> & string}`
   : never
 
-export type DeepValue<T, TProp> = T extends Record<string | number, any>
-  ? TProp extends `${infer TBranch}.${infer TDeepProp}`
-    ? DeepValue<T[TBranch], TDeepProp>
-    : T[TProp & string]
-  : never
+export type DeepValue<T, TProp> = TProp extends ''
+  ? T
+  : T extends Record<string | number, any>
+    ? TProp extends (`["${infer TBranch}"].${infer TDeepProp}`)
+      ? DeepValue<T[TBranch], TDeepProp>
+      : TProp extends (`["${infer TBranch}"]${infer TDeepProp}`)
+        ? DeepValue<T[TBranch], TDeepProp>
+        : TProp extends `${infer TBranch}.${infer TDeepProp}`
+          ? DeepValue<T[TBranch], TDeepProp>
+          : T[TProp & string]
+    : never
 
 type EscapedKey<T extends string> = T extends `${string}.${string}` ? `["${T}"]` | `['${T}']` : T
 

--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -324,7 +324,7 @@ export type DeepKeys<T, TDepth extends any[] = []> = TDepth['length'] extends 5
           : T extends Date
             ? never
             : T extends object
-              ? (keyof T & string) | DeepKeysPrefix<T, keyof T, TDepth>
+              ? EscapedKey<(keyof T & string)> | DeepKeysPrefix<T, keyof T, TDepth>
               : never
 
 type DeepKeysPrefix<
@@ -340,6 +340,8 @@ export type DeepValue<T, TProp> = T extends Record<string | number, any>
     ? DeepValue<T[TBranch], TDeepProp>
     : T[TProp & string]
   : never
+
+type EscapedKey<T extends string> = T extends `${string}.${string}` ? `["${T}"]` | `['${T}']` : T
 
 type Narrowable = string | number | bigint | boolean
 

--- a/packages/react-form/src/useField.tsx
+++ b/packages/react-form/src/useField.tsx
@@ -100,7 +100,7 @@ export function useField<
     fieldApi.store,
     opts.mode === 'array'
       ? (state) => {
-          return [state.meta, Object.keys(state.value).length]
+          return [state.meta, Object.keys(state.value as any[]).length]
         }
       : undefined,
   )


### PR DESCRIPTION
Attempts to address https://github.com/TanStack/form/discussions/532 . 

This is a sketch implementation for feedback, using lodash's internals for get. 
Happy to roll a custom implementation but I thought of using an existing battle-tested implementation. 

This implementation handles some of the cases in https://github.com/lodash/lodash/blob/main/test/toPath.spec.js . 