### PR TITLE
Remove typo basic-concepts.md

### DIFF
--- a/docs/guides/basic-concepts.md
+++ b/docs/guides/basic-concepts.md
@@ -125,7 +125,7 @@ import { zodValidator } from '@tanstack/zod-form-adapter'
 import { z } from 'zod'
 
 // ...
-;<form.Field
+<form.Field
   name="firstName"
   validatorAdapter={zodValidator}
   validators={{


### PR DESCRIPTION
There was an extra semicolon which seems like a typo. Removed it.