### PR TITLE
fix: Conditionally rendering fields in <StrictMode>

### DIFF
--- a/packages/react-form/src/useField.tsx
+++ b/packages/react-form/src/useField.tsx
@@ -76,6 +76,28 @@ export function useField<
       .filter((d) => d !== undefined)
       .join('.')
 
+    // NOTE: I know, it's a type error, but this is not the final code
+    const previousInstance:
+      | FieldApi<
+          TParentData,
+          TName,
+          TFieldValidator,
+          TFormValidator,
+          DeepValue<TParentData, TName>
+        >
+      | undefined = Object.values(formApi.getFieldInfo(name).instances)[0]
+
+    if (previousInstance) {
+      /* NOTE: In <StrictMode>, an instance of `FieldApi` is already created
+      the first time this hook ran, but it will not get cleaned up on its own,
+      when the component unmounts, because of the  useIsomorphicEffectOnce() hook,
+      which doesn't execute the cleanup function on "dummy React cycles".
+
+      This code change seems to solve https://github.com/TanStack/form/issues/571
+      */
+      return previousInstance
+    }
+
     const api = new FieldApi({
       ...opts,
       form: formApi as never,


### PR DESCRIPTION
Addresses https://github.com/TanStack/form/issues/571.

# TL;DR

It seems like [the bug]( https://github.com/TanStack/form/issues/571) can be tracked to `useField` creating duplicate instances of the field (`FieldApi`) in strict mode and not cleaning them up properly. This PR at this point is just a proof of concept for a solution.

# Details of the bug

Basically, the `useField` hook runs twice in strict mode, and creates a new instance of `FieldApi` every time it runs ([source](https://github.com/TanStack/form/blob/08ad74d07d1dcaf117a9ef0390e937cf20edbcd6/packages/react-form/src/useField.tsx#L70-L89)):
```tsx
  const [fieldApi] = useState(() => {
    [...]
    
    const api = new FieldApi({
      ...opts,
      form: formApi as never,
      // TODO: Fix typings to include `index` and `parentFieldName`, if present
      name: name as typeof opts.name as never,
    })


    api.Field = Field as never


    return api
  })
```

I think that problem is that the cleanup function only runs once, because it's wrapped in a `useIsomorphicEffectOnce` hook [source](https://github.com/TanStack/form/blob/08ad74d07d1dcaf117a9ef0390e937cf20edbcd6/packages/react-form/src/useField.tsx#L109-L119):
```tsx
  useIsomorphicEffectOnce(() => {
    return () => {
      unmountFn.current?.()
    }
  })


  // We have to mount it right as soon as it renders, otherwise we get:
  // https://github.com/TanStack/form/issues/523
  if (!unmountFn.current) {
    unmountFn.current = fieldApi.mount()
  }
```

Honestly, there's a lot of things happening here, so I'm not a 100% percent sure I read the situation correctly. 😆 

# My solution and questions

I thought the best way to approach this issue is preventing a duplicate `FieldInstance` from being created, by checking if there's an instance already in the initialization function of the `useState` hook in `useField`. My question is: how dangerous is it? 🤣  In what cases would the field have multiple instances (in general, not just at this point)? Also, I'd love to understand a bit more about `tanstack/store`, especially if it's important here (a quick overview would be enough). I'm happy to get guidance on Discord, if a (or rather _the_) maintainer has time for it.