### PR TITLE
fix: Correctly exit publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "namespace": "@tanstack",
   "devDependencies": {
     "@solidjs/testing-library": "^0.8.5",
-    "@tanstack/config": "^0.1.6",
+    "@tanstack/config": "^0.1.7",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",
     "@testing-library/react-hooks": "^8.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.8.5
         version: 0.8.5(@solidjs/router@0.8.3)(solid-js@1.7.12)
       '@tanstack/config':
-        specifier: ^0.1.6
-        version: 0.1.6(@types/node@18.19.4)(esbuild@0.19.11)(typescript@5.2.2)(vite@5.0.10)
+        specifier: ^0.1.7
+        version: 0.1.7(@types/node@18.19.4)(esbuild@0.19.11)(typescript@5.2.2)(vite@5.0.10)
       '@testing-library/jest-dom':
         specifier: ^6.1.5
         version: 6.1.6(@types/jest@26.0.24)(vitest@1.1.0)
@@ -3951,8 +3951,8 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@tanstack/config@0.1.6(@types/node@18.19.4)(esbuild@0.19.11)(typescript@5.2.2)(vite@5.0.10):
-    resolution: {integrity: sha512-QNyg/wawvs/idXFdECbHfyDC3TZ8nznrM/Zz75J41+YU1TUcBy7QZvjVw2NT97SPsKvnoXxWJjg/YPzxn9p1ZQ==}
+  /@tanstack/config@0.1.7(@types/node@18.19.4)(esbuild@0.19.11)(typescript@5.2.2)(vite@5.0.10):
+    resolution: {integrity: sha512-+IbRTGbIEuWSNbouink96KL9aEGwhNzzy7DXtYg6CgCU5fpiGCIuNm7pGddEloTW1hHv+vvlqhlfx63F6ueWuA==}
     engines: {node: '>=18'}
     hasBin: true
     dependencies:
@@ -9089,7 +9089,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 4.1.0
-      is-core-module: 2.13.0
+      is-core-module: 2.13.1
       semver: 7.5.4
       validate-npm-package-license: 3.0.4
     dev: true
@@ -9099,7 +9099,7 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       hosted-git-info: 6.1.1
-      is-core-module: 2.13.0
+      is-core-module: 2.13.1
       semver: 7.5.4
       validate-npm-package-license: 3.0.4
     dev: true
@@ -9507,7 +9507,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.22.13
+      '@babel/code-frame': 7.23.5
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -3,16 +3,11 @@
 import { publish } from '@tanstack/config/publish'
 import { branchConfigs, packages, rootDir } from './config.js'
 
-try {
-  await publish({
-    branchConfigs,
-    packages,
-    rootDir,
-    branch: process.env.BRANCH,
-    tag: process.env.TAG,
-    ghToken: process.env.GH_TOKEN,
-  })
-} catch (error) {
-  console.error(error)
-  process.exit(1)
-}
+await publish({
+  branchConfigs,
+  packages,
+  rootDir,
+  branch: process.env.BRANCH,
+  tag: process.env.TAG,
+  ghToken: process.env.GH_TOKEN,
+})

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -3,14 +3,16 @@
 import { publish } from '@tanstack/config/publish'
 import { branchConfigs, packages, rootDir } from './config.js'
 
-publish({
-  branchConfigs,
-  packages,
-  rootDir,
-  branch: process.env.BRANCH,
-  tag: process.env.TAG,
-  ghToken: process.env.GH_TOKEN,
-}).catch((err) => {
-  console.info(err)
+try {
+  await publish({
+    branchConfigs,
+    packages,
+    rootDir,
+    branch: process.env.BRANCH,
+    tag: process.env.TAG,
+    ghToken: process.env.GH_TOKEN,
+  })
+} catch (error) {
+  console.error(error)
   process.exit(1)
-})
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,25 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "lib": ["ES2022"],
-    "target": "ES2020",
-    "module": "ES2020",
+    "allowJs": true,
     "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "strictNullChecks": true,
+    "allowUnreachableCode": true,
+    "baseUrl": ".",
+    "checkJs": true,
     "declaration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "module": "ES2022",
     "noEmit": true,
     "noImplicitReturns": true,
-    "esModuleInterop": true,
+    "noUncheckedIndexedAccess": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
-    "baseUrl": ".",
-    "allowUnreachableCode": true,
-    "allowJs": true,
-    "checkJs": true
+    "strict": true,
+    "strictNullChecks": true,
+    "target": "ES2020"
   },
   "include": [".eslintrc.cjs", "prettier.config.js"]
 }


### PR DESCRIPTION
On successfully finishing the script, this github workflow continued indefinitely: https://github.com/TanStack/form/actions/runs/7419873463

This seems to be an async/await error. I'm expecting this change (https://github.com/TanStack/config/releases/tag/v0.1.7) will allow it to correctly return exit code 0.

I've tweaked the tsconfig file to use `"module": "ES2022"`, since this permits top-level await. This has no impact on the types generated for packages.