### PR TITLE
chore: Stricter tsconfig options

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
-    "allowUnreachableCode": true,
-    "baseUrl": ".",
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
     "checkJs": true,
     "declaration": true,
     "esModuleInterop": true,
@@ -15,10 +15,11 @@
     "noEmit": true,
     "noImplicitReturns": true,
     "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": false, // TODO enable
+    "noUnusedParameters": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "strictNullChecks": true,
     "target": "ES2020"
   },
   "include": [".eslintrc.cjs", "prettier.config.js"]


### PR DESCRIPTION
- Disabled `allowUnreachableCode` and `allowUnusedLabels`
- Enabled `noUnusedParameters`
- Added `noUnusedLocals` to enable once issues are fixed
- Removed `strictNullChecks` (covered by `strict`)
- Removed `baseUrl` (no longer used to resolve packages)
