### PR TITLE
ci: Avoid uploading coverage files in Nx cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
     if: github.repository == 'TanStack/form'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: '0'
       - name: Setup pnpm
@@ -34,7 +35,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: 'pnpm'
+          cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Run Tests
@@ -51,3 +52,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           TAG: ${{ inputs.tag }}
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          directory: packages

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,10 +17,11 @@ env:
 
 jobs:
   test:
-    name: 'Test'
+    name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup pnpm
@@ -31,10 +32,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: 'pnpm'
+          cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
-      - name: Get appropriate base and head commits for `nx affected` commands
+      - name: Get base and head commits for `nx affected`
         uses: nrwl/nx-set-shas@v3
         with:
           main-branch-name: 'main'
@@ -42,3 +43,5 @@ jobs:
         run: pnpm run test:pr
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          directory: packages


### PR DESCRIPTION
`codecov/codecov-action@v3` would scan the `.nx/cache` directory and upload coverage reports from here, which could mess with accuracy. Logic copied from query repo.