### PR TITLE
docs: Reusable styled form component

### DIFF
--- a/docs/framework/react/guides/reusable-styled-form-component.md
+++ b/docs/framework/react/guides/reusable-styled-form-component.md
@@ -1,0 +1,69 @@
+---
+id: reusable-styled-form-component
+title: Reusable Styled Form Component
+---
+
+# Creating your own Reusable Styled Form Component
+This guide will walk you through the process of creating a reusable styled form component. A reusable styled form component is a component that encapsulates the logic and styling of a form, allowing you to reuse it across your application. It is highly opinionated and meant to be customised for your specific project. The concepts in this guide are applicable to any ui-library and it is meant as a reference for you to create your own reusable styled form component. 
+
+You can think of a reusable styled form component as a wrapper around TanStack Form that encapsulates the logic and styling of a form for a higher level of abstraction. It can be thought of as a giant UI component for forms that implements simpler UI components like `Input`, `Select`, `Button`, etc.
+
+## When to Create a Reusable Styled Form Component
+Creating a reusable styled form component is a great way to reduce boilerplate and enforce consistency across your application. It is especially useful if you have a lot of forms in your application, but in many cases it is overkill. If you only have a few forms in your application, it is probably better to use TanStack Form directly. 
+
+## Prerequisites
+This example uses [Tailwind CSS](https://tailwindcss.com/) for styling and [Class Variance Authority](https://beta.cva.style/) for UI component variants. You can use any styling solution of your choice, just replace the custom components with your own and provide the appropriate props. It also uses `Zod` for validation, but you can use any validation library of your choice.
+
+## Composition
+The reusable form component is composed of compound components to make it easier to customise. The `<Form />` component is the main component. While `<Form.Field />` and `<Form.Subscribe />` renders the appropriate components from TanStack Form. The rest of the compound components are examples of components that you can add to your own reusable form component. For example, `<Form.Field.Text />` is a compound component that renders a text field. You can add as many compound components as you want to your reusable form component and some of the examples in this guide are just that, examples. You may not need a `<Form.ResetButton />` component, but it is included here.
+
+## Let's Get Started
+
+### `<Form />`
+
+```tsx
+const Form = React.forwardRef<HTMLFormElement, FormProps>(
+  ({ className, children, formOptions, ...props }, ref) => {
+    const { Provider, Field, handleSubmit, useStore, Subscribe, reset } =
+      useForm({
+        validatorAdapter: zodValidator,
+        ...formOptions,
+      })
+    return (
+      <Provider>
+        <form
+          className={className}
+          onSubmit={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            handleSubmit()
+          }}
+          ref={ref}
+          {...props}
+        >
+          <FormContext.Provider value={{ Field, Subscribe, reset }}>
+            {typeof children === 'function' ? children(useStore) : children}
+          </FormContext.Provider>
+        </form>
+      </Provider>
+    )
+  },
+) as FormComponentProps
+```
+The `<Form />` component wraps the form in the `<Provider />` from TanStack Form and provides the appropriate `onSubmit` props which is something you would normally do when using TanStack Form directly. It also initiates the `useForm` from Tanstack Form and here you can pass any options that you want to have in every single form in your application. For example the validator adapter. The `<Form />` component also renders the `<FormContext.Provider />` which provides the `<Form.Field />` and `<Form.Subscribe />` components to the rest of the form. The `<Form />` component also provides the `useStore` hook from TanStack Form to the rest of the form. This is so that you can access the form state from anywhere in the form.
+
+### `<Form.Field />` & `<Form.Subscribe />`
+
+```tsx
+Form.Field = React.forwardRef<FormFieldProps>(({ ...props }, ref) => {
+  const { Field } = React.useContext(FormContext)
+  return <Field ref={ref} {...props} />
+})
+
+Form.Subscribe = React.forwardRef<FormFieldProps>(({ ...props }, ref) => {
+  const { Subscribe } = React.useContext(FormContext)
+  return <Subscribe ref={ref} {...props} />
+})
+```
+The `<Form.Field />` and `<Form.Subscribe />` components are just wrappers around the `<Field />` and `<Subscribe />` components from TanStack Form. They are not necessary, but they make it easier to customise the form. For example, `<Form.Field />` gives access to the `field` prop which is the field object from TanStack Form. This allows you to access and overwrite any value that you pass down in your UI compound components. For example, you can have a default `onChange={(e) => field.handleChange(e.target.value)}` prop that you want to change to something else like `onChange={(e) => field.handleChange(e.target.valueAsNumber)}` where you still would need access to the `field` prop. The `<Form.Subscribe />` component can be useful if you want to render a component that is not a field, but still needs access to the form state. For example, a loading indicator, a button that is disabled when the form is submitting, a JSON representation of the form state, etc. If you don't need this flexibility in your reusable form component, you can hardcode the `<Field />` and `<Subscribe />` components from TanStack Form directly into your UI compound components.
+

--- a/docs/framework/react/guides/reusable-styled-form-component.md
+++ b/docs/framework/react/guides/reusable-styled-form-component.md
@@ -4,7 +4,7 @@ title: Reusable Styled Form Component
 ---
 
 # Creating your own Reusable Styled Form Component
-This guide will walk you through the process of creating a reusable styled form component. A reusable styled form component is a component that encapsulates the logic and styling of a form, allowing you to reuse it across your application. It is highly opinionated and meant to be customised for your specific project. The concepts in this guide are applicable to any ui-library and it is meant as a reference for you to create your own reusable styled form component. 
+This guide will walk you through the process of creating a reusable styled form component. A reusable styled form component is a component that encapsulates the logic and styling of a form, allowing you to reuse it across your application. It is highly opinionated and meant to be customised for your specific project. The concepts in this guide are applicable to any UI library and it is meant as a reference for you to create your own reusable styled form component. 
 
 You can think of a reusable styled form component as a wrapper around TanStack Form that encapsulates the logic and styling of a form for a higher level of abstraction. It can be thought of as a giant UI component for forms that implements simpler UI components like `Input`, `Select`, `Button`, etc.
 
@@ -12,10 +12,10 @@ You can think of a reusable styled form component as a wrapper around TanStack F
 Creating a reusable styled form component is a great way to reduce boilerplate and enforce consistency across your application. It is especially useful if you have a lot of forms in your application, but in many cases it is overkill. If you only have a few forms in your application, it is probably better to use TanStack Form directly. 
 
 ## Prerequisites
-This example uses [Tailwind CSS](https://tailwindcss.com/) for styling and [Class Variance Authority](https://beta.cva.style/) for UI component variants. You can use any styling solution of your choice, just replace the custom components with your own and provide the appropriate props. It also uses `Zod` for validation, but you can use any validation library of your choice.
+This example uses [Tailwind CSS](https://tailwindcss.com/) for styling and [Class Variance Authority](https://beta.cva.style/) for UI component variants. You can use any styling solution of your choice, just replace the custom components with your own and provide the appropriate props. It also uses `Zod` for validation, but you can use any validation library of your choice. If you want to take a look at the custom UI components you can see them in the codesandbox in the examples section.
 
 ## Composition
-The reusable form component is composed of compound components to make it easier to customise. The `<Form />` component is the main component. While `<Form.Field />` and `<Form.Subscribe />` renders the appropriate components from TanStack Form. The rest of the compound components are examples of components that you can add to your own reusable form component. For example, `<Form.Field.Text />` is a compound component that renders a text field. You can add as many compound components as you want to your reusable form component and some of the examples in this guide are just that, examples. You may not need a `<Form.ResetButton />` component, but it is included here.
+The reusable form component is composed of compound components to make it easier to customise. The `<Form />` component is the main component. While `<Form.Field />` and `<Form.Subscribe />` renders the appropriate components from TanStack Form. The rest of the compound components are examples of components that you can add to your own reusable form component. For example, `<Form.Field.Text />` is a compound component that renders a text field. You can add as many compound components as you want to your reusable form component and some of the examples in this guide are just that, examples. You may not need a `<Form.ResetButton />` component, but it is included here. All the components in this example are forwarding the ref to the underlying HTML element. This is so that you can access the HTML element directly if needed. For example, if you want to focus the first field in the form when the form is submitted.
 
 ## Let's Get Started
 
@@ -67,3 +67,255 @@ Form.Subscribe = React.forwardRef<FormFieldProps>(({ ...props }, ref) => {
 ```
 The `<Form.Field />` and `<Form.Subscribe />` components are just wrappers around the `<Field />` and `<Subscribe />` components from TanStack Form. They are not necessary, but they make it easier to customise the form. For example, `<Form.Field />` gives access to the `field` prop which is the field object from TanStack Form. This allows you to access and overwrite any value that you pass down in your UI compound components. For example, you can have a default `onChange={(e) => field.handleChange(e.target.value)}` prop that you want to change to something else like `onChange={(e) => field.handleChange(e.target.valueAsNumber)}` where you still would need access to the `field` prop. The `<Form.Subscribe />` component can be useful if you want to render a component that is not a field, but still needs access to the form state. For example, a loading indicator, a button that is disabled when the form is submitting, a JSON representation of the form state, etc. If you don't need this flexibility in your reusable form component, you can hardcode the `<Field />` and `<Subscribe />` components from TanStack Form directly into your UI compound components.
 
+### `<Form.Field.Text />`, `<Form.Field.Checkbox />` & `<Form.Field.Select />`
+
+```tsx
+Form.Field.Text = React.forwardRef<HTMLInputElement, FormFieldTextProps>(
+  ({ className, hasErrorField, field, label, ...props }, ref) => {
+    return (
+      <div className="flex relative">
+        <Input
+          className={cx(
+            'placeholder:text-white dark:placeholder:text-black',
+            className,
+          )}
+          invalid={field.state.meta.errors.length !== 0}
+          type="text"
+          id={field.name}
+          name={field.name}
+          placeholder={label}
+          value={field.state.value}
+          onBlur={field.handleBlur}
+          onChange={(e) => field.handleChange(e.target.value)}
+          aria-describedby={
+            hasErrorField && field.state.meta.errors.length !== 0
+              ? `${field.name}-error`
+              : ''
+          }
+          aria-invalid={field.state.meta.errors.length !== 0}
+          ref={ref}
+          {...props}
+        />
+        {label && (
+          <Label
+            className={cx(
+              'pointer-events-none absolute origin-left translate-x-[5px] translate-y-[9px] scale-100 rounded-md bg-white dark:bg-black px-2 py-1 font-normal text-gray-500 transition peer-focus:-translate-y-[11px] peer-focus:translate-x-[7px] peer-focus:scale-[calc(12/14)] peer-focus:text-blue-500 peer-[:not(:placeholder-shown):not(:focus)]:-translate-y-[11px] peer-[:not(:placeholder-shown):not(:focus)]:translate-x-[7px] peer-[:not(:placeholder-shown):not(:focus)]:scale-[calc(12/14)] peer-[:not(:placeholder-shown):not(:focus)]:text-gray-500',
+              field.state.meta.errors.length !== 0 &&
+                'peer-focus:text-red-500 peer-[:not(:placeholder-shown):not(:focus)]:text-red-500',
+            )}
+            htmlFor={field.name}
+          >
+            {label}
+          </Label>
+        )}
+      </div>
+    )
+  },
+)
+
+Form.Field.Checkbox = React.forwardRef<
+  HTMLInputElement,
+  FormFieldCheckboxProps
+>(({ className, children, field, label, ...props }, ref) => {
+  return (
+    <div className="flex relative items-center gap-2">
+      <Input
+        className={className}
+        type="checkbox"
+        id={field.name}
+        name={field.name}
+        placeholder={label}
+        checked={field.state.value}
+        onBlur={field.handleBlur}
+        onChange={(e) => field.handleChange(e.target.checked)}
+        ref={ref}
+        {...props}
+      />
+      {label && (
+        <Label className="cursor-pointer" htmlFor={field.name}>
+          {label}
+        </Label>
+      )}
+    </div>
+  )
+})
+
+Form.Field.Select = React.forwardRef<HTMLSelectElement, FormFieldSelectProps>(
+  ({ className, hasErrorField, field, label, ...props }, ref) => {
+    return (
+      <div className="flex flex-col relative gap-2">
+        {label && (
+          <Label className="cursor-pointer" htmlFor={field.name}>
+            {label}
+          </Label>
+        )}
+        <Select
+          className={className}
+          id={field.name}
+          name={field.name}
+          value={field.state.value}
+          onBlur={field.handleBlur}
+          onChange={(e) => field.handleChange(e.target.value)}
+          aria-describedby={
+            hasErrorField && field.state.meta.errors.length !== 0
+              ? `${field.name}-error`
+              : ''
+          }
+          ref={ref}
+          {...props}
+        />
+      </div>
+    )
+  },
+)
+```
+The `<Form.Field.Text />`, `<Form.Field.Checkbox /` and `<Form.Field.Select />` components are examples of compound components that you can add to your reusable form component. They are using the custom UI components `<Input />`, `<Label />`, `<Select />` and aswell as extra Tailwind styles to style the form. You can use your own UI components, style the primitive HTML elements directly or use a UI styling library. All of these components have all the base props that you would have to supply anyway like `id`, `name`, `value`, `onChange`, `onBlur`, etc. given through the field prop. You pass this prop from the `<Form.Field />` which make it easy to overwrite anything if needed. They also optionaly render a label and error message if you pass the `label` and `hasErrorField` props. The `hasErrorField` prop is a boolean that enables aria labelling when you combine it with an error message component. This is not applicable to the Checkbox.
+
+### `<Form.Field.Error />`
+
+```tsx
+Form.Field.Error = React.forwardRef<HTMLSpanElement, FormFieldErrorProps>(
+  ({ className, field, ...props }, ref) => {
+    return (
+      <>
+        <ExclamationCircleIcon
+          className={cx(
+            'absolute h-4 w-4 translate-x-[3px] translate-y-px text-red-500 opacity-0 transition-opacity',
+            field.state.meta.errors.length !== 0 && 'opacity-100',
+          )}
+        />
+        <span
+          className={cx(
+            'absolute translate-x-5 leading-none translate-y-px text-xs text-red-500 opacity-0 transition-opacity',
+            field.state.meta.errors.length !== 0 && 'opacity-100',
+          )}
+          id={`${field.name}-error`}
+          aria-hidden={field.state.meta.errors.length !== 0 ? 'false' : 'true'}
+          ref={ref}
+          {...props}
+        >
+          {field.state.meta.errors.length !== 0 &&
+            field.state.meta.errors[0].split(', ')[0]}
+        </span>
+      </>
+    )
+  },
+)
+```
+The `<Form.Field.Error />` component is an example of a styled error message compound component that you can combine with the other field compound components to render an error message. It shows an error message only when needed and uses aria labelling to make it accessible. It also only renders a single error message even if there are multiple errors. You can use your own error message component or style the error message directly on the field compound components. This is just an example.
+
+### `<Form.ResetButton />` & `<Form.SubmitButton />`
+
+```tsx
+Form.SubmitButton = React.forwardRef<HTMLButtonElement, FormSubmitButtonProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <Form.Subscribe selector={(state) => state.canSubmit}>
+        {(canSubmit) => (
+          <Button
+            className={className}
+            variant="primary"
+            size="md"
+            type="submit"
+            disabled={!canSubmit}
+            ref={ref}
+            {...props}
+          />
+        )}
+      </Form.Subscribe>
+    )
+  },
+)
+
+Form.ResetButton = React.forwardRef<HTMLButtonElement, FormResetButtonProps>(
+  ({ className, ...props }, ref) => {
+    const { reset } = React.useContext(FormContext)
+    return (
+      <Form.Subscribe selector={(state) => state.submissionAttempts}>
+        {(submissionAttempts) => (
+          <Button
+            className={cx('text-blue-500 dark:text-blue-500', className)}
+            disabled={submissionAttempts === 0}
+            onClick={() => reset()}
+            variant="ghost"
+            size="xs"
+            ref={ref}
+            {...props}
+          />
+        )}
+      </Form.Subscribe>
+    )
+  },
+)
+```
+
+The `<Form.ResetButton />` and `<Form.SubmitButton />` components uses a custom `<Button />` UI component to render the buttons with appropriate styles. They also implement the `<Form.Subscribe />` component diresctly to subscribe to the necessary form state and render the buttons accordingly. The `<Form.SubmitButton />` component is disabled when the form is not ready to submit and the `<Form.ResetButton />` component is disabled when the form has not been submitted. You don't have to create these components if you dont need them. You can just use the `<Button />` component directly in your form if you want that, but it can be useful if you need to use the same style of Submit and Reset buttons across multiple forms. You can also choose to not implement the `<Form.Subscribe />` component directly, and instead pass the state as a prop to a `<Form.Subscirbe.SubmitButton />` component to make the prop more reusable. There is always a balance of how much abstraction you want to have in your reusable form component, and how much you want to hardcode to make it easier to customise.
+
+## A simple example
+This is a simple example of how to use this reusable styled form component as it is made here. For a more complex example, that implements many features of TanStack Form, see in the codesandbox in the example section.
+
+```tsx
+<Form
+  formOptions={{
+    defaultValues: {
+      likesCars: false,
+      favouriteCarBrand: 'Porsche',
+      comments: '',
+    },
+  }}>
+  <Form.Field
+    name="likesCars"
+    children={(field) => (
+      <Form.Field.Checkbox
+        field={field}
+        label="Do you like cars?"
+      />
+    )}
+  />
+  <Form.Field
+    name="favouriteCarBrand"
+    children={(field) => (
+      <Form.Field.Select
+        field={field}
+        label="What is your favourite car brand?"
+      >
+        <option value="Porsche">Porsche</option>
+        <option value="Ferrari">Ferrari</option>
+        <option value="Lamborghini">Lamborghini</option>
+      </Form.Field.Select>
+    )}
+  />
+  <Form.Field
+    name="comments"
+    validators={{
+      onSubmit: z
+        .string()
+        .min(10, "Must be at least 10 characters"),
+        .max(100, "Must be at most 100 characters"),
+        .refine((value)) => value.includes("car"), "Must contain the word car"),
+      }}
+    children={(field) => (
+      <div className="relative">
+        <Form.Field.Text
+          field={field}
+          hasErrorField
+          label="Any comments?"
+        />
+        <Form.Field.Error field={field} />
+      </div>
+    )}
+  />
+  <Form.SubmitButton>Submit</Form.SubmitButton>
+  <Form.ResetButton>Reset</Form.ResetButton>
+  <Form.Subscribe selector={(state) => state.isValidating}>
+    {(isValidating) => (
+      <p className="text-sm text-gray-500 italic">
+        {isValidating ? 'Currently validating the form' : "Not validating the form"}
+      </p>
+    )}
+  </Form>
+```
+The pros with this reusable form component is that this form is not verbose at all and easy to reuse. You can also easily add new styled compound components to it and it is completely customizable. The cons is that it is more complex than just using TanStack Form directly and it is more difficult to understand how it works. It is also more difficult to debug if something goes wrong. 
+
+## End Notes
+Hope this guide was helpful and that you can use it as a reference to create your own reusable styled form component, or it helped you better understand the concepts of TanStack Form. It can be smart to take a llook at the example in the codesandbox to see how it works in a more real world example. 

--- a/examples/react/reusable-styled-form-component/.eslintrc.cjs
+++ b/examples/react/reusable-styled-form-component/.eslintrc.cjs
@@ -1,0 +1,15 @@
+// @ts-check
+
+/** @type {import('eslint').Linter.Config} */
+const config = {
+  extends: ['plugin:react/recommended', 'plugin:react-hooks/recommended'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.json',
+  },
+  rules: {
+    'react/no-children-prop': 'off',
+  },
+}
+
+module.exports = config

--- a/examples/react/reusable-styled-form-component/.gitignore
+++ b/examples/react/reusable-styled-form-component/.gitignore
@@ -1,0 +1,27 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+pnpm-lock.yaml
+yarn.lock
+package-lock.json
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/examples/react/reusable-styled-form-component/README.md
+++ b/examples/react/reusable-styled-form-component/README.md
@@ -1,0 +1,6 @@
+# Example
+
+To run this example:
+
+- `npm install`
+- `npm run dev`

--- a/examples/react/reusable-styled-form-component/index.html
+++ b/examples/react/reusable-styled-form-component/index.html
@@ -6,7 +6,7 @@
     <title>TanStack Reusable Styled Form Component</title>
     <link rel="stylesheet" href="/src/index.css" />
   </head>
-  <body class="h-full w-full">
+  <body class="h-full w-full bg-white dark:bg-black text-black dark:text-white">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div class="h-full w-full" id="root"></div>
     <script type="module" src="/src/index.tsx"></script>

--- a/examples/react/reusable-styled-form-component/index.html
+++ b/examples/react/reusable-styled-form-component/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html class="h-full w-full" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>TanStack Reusable Styled Form Component</title>
+    <link rel="stylesheet" href="/src/index.css" />
+  </head>
+  <body class="h-full w-full">
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div class="h-full w-full" id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/examples/react/reusable-styled-form-component/package.json
+++ b/examples/react/reusable-styled-form-component/package.json
@@ -14,6 +14,7 @@
     "cva": "1.0.0-beta.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
+    "react-phone-number-input": "^3.3.8",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/examples/react/reusable-styled-form-component/package.json
+++ b/examples/react/reusable-styled-form-component/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@heroicons/react": "^2.1.1",
     "@tanstack/react-form": "<1.0.0",
     "@tanstack/zod-form-adapter": "<1.0.0",
     "cva": "1.0.0-beta.1",

--- a/examples/react/reusable-styled-form-component/package.json
+++ b/examples/react/reusable-styled-form-component/package.json
@@ -17,6 +17,7 @@
     "zod": "^3.21.4"
   },
   "devDependencies": {
+    "@tailwindcss/forms": "^0.5.7",
     "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "^10.4.16",
     "postcss": "8.4.32",

--- a/examples/react/reusable-styled-form-component/package.json
+++ b/examples/react/reusable-styled-form-component/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@tanstack/reusable-styled-form-component",
+  "version": "0.0.1",
+  "main": "src/index.tsx",
+  "scripts": {
+    "dev": "vite --port=3001",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tanstack/react-form": "<1.0.0",
+    "@tanstack/zod-form-adapter": "<1.0.0",
+    "cva": "1.0.0-beta.1",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "zod": "^3.21.4"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.16",
+    "postcss": "8.4.32",
+    "tailwind-merge": "^2.2.0",
+    "tailwindcss": "^3.4.1",
+    "vite": "^5.0.10"
+  }
+}

--- a/examples/react/reusable-styled-form-component/package.json
+++ b/examples/react/reusable-styled-form-component/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@heroicons/react": "^2.1.1",
     "@tanstack/react-form": "<1.0.0",
-    "@tanstack/zod-form-adapter": "<1.0.0",
+    "@tanstack/zod-form-adapter": "workspace:^",
     "cva": "1.0.0-beta.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/react/reusable-styled-form-component/package.json
+++ b/examples/react/reusable-styled-form-component/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@heroicons/react": "^2.1.1",
     "@tanstack/react-form": "<1.0.0",
-    "@tanstack/zod-form-adapter": "workspace:^",
+    "@tanstack/zod-form-adapter": "<1.0.0",
     "cva": "1.0.0-beta.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/react/reusable-styled-form-component/postcss.config.js
+++ b/examples/react/reusable-styled-form-component/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/examples/react/reusable-styled-form-component/src/Button.tsx
+++ b/examples/react/reusable-styled-form-component/src/Button.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+
+import { type buttonVariantProps, buttonVariants } from './variants'
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+  buttonVariantProps
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, base = true, variant, size, ...props }, ref) => {
+    return (
+      <button
+        className={buttonVariants({ className, base, variant, size })}
+        ref={ref}
+        {...props}
+      />
+    )
+  },
+)
+
+Button.displayName = 'Button'
+
+export { Button, type ButtonProps }

--- a/examples/react/reusable-styled-form-component/src/Form.tsx
+++ b/examples/react/reusable-styled-form-component/src/Form.tsx
@@ -6,6 +6,7 @@ import { cx } from './utils'
 import { Input } from './Input'
 import { Label } from './Label'
 import { Select } from './Select'
+import { Button } from './Button'
 
 type FormProps = any
 
@@ -39,7 +40,7 @@ const FormContext = React.createContext<any>({})
 
 const Form = React.forwardRef<HTMLFormElement, FormProps>(
   ({ className, children, formOptions, ...props }, ref) => {
-    const { Provider, Field, handleSubmit, useStore, Subscribe, state } =
+    const { Provider, Field, handleSubmit, useStore, Subscribe, reset } =
       useForm({
         validatorAdapter: zodValidator,
         ...formOptions,
@@ -57,7 +58,9 @@ const Form = React.forwardRef<HTMLFormElement, FormProps>(
           {...props}
         >
           <FormContext.Provider value={{ Field, Subscribe }}>
-            {typeof children === 'function' ? children(useStore) : children}
+            {typeof children === 'function'
+              ? children(useStore, reset)
+              : children}
           </FormContext.Provider>
         </form>
       </Provider>
@@ -210,6 +213,23 @@ Form.Subscribe = React.forwardRef<FormFieldProps>(({ ...props }, ref) => {
 })
 
 Form.Subscribe.displayName = 'Form.Subscribe'
+
+Form.Subscribe.Button = React.forwardRef<
+  HTMLButtonElement,
+  FormSubscribeButtonProps
+>(({ className, state, ...props }, ref) => {
+  return (
+    <Button
+      className={className}
+      variant="primary"
+      size="md"
+      type="submit"
+      disabled={!state.canSubmit}
+      ref={ref}
+      {...props}
+    />
+  )
+})
 
 export {
   Form,

--- a/examples/react/reusable-styled-form-component/src/Form.tsx
+++ b/examples/react/reusable-styled-form-component/src/Form.tsx
@@ -69,11 +69,6 @@ Form.Field.displayName = 'Form.Field'
 
 Form.Field.Text = React.forwardRef<HTMLInputElement, FormFieldTextProps>(
   ({ className, children, field, label, ...props }, ref) => {
-    const childWithField = React.Children.map(children, (child) =>
-      React.isValidElement(child)
-        ? React.cloneElement(child, { field })
-        : child,
-    )
     return (
       <div className="flex relative">
         <Input
@@ -98,17 +93,18 @@ Form.Field.Text = React.forwardRef<HTMLInputElement, FormFieldTextProps>(
           ref={ref}
           {...props}
         />
-        <Label
-          className={cx(
-            'pointer-events-none absolute origin-left translate-x-[5px] translate-y-[9px] scale-100 rounded-md bg-white dark:bg-black px-2 py-1 font-normal text-gray-500 transition peer-focus:-translate-y-[11px] peer-focus:translate-x-[7px] peer-focus:scale-[calc(12/14)] peer-focus:text-blue-500 peer-[:not(:placeholder-shown):not(:focus)]:-translate-y-[11px] peer-[:not(:placeholder-shown):not(:focus)]:translate-x-[7px] peer-[:not(:placeholder-shown):not(:focus)]:scale-[calc(12/14)] peer-[:not(:placeholder-shown):not(:focus)]:text-gray-500',
-            field.state.meta.errors.length !== 0 &&
-              'peer-focus:text-red-500 peer-[:not(:placeholder-shown):not(:focus)]:text-red-500',
-          )}
-          htmlFor={field.name}
-        >
-          {label}
-        </Label>
-        {childWithField}
+        {label && (
+          <Label
+            className={cx(
+              'pointer-events-none absolute origin-left translate-x-[5px] translate-y-[9px] scale-100 rounded-md bg-white dark:bg-black px-2 py-1 font-normal text-gray-500 transition peer-focus:-translate-y-[11px] peer-focus:translate-x-[7px] peer-focus:scale-[calc(12/14)] peer-focus:text-blue-500 peer-[:not(:placeholder-shown):not(:focus)]:-translate-y-[11px] peer-[:not(:placeholder-shown):not(:focus)]:translate-x-[7px] peer-[:not(:placeholder-shown):not(:focus)]:scale-[calc(12/14)] peer-[:not(:placeholder-shown):not(:focus)]:text-gray-500',
+              field.state.meta.errors.length !== 0 &&
+                'peer-focus:text-red-500 peer-[:not(:placeholder-shown):not(:focus)]:text-red-500',
+            )}
+            htmlFor={field.name}
+          >
+            {label}
+          </Label>
+        )}
       </div>
     )
   },
@@ -120,9 +116,6 @@ Form.Field.Checkbox = React.forwardRef<
   HTMLInputElement,
   FormFieldCheckboxProps
 >(({ className, children, field, label, ...props }, ref) => {
-  const childWithField = React.Children.map(children, (child) =>
-    React.isValidElement(child) ? React.cloneElement(child, { field }) : child,
-  )
   return (
     <div className="flex relative items-center gap-2">
       <Input
@@ -137,10 +130,11 @@ Form.Field.Checkbox = React.forwardRef<
         ref={ref}
         {...props}
       />
-      <Label className="cursor-pointer" htmlFor={field.name}>
-        {label}
-      </Label>
-      {childWithField}
+      {label && (
+        <Label className="cursor-pointer" htmlFor={field.name}>
+          {label}
+        </Label>
+      )}
     </div>
   )
 })
@@ -148,17 +142,14 @@ Form.Field.Checkbox = React.forwardRef<
 Form.Field.Checkbox.displayName = 'Form.Field.Checkbox'
 
 Form.Field.Select = React.forwardRef<HTMLSelectElement, FormFieldSelectProps>(
-  ({ className, children, field, label, ...props }, ref) => {
-    const childWithField = React.Children.map(children, (child) =>
-      React.isValidElement(child)
-        ? React.cloneElement(child, { field })
-        : child,
-    )
+  ({ className, field, label, ...props }, ref) => {
     return (
-      <div className="flex relative">
-        <Label className="cursor-pointer" htmlFor={field.name}>
-          {label}
-        </Label>
+      <div className="flex flex-col relative gap-2">
+        {label && (
+          <Label className="cursor-pointer" htmlFor={field.name}>
+            {label}
+          </Label>
+        )}
         <Select
           className={className}
           id={field.name}
@@ -169,7 +160,6 @@ Form.Field.Select = React.forwardRef<HTMLSelectElement, FormFieldSelectProps>(
           ref={ref}
           {...props}
         />
-        {childWithField}
       </div>
     )
   },
@@ -183,14 +173,14 @@ Form.Field.Error = React.forwardRef<HTMLSpanElement, FormFieldErrorProps>(
       <>
         <ExclamationCircleIcon
           className={cx(
-            'absolute h-4 w-4 translate-x-[3px] translate-y-[42px] text-red-500 opacity-0 transition-opacity',
-            field.state.meta.errors.length !== 0 && 'peer-focus:opacity-100',
+            'absolute h-4 w-4 translate-x-[3px] translate-y-px text-red-500 opacity-0 transition-opacity',
+            field.state.meta.errors.length !== 0 && 'opacity-100',
           )}
         />
         <span
           className={cx(
-            'absolute translate-x-5 leading-none translate-y-[42px] text-xs text-red-500 opacity-0 transition-opacity',
-            field.state.meta.errors.length !== 0 && 'peer-focus:opacity-100',
+            'absolute translate-x-5 leading-none translate-y-px text-xs text-red-500 opacity-0 transition-opacity',
+            field.state.meta.errors.length !== 0 && 'opacity-100',
           )}
           id={`${field.name}-error`}
           aria-hidden={field.state.meta.errors.length !== 0 ? 'false' : 'true'}

--- a/examples/react/reusable-styled-form-component/src/Form.tsx
+++ b/examples/react/reusable-styled-form-component/src/Form.tsx
@@ -12,12 +12,15 @@ type FormFieldProps = any
 
 type FormFieldTextProps = any
 
+type FormFieldErrorProps = any
+
 type FormFieldCheckboxProps = any
 
 type FormFieldSelectProps = any
 
 type FormComponentProps = React.ForwardRefExoticComponent<FormProps> & {
   Field: FormFieldProps & {
+    Error: React.ForwardRefExoticComponent<FormFieldErrorProps>
     Text: React.ForwardRefExoticComponent<FormFieldTextProps>
     Checkbox: React.ForwardRefExoticComponent<FormFieldCheckboxProps>
     Select: React.ForwardRefExoticComponent<FormFieldSelectProps>
@@ -66,16 +69,20 @@ Form.Field = ({ ...props }: FormFieldProps) => {
 Form.Field.displayName = 'Form.Field'
 
 Form.Field.Text = React.forwardRef<HTMLInputElement, FormFieldTextProps>(
-  ({ className, field, label, ...props }, ref) => {
-    const formMessageId = `${field.name}-message`
+  ({ className, children, field, label, ...props }, ref) => {
+    const childWithField = React.Children.map(children, (child) =>
+      React.isValidElement(child)
+        ? React.cloneElement(child, { field })
+        : child,
+    )
     return (
-      <div className="flex">
+      <div className="flex relative">
         <Input
           className={cx(
             'placeholder:text-white dark:placeholder:text-black',
             className,
           )}
-          invalid={field.state.meta.errors.length > 0}
+          invalid={field.state.meta.errors.length !== 0}
           type="text"
           id={field.name}
           name={field.name}
@@ -84,44 +91,89 @@ Form.Field.Text = React.forwardRef<HTMLInputElement, FormFieldTextProps>(
           onBlur={field.handleBlur}
           onChange={(e) => field.handleChange(e.target.value)}
           aria-describedby={
-            field.state.meta.errors.length > 0 ? `${formMessageId}` : ''
+            field.state.meta.errors.length !== 0 && children
+              ? `${field.name}-error`
+              : ''
           }
-          aria-invalid={field.state.meta.errors.length > 0}
+          aria-invalid={field.state.meta.errors.length !== 0}
           ref={ref}
           {...props}
         />
         <Label
           className={cx(
             'pointer-events-none absolute origin-left translate-x-[5px] translate-y-[9px] scale-100 rounded-md bg-white dark:bg-black px-2 py-1 font-normal text-gray-500 transition peer-focus:-translate-y-[11px] peer-focus:translate-x-[7px] peer-focus:scale-[calc(12/14)] peer-focus:text-blue-500 peer-[:not(:placeholder-shown):not(:focus)]:-translate-y-[11px] peer-[:not(:placeholder-shown):not(:focus)]:translate-x-[7px] peer-[:not(:placeholder-shown):not(:focus)]:scale-[calc(12/14)] peer-[:not(:placeholder-shown):not(:focus)]:text-gray-500',
-            field.state.meta.errors.length > 0 &&
+            field.state.meta.errors.length !== 0 &&
               'peer-focus:text-red-500 peer-[:not(:placeholder-shown):not(:focus)]:text-red-500',
           )}
           htmlFor={field.name}
         >
           {label}
         </Label>
-        <ExclamationCircleIcon
-          className={cx(
-            'absolute h-4 w-4 translate-x-[3px] translate-y-[42px] text-blue-500 opacity-0 transition-opacity',
-            field.state.meta.errors.length > 0 &&
-              'peer-focus:opacity-100 text-red-500',
-          )}
-        />
-        <span
-          className={cx(
-            'absolute translate-x-5 translate-y-[43px] text-xs text-gray-500 opacity-0 transition-opacity',
-            field.state.meta.errors.length > 0 &&
-              'peer-focus:opacity-100 text-red-500',
-          )}
-          aria-hidden={field.state.meta.errors.length > 0 ? 'false' : 'true'}
-        >
-          {field.state.meta.touchedErrors}
-        </span>
+        {childWithField}
       </div>
     )
   },
 )
 
 Form.Field.Text.displayName = 'Form.Field.Text'
+
+Form.Field.Error = React.forwardRef<HTMLSpanElement, FormFieldErrorProps>(
+  ({ className, field, ...props }, ref) => {
+    return (
+      <>
+        <ExclamationCircleIcon
+          className={cx(
+            'absolute h-4 w-4 translate-x-[3px] translate-y-[42px] text-red-500 opacity-0 transition-opacity',
+            field.state.meta.errors.length !== 0 && 'peer-focus:opacity-100',
+          )}
+        />
+        <span
+          className={cx(
+            'absolute translate-x-5 leading-none translate-y-[42px] text-xs text-red-500 opacity-0 transition-opacity',
+            field.state.meta.errors.length !== 0 && 'peer-focus:opacity-100',
+          )}
+          id={`${field.name}-error`}
+          aria-hidden={field.state.meta.errors.length !== 0 ? 'false' : 'true'}
+          ref={ref}
+          {...props}
+        >
+          {field.state.meta.errors.length !== 0 &&
+            field.state.meta.errors[0].split(', ')[0]}
+        </span>
+      </>
+    )
+  },
+)
+
+Form.Field.Error.displayName = 'Form.Field.Error'
+
+Form.Field.Checkbox = React.forwardRef<
+  HTMLInputElement,
+  FormFieldCheckboxProps
+>(({ className, children, field, label, ...props }, ref) => {
+  const childWithField = React.Children.map(children, (child) =>
+    React.isValidElement(child) ? React.cloneElement(child, { field }) : child,
+  )
+  return (
+    <div className="flex relative items-center gap-2">
+      <Input
+        className={className}
+        type="checkbox"
+        id={field.name}
+        name={field.name}
+        placeholder={label}
+        value={field.state.checked}
+        onBlur={field.handleBlur}
+        onChange={(e) => field.handleChange(e.target.checked)}
+        ref={ref}
+        {...props}
+      />
+      <Label className="cursor-pointer" htmlFor={field.name}>
+        {label}
+      </Label>
+      {childWithField}
+    </div>
+  )
+})
 
 export { Form, type FormProps, type FormFieldProps }

--- a/examples/react/reusable-styled-form-component/src/Form.tsx
+++ b/examples/react/reusable-styled-form-component/src/Form.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react'
+import { type FormApi, type FormOptions, useForm } from '@tanstack/react-form'
+import { ExclamationCircleIcon } from '@heroicons/react/20/solid'
+import { zodValidator } from '@tanstack/zod-form-adapter'
+import { cx } from './utils'
+import { Input } from './Input'
+import { Label } from './Label'
+
+type FormProps = any
+
+type FormFieldProps = any
+
+type FormFieldTextProps = any
+
+type FormFieldCheckboxProps = any
+
+type FormFieldSelectProps = any
+
+type FormComponentProps = React.ForwardRefExoticComponent<FormProps> & {
+  Field: FormFieldProps & {
+    Text: React.ForwardRefExoticComponent<FormFieldTextProps>
+    Checkbox: React.ForwardRefExoticComponent<FormFieldCheckboxProps>
+    Select: React.ForwardRefExoticComponent<FormFieldSelectProps>
+  }
+}
+
+type FormContextProps = FormApi<Record<string, unknown>, typeof zodValidator>
+
+const FormContext = React.createContext<FormContextProps>(
+  {} as FormContextProps,
+)
+
+const Form = React.forwardRef<HTMLFormElement, FormProps>(
+  ({ className, formOptions, ...props }, ref) => {
+    const HeadlessForm = useForm({
+      validatorAdapter: zodValidator,
+      ...formOptions,
+    })
+
+    return (
+      <FormContext.Provider value={HeadlessForm}>
+        <HeadlessForm.Provider>
+          <form
+            className={className}
+            onSubmit={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              void HeadlessForm.handleSubmit()
+            }}
+            ref={ref}
+            {...props}
+          />
+        </HeadlessForm.Provider>
+      </FormContext.Provider>
+    )
+  },
+) as FormComponentProps
+
+Form.displayName = 'Form'
+
+Form.Field = ({ ...props }: FormFieldProps) => {
+  const HeadlessForm = React.useContext(FormContext)
+  return <HeadlessForm.Field {...props} />
+}
+
+Form.Field.displayName = 'Form.Field'
+
+Form.Field.Text = React.forwardRef<HTMLInputElement, FormFieldTextProps>(
+  ({ className, field, label, ...props }, ref) => {
+    const formMessageId = `${field.name}-message`
+    return (
+      <div className="flex">
+        <Input
+          className={cx(
+            'placeholder:text-white dark:placeholder:text-black',
+            className,
+          )}
+          invalid={field.state.meta.errors.length > 0}
+          type="text"
+          id={field.name}
+          name={field.name}
+          placeholder={label}
+          value={field.state.value}
+          onBlur={field.handleBlur}
+          onChange={(e) => field.handleChange(e.target.value)}
+          aria-describedby={
+            field.state.meta.errors.length > 0 ? `${formMessageId}` : ''
+          }
+          aria-invalid={field.state.meta.errors.length > 0}
+          ref={ref}
+          {...props}
+        />
+        <Label
+          className={cx(
+            'pointer-events-none absolute origin-left translate-x-[5px] translate-y-[9px] scale-100 rounded-md bg-white dark:bg-black px-2 py-1 font-normal text-gray-500 transition peer-focus:-translate-y-[11px] peer-focus:translate-x-[7px] peer-focus:scale-[calc(12/14)] peer-focus:text-blue-500 peer-[:not(:placeholder-shown):not(:focus)]:-translate-y-[11px] peer-[:not(:placeholder-shown):not(:focus)]:translate-x-[7px] peer-[:not(:placeholder-shown):not(:focus)]:scale-[calc(12/14)] peer-[:not(:placeholder-shown):not(:focus)]:text-gray-500',
+            field.state.meta.errors.length > 0 &&
+              'peer-focus:text-red-500 peer-[:not(:placeholder-shown):not(:focus)]:text-red-500',
+          )}
+          htmlFor={field.name}
+        >
+          {label}
+        </Label>
+        <ExclamationCircleIcon
+          className={cx(
+            'absolute h-4 w-4 translate-x-[3px] translate-y-[42px] text-blue-500 opacity-0 transition-opacity',
+            field.state.meta.errors.length > 0 &&
+              'peer-focus:opacity-100 text-red-500',
+          )}
+        />
+        <span
+          className={cx(
+            'absolute translate-x-5 translate-y-[43px] text-xs text-gray-500 opacity-0 transition-opacity',
+            field.state.meta.errors.length > 0 &&
+              'peer-focus:opacity-100 text-red-500',
+          )}
+          aria-hidden={field.state.meta.errors.length > 0 ? 'false' : 'true'}
+        >
+          {field.state.meta.touchedErrors}
+        </span>
+      </div>
+    )
+  },
+)
+
+Form.Field.Text.displayName = 'Form.Field.Text'
+
+export { Form, type FormProps, type FormFieldProps }

--- a/examples/react/reusable-styled-form-component/src/Form.tsx
+++ b/examples/react/reusable-styled-form-component/src/Form.tsx
@@ -19,24 +19,31 @@ type FormFieldSelectProps = any
 
 type FormFieldErrorProps = any
 
+type FormSubscribeProps = any
+
+type FormSubscribeButtonProps = any
+
 type FormComponentProps = React.ForwardRefExoticComponent<FormProps> & {
   Field: FormFieldProps & {
-    Error: React.ForwardRefExoticComponent<FormFieldErrorProps>
-    Text: React.ForwardRefExoticComponent<FormFieldTextProps>
-    Checkbox: React.ForwardRefExoticComponent<FormFieldCheckboxProps>
-    Select: React.ForwardRefExoticComponent<FormFieldSelectProps>
+    Error: React.FC<FormFieldErrorProps>
+    Text: React.FC<FormFieldTextProps>
+    Checkbox: React.FC<FormFieldCheckboxProps>
+    Select: React.FC<FormFieldSelectProps>
+  }
+  Subscribe: FormSubscribeProps & {
+    Button: React.FC<FormSubscribeButtonProps>
   }
 }
 
-const FieldContext = React.createContext<FormFieldProps>({} as FormFieldProps)
+const FormContext = React.createContext<any>({})
 
 const Form = React.forwardRef<HTMLFormElement, FormProps>(
   ({ className, children, formOptions, ...props }, ref) => {
-    const { Provider, Field, handleSubmit } = useForm({
-      validatorAdapter: zodValidator,
-      ...formOptions,
-    })
-
+    const { Provider, Field, handleSubmit, useStore, Subscribe, state } =
+      useForm({
+        validatorAdapter: zodValidator,
+        ...formOptions,
+      })
     return (
       <Provider>
         <form
@@ -49,9 +56,9 @@ const Form = React.forwardRef<HTMLFormElement, FormProps>(
           ref={ref}
           {...props}
         >
-          <FieldContext.Provider value={Field}>
-            {children}
-          </FieldContext.Provider>
+          <FormContext.Provider value={{ Field, Subscribe }}>
+            {typeof children === 'function' ? children(useStore) : children}
+          </FormContext.Provider>
         </form>
       </Provider>
     )
@@ -61,7 +68,7 @@ const Form = React.forwardRef<HTMLFormElement, FormProps>(
 Form.displayName = 'Form'
 
 Form.Field = React.forwardRef<FormFieldProps>(({ ...props }, ref) => {
-  const Field = React.useContext(FieldContext)
+  const { Field } = React.useContext(FormContext)
   return <Field ref={ref} {...props} />
 })
 
@@ -196,6 +203,13 @@ Form.Field.Error = React.forwardRef<HTMLSpanElement, FormFieldErrorProps>(
 )
 
 Form.Field.Error.displayName = 'Form.Field.Error'
+
+Form.Subscribe = React.forwardRef<FormFieldProps>(({ ...props }, ref) => {
+  const { Subscribe } = React.useContext(FormContext)
+  return <Subscribe ref={ref} {...props} />
+})
+
+Form.Subscribe.displayName = 'Form.Subscribe'
 
 export {
   Form,

--- a/examples/react/reusable-styled-form-component/src/Input.tsx
+++ b/examples/react/reusable-styled-form-component/src/Input.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+import { type inputVariantProps, inputVariants } from './variants'
+
+type InputProps = React.InputHTMLAttributes<HTMLInputElement> &
+  Omit<inputVariantProps, 'type'> & {
+    invalid?: boolean
+  }
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, invalid = false, ...props }, ref) => {
+    return (
+      <input
+        className={inputVariants({
+          className,
+          type,
+          invalid,
+        } as inputVariantProps)}
+        type={type}
+        ref={ref}
+        {...props}
+      />
+    )
+  },
+)
+
+Input.displayName = 'Input'
+
+export { Input, inputVariants, type InputProps }

--- a/examples/react/reusable-styled-form-component/src/Label.tsx
+++ b/examples/react/reusable-styled-form-component/src/Label.tsx
@@ -8,7 +8,7 @@ const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
     return (
       <label
         className={cx(
-          'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+          'text-sm font-medium select-none leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
           className,
         )}
         ref={ref}

--- a/examples/react/reusable-styled-form-component/src/Label.tsx
+++ b/examples/react/reusable-styled-form-component/src/Label.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react'
+import { cx } from './utils'
+
+type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>
+
+const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <label
+        className={cx(
+          'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  },
+)
+
+Label.displayName = 'Label'
+
+export { Label, type LabelProps }

--- a/examples/react/reusable-styled-form-component/src/Label.tsx
+++ b/examples/react/reusable-styled-form-component/src/Label.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react'
 import { cx } from './utils'
 
-type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>
+type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement> & {
+  className?: string
+}
 
 const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
   ({ className, ...props }, ref) => {

--- a/examples/react/reusable-styled-form-component/src/Select.tsx
+++ b/examples/react/reusable-styled-form-component/src/Select.tsx
@@ -5,7 +5,7 @@ import { cx } from './utils'
 type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement> & {
   className?: string
   displayValue?: boolean
-  value: string
+  value?: string
 }
 
 type SelectOptionGroupProps = React.OptgroupHTMLAttributes<HTMLOptGroupElement>
@@ -27,7 +27,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
       <SelectContext.Provider value={displayValue ? value : ''}>
         <select
           className={cx(
-            'h-10 w-full cursor-pointer rounded-md border border-secondary-200 bg-background fill-accent stroke-accent px-3 py-2 text-sm transition-border focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:border-primary disabled:cursor-not-allowed disabled:opacity-50 dark:border-secondary-700 focus-visible:dark:border-primary',
+            'h-10 w-full cursor-pointer rounded-md border border-gray-300 bg-white dark:bg-black px-3 py-2 text-sm transition-border focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:border-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 focus-visible:dark:border-blue-500',
             className,
           )}
           ref={ref}

--- a/examples/react/reusable-styled-form-component/src/Select.tsx
+++ b/examples/react/reusable-styled-form-component/src/Select.tsx
@@ -4,7 +4,6 @@ import { cx } from './utils'
 
 type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement> & {
   className?: string
-  displayValue?: boolean
   value?: string
 }
 
@@ -12,6 +11,7 @@ type SelectOptionGroupProps = React.OptgroupHTMLAttributes<HTMLOptGroupElement>
 
 type SelectOptionProps = React.OptionHTMLAttributes<HTMLOptionElement> & {
   value: string
+  displayValue?: string
 }
 
 type SelectComponentProps = React.ForwardRefExoticComponent<SelectProps> & {
@@ -22,14 +22,15 @@ type SelectComponentProps = React.ForwardRefExoticComponent<SelectProps> & {
 const SelectContext = React.createContext<SelectProps['value']>('')
 
 const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
-  ({ className, value, displayValue = false, ...props }, ref) => {
+  ({ className, value, ...props }, ref) => {
     return (
-      <SelectContext.Provider value={displayValue ? value : ''}>
+      <SelectContext.Provider value={value}>
         <select
           className={cx(
             'h-10 w-full cursor-pointer rounded-md border border-gray-300 bg-white dark:bg-black px-3 py-2 text-sm transition-border focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:border-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 focus-visible:dark:border-blue-500',
             className,
           )}
+          value={value}
           ref={ref}
           {...props}
         />
@@ -50,11 +51,13 @@ Select.OptionGroup = React.forwardRef<
 Select.OptionGroup.displayName = 'Select.OptionGroup'
 
 Select.Option = React.forwardRef<HTMLOptionElement, SelectOptionProps>(
-  ({ children, value, ...props }, ref) => {
+  ({ children, value, displayValue, ...props }, ref) => {
     const selectedValue = React.useContext(SelectContext)
     return (
       <option value={value} ref={ref} {...props}>
-        {selectedValue === value ? value : children}
+        {selectedValue === value && displayValue !== undefined
+          ? displayValue
+          : children}
       </option>
     )
   },

--- a/examples/react/reusable-styled-form-component/src/Select.tsx
+++ b/examples/react/reusable-styled-form-component/src/Select.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react'
+
+import { cx } from './utils'
+
+type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement> & {
+  className?: string
+  displayValue?: boolean
+  value: string
+}
+
+type SelectOptionGroupProps = React.OptgroupHTMLAttributes<HTMLOptGroupElement>
+
+type SelectOptionProps = React.OptionHTMLAttributes<HTMLOptionElement> & {
+  value: string
+}
+
+type SelectComponentProps = React.ForwardRefExoticComponent<SelectProps> & {
+  OptionGroup: React.FC<SelectOptionGroupProps>
+  Option: React.FC<SelectOptionProps>
+}
+
+const SelectContext = React.createContext<SelectProps['value']>('')
+
+const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, value, displayValue = false, ...props }, ref) => {
+    return (
+      <SelectContext.Provider value={displayValue ? value : ''}>
+        <select
+          className={cx(
+            'h-10 w-full cursor-pointer rounded-md border border-secondary-200 bg-background fill-accent stroke-accent px-3 py-2 text-sm transition-border focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:border-primary disabled:cursor-not-allowed disabled:opacity-50 dark:border-secondary-700 focus-visible:dark:border-primary',
+            className,
+          )}
+          ref={ref}
+          {...props}
+        />
+      </SelectContext.Provider>
+    )
+  },
+) as SelectComponentProps
+
+Select.displayName = 'Select'
+
+Select.OptionGroup = React.forwardRef<
+  HTMLOptGroupElement,
+  SelectOptionGroupProps
+>(({ ...props }, ref) => {
+  return <optgroup ref={ref} {...props} />
+})
+
+Select.OptionGroup.displayName = 'Select.OptionGroup'
+
+Select.Option = React.forwardRef<HTMLOptionElement, SelectOptionProps>(
+  ({ children, value, ...props }, ref) => {
+    const selectedValue = React.useContext(SelectContext)
+    return (
+      <option value={value} ref={ref} {...props}>
+        {selectedValue === value ? value : children}
+      </option>
+    )
+  },
+)
+
+Select.Option.displayName = 'Select.Option'
+
+export {
+  Select,
+  type SelectProps,
+  type SelectOptionGroupProps,
+  type SelectOptionProps,
+}

--- a/examples/react/reusable-styled-form-component/src/index.css
+++ b/examples/react/reusable-styled-form-component/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/examples/react/reusable-styled-form-component/src/index.css
+++ b/examples/react/reusable-styled-form-component/src/index.css
@@ -1,3 +1,14 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  input:-webkit-autofill,
+  input:-webkit-autofill:hover,
+  input:-webkit-autofill:focus,
+  input:-webkit-autofill:active {
+    -webkit-box-shadow: 0 0 0 30px theme('colors.yellow.500') inset !important;
+    box-shadow: 0 0 0 30px theme('colors.yellow.500') inset !important;
+    transition: background-color 500ms ease-in-out 0s;
+  }
+}

--- a/examples/react/reusable-styled-form-component/src/index.tsx
+++ b/examples/react/reusable-styled-form-component/src/index.tsx
@@ -1,8 +1,173 @@
 import * as React from 'react'
 import { createRoot } from 'react-dom/client'
-import { Form } from './Form'
+import {
+  getCountries,
+  getCountryCallingCode,
+  isValidPhoneNumber,
+  formatPhoneNumberIntl,
+} from 'react-phone-number-input'
+import en from 'react-phone-number-input/locale/en'
 import { z } from 'zod'
+
+import { Form } from './Form'
 import { Select } from './Select'
+
+function Username({ useStore }) {
+  const submissionAttempts = useStore((state) => state.submissionAttempts)
+
+  function checkUsernameTaken(username) {
+    return new Promise<void>((resolve, reject) => {
+      const isTaken = [
+        'NoobMaster69',
+        'RickAstley',
+        'Michael',
+        'Tanner',
+      ].includes(username)
+      if (isTaken) {
+        reject(`The username ${username} is already taken`)
+      } else {
+        resolve()
+      }
+    })
+  }
+
+  return (
+    <Form.Field
+      name="username"
+      validators={
+        submissionAttempts !== 0 && {
+          onChange: z
+            .string()
+            .min(3, "Username can't be less than 3 characters"),
+          onChangeAsyncDebounceMs: 500,
+          onChangeAsync: async ({ value }) => {
+            await checkUsernameTaken(value)
+          },
+        }
+      }
+      children={(field) => (
+        <div className="relative">
+          <Form.Field.Text
+            field={field}
+            hasErrorField
+            label="Username"
+            autoComplete="name"
+            maxLength={30}
+          />
+          <Form.Field.Error field={field} />
+        </div>
+      )}
+    />
+  )
+}
+
+function Phone({ useStore }) {
+  const submissionAttempts = useStore((state) => state.submissionAttempts)
+  const countryCode = getCountryCallingCode(
+    useStore((state) => state.values.country),
+  )
+  return (
+    <div className="relative flex">
+      <Form.Field
+        name="country"
+        children={(field) => (
+          <Form.Field.Select className="rounded-r-none w-20" field={field}>
+            <Select.OptionGroup label="Country code" />
+            {getCountries().map((country) => (
+              <Select.Option
+                key={country}
+                value={country}
+                displayValue={'+' + getCountryCallingCode(country)}
+              >
+                {en[country]} +{getCountryCallingCode(country)}
+              </Select.Option>
+            ))}
+          </Form.Field.Select>
+        )}
+      />
+      <Form.Field
+        name="phoneNumber"
+        validators={
+          submissionAttempts !== 0 && {
+            onChange: z
+              .string()
+              .refine(
+                (value) => isValidPhoneNumber('+' + countryCode + value),
+                'Invalid phone number',
+              ),
+          }
+        }
+        children={(field) => (
+          <div className="relative w-full">
+            <Form.Field.Text
+              className="rounded-l-none"
+              field={field}
+              hasErrorField
+              label="Phone Number"
+              type="tel"
+              autoComplete="tel"
+              maxLength={20}
+              onChange={(e) => {
+                const phoneNumberValue = e.target.value.replace(
+                  /[^0-9\s()+-]/g,
+                  '',
+                )
+                field.handleChange(phoneNumberValue)
+              }}
+            />
+            <Form.Field.Error field={field} />
+          </div>
+        )}
+      />
+    </div>
+  )
+}
+
+function Password({ useStore }) {
+  const submissionAttempts = useStore((state) => state.submissionAttempts)
+  const showPassword = useStore((state) => state.values.showPassword)
+  return (
+    <>
+      <Form.Field
+        name="password"
+        validators={
+          submissionAttempts !== 0 && {
+            onChange: z
+              .string()
+              .min(9, "Password can't be less than 9 characters")
+              .max(20, "Password can't be more than 20 characters")
+              .refine(
+                (value) => /[A-Z]/.test(value),
+                'Password must include a capital letter',
+              )
+              .refine(
+                (value) => /\d/.test(value),
+                'Password must include a number',
+              ),
+          }
+        }
+        children={(field) => (
+          <div className="relative">
+            <Form.Field.Text
+              field={field}
+              hasErrorField
+              label="Password"
+              autoComplete="password"
+              type={showPassword ? 'text' : 'password'}
+            />
+            <Form.Field.Error field={field} />
+          </div>
+        )}
+      />
+      <Form.Field
+        name="showPassword"
+        children={(field) => (
+          <Form.Field.Checkbox field={field} label="Show Password" />
+        )}
+      />
+    </>
+  )
+}
 
 export default function App() {
   return (
@@ -12,141 +177,34 @@ export default function App() {
         formOptions={{
           defaultValues: {
             username: '',
-            countryCode: '+1',
+            country: 'US',
             phoneNumber: '',
             password: '',
             showPassword: false,
           },
+          onSubmit: (form) => {
+            const submitValues = {
+              username: form.value.username,
+              phone: formatPhoneNumberIntl(
+                '+' +
+                  getCountryCallingCode(form.value.country) +
+                  form.value.phoneNumber,
+              ),
+              password: form.value.password,
+            }
+            console.log(submitValues)
+            alert(JSON.stringify(submitValues, null, 2))
+          },
         }}
       >
-        {(useStore, reset) => (
+        {(useStore) => (
           <>
-            <Form.Field
-              name="username"
-              children={(field) => {
-                return (
-                  <Form.Field.Text
-                    field={field}
-                    label="Username"
-                    autoComplete="name"
-                    maxLength={30}
-                  />
-                )
-              }}
-            />
-            <div className="relative flex">
-              <Form.Field
-                name="countryCode"
-                children={(field) => {
-                  return (
-                    <Form.Field.Select
-                      className="rounded-r-none w-20"
-                      field={field}
-                      displayValue
-                    >
-                      <Select.OptionGroup label="Country code" />
-                      <Select.Option value="+1">+1 United States</Select.Option>
-                      <Select.Option value="+44">
-                        +44 United Kingdom
-                      </Select.Option>
-                      <Select.Option value="+49">+49 Germany</Select.Option>
-                      <Select.Option value="+47">+47 Norway</Select.Option>
-                    </Form.Field.Select>
-                  )
-                }}
-              />
-              <Form.Field
-                name="phoneNumber"
-                validators={{}}
-                children={(field) => {
-                  return (
-                    <div className="relative w-full">
-                      <Form.Field.Text
-                        className="rounded-l-none"
-                        field={field}
-                        label="Phone Number"
-                        type="tel"
-                        autoComplete="tel"
-                        maxLength={20}
-                        onChange={(e) => {
-                          const phoneNumberValue = e.target.value.replace(
-                            /[^0-9\s()+-]/g,
-                            '',
-                          )
-                          field.handleChange(phoneNumberValue)
-                        }}
-                      />
-                      <Form.Field.Error field={field} />
-                    </div>
-                  )
-                }}
-              />
-            </div>
-            <Form.Field
-              name="password"
-              validators={
-                useStore((state) => state.submissionAttempts) !== 0 && {
-                  onChange: z
-                    .string()
-                    .min(9, "Password can't be less than 9 characters")
-                    .max(20, "Password can't be more than 20 characters")
-                    .refine(
-                      (value) => /[A-Z]/.test(value),
-                      'Password must include a capital letter',
-                    )
-                    .refine(
-                      (value) => /\d/.test(value),
-                      'Password must include a number',
-                    ),
-                }
-              }
-              children={(field) => {
-                return (
-                  <div className="relative">
-                    <Form.Field.Text
-                      field={field}
-                      label="Password"
-                      type={
-                        useStore((state) => state.values.showPassword)
-                          ? 'text'
-                          : 'password'
-                      }
-                    />
-                    <Form.Field.Error field={field} />
-                  </div>
-                )
-              }}
-            />
-            <Form.Field
-              name="showPassword"
-              children={(field) => {
-                return (
-                  <Form.Field.Checkbox field={field} label="Show Password" />
-                )
-              }}
-            />
+            <Username useStore={useStore} />
+            <Phone useStore={useStore} />
+            <Password useStore={useStore} />
             <div className="flex justify-between items-center">
-              <Form.Subscribe selector={(state) => state}>
-                {(state) => (
-                  <Form.Subscribe.Button
-                    className="text-blue-500 dark:text-blue-500"
-                    state={state}
-                    disabled={state.submissionAttempts === 0}
-                    onClick={() => reset()}
-                    variant="ghost"
-                    size="xs"
-                  >
-                    Reset
-                  </Form.Subscribe.Button>
-                )}
-              </Form.Subscribe>
-              <Form.Subscribe selector={(state) => state}>
-                {(state) => (
-                  <Form.Subscribe.Button state={state}>
-                    Submit
-                  </Form.Subscribe.Button>
-                )}
-              </Form.Subscribe>
+              <Form.ResetButton>Reset</Form.ResetButton>
+              <Form.SubmitButton>Submit</Form.SubmitButton>
             </div>
           </>
         )}

--- a/examples/react/reusable-styled-form-component/src/index.tsx
+++ b/examples/react/reusable-styled-form-component/src/index.tsx
@@ -19,7 +19,7 @@ export default function App() {
           },
         }}
       >
-        {(useStore) => (
+        {(useStore, reset) => (
           <>
             <Form.Field
               name="username"
@@ -44,16 +44,13 @@ export default function App() {
                       field={field}
                       displayValue
                     >
-                      <Select.OptionGroup label="Country code">
-                        <Select.Option value="+1">
-                          +1 United States
-                        </Select.Option>
-                        <Select.Option value="+44">
-                          +44 United Kingdom
-                        </Select.Option>
-                        <Select.Option value="+49">+49 Germany</Select.Option>
-                        <Select.Option value="+47">+47 Norway</Select.Option>
-                      </Select.OptionGroup>
+                      <Select.OptionGroup label="Country code" />
+                      <Select.Option value="+1">+1 United States</Select.Option>
+                      <Select.Option value="+44">
+                        +44 United Kingdom
+                      </Select.Option>
+                      <Select.Option value="+49">+49 Germany</Select.Option>
+                      <Select.Option value="+47">+47 Norway</Select.Option>
                     </Form.Field.Select>
                   )
                 }}
@@ -128,8 +125,29 @@ export default function App() {
                 )
               }}
             />
-
-            <button>submit</button>
+            <div className="flex justify-between items-center">
+              <Form.Subscribe selector={(state) => state}>
+                {(state) => (
+                  <Form.Subscribe.Button
+                    className="text-blue-500 dark:text-blue-500"
+                    state={state}
+                    disabled={state.submissionAttempts === 0}
+                    onClick={() => reset()}
+                    variant="ghost"
+                    size="xs"
+                  >
+                    Reset
+                  </Form.Subscribe.Button>
+                )}
+              </Form.Subscribe>
+              <Form.Subscribe selector={(state) => state}>
+                {(state) => (
+                  <Form.Subscribe.Button state={state}>
+                    Submit
+                  </Form.Subscribe.Button>
+                )}
+              </Form.Subscribe>
+            </div>
           </>
         )}
       </Form>

--- a/examples/react/reusable-styled-form-component/src/index.tsx
+++ b/examples/react/reusable-styled-form-component/src/index.tsx
@@ -19,82 +19,119 @@ export default function App() {
           },
         }}
       >
-        <Form.Field
-          name="username"
-          children={(field) => {
-            return <Form.Field.Text field={field} label="Username" />
-          }}
-        />
-        <div className="relative flex">
-          <Form.Field
-            name="countryCode"
-            children={(field) => {
-              return (
-                <Form.Field.Select
-                  className="rounded-r-none w-20"
-                  field={field}
-                  displayValue
-                >
-                  <Select.OptionGroup label="Country code">
-                    <Select.Option value="+1">+1 United States</Select.Option>
-                    <Select.Option value="+44">
-                      +44 United Kingdom
-                    </Select.Option>
-                    <Select.Option value="+49">+49 Germany</Select.Option>
-                    <Select.Option value="+47">+47 Norway</Select.Option>
-                  </Select.OptionGroup>
-                </Form.Field.Select>
-              )
-            }}
-          />
-          <Form.Field
-            name="phoneNumber"
-            validators={{}}
-            children={(field) => {
-              return (
-                <div className="relative w-full">
+        {(useStore) => (
+          <>
+            <Form.Field
+              name="username"
+              children={(field) => {
+                return (
                   <Form.Field.Text
-                    className="rounded-l-none"
                     field={field}
-                    label="Phone Number"
+                    label="Username"
+                    autoComplete="name"
+                    maxLength={30}
                   />
-                  <Form.Field.Error field={field} />
-                </div>
-              )
-            }}
-          />
-        </div>
-        <Form.Field
-          name="password"
-          validators={{
-            onChange: z
-              .string()
-              .min(9, "Password can't be less than 9 characters")
-              .max(20, "Password can't be more than 20 characters")
-              .refine(
-                (value) => /[A-Z]/.test(value),
-                'Password must include a capital letter',
-              )
-              .refine(
-                (value) => /\d/.test(value),
-                'Password must include a number',
-              ),
-          }}
-          children={(field) => {
-            return (
-              <div className="relative">
-                <Form.Field.Text field={field} label="Password" />
-                <Form.Field.Error field={field} />
-              </div>
-            )
-          }}
-        />
-        <Form.Field
-          name="showPassword"
-          children={(field) => {
-            return <Form.Field.Checkbox field={field} label="Show Password" />
-          }}
-        />
+                )
+              }}
+            />
+            <div className="relative flex">
+              <Form.Field
+                name="countryCode"
+                children={(field) => {
+                  return (
+                    <Form.Field.Select
+                      className="rounded-r-none w-20"
+                      field={field}
+                      displayValue
+                    >
+                      <Select.OptionGroup label="Country code">
+                        <Select.Option value="+1">
+                          +1 United States
+                        </Select.Option>
+                        <Select.Option value="+44">
+                          +44 United Kingdom
+                        </Select.Option>
+                        <Select.Option value="+49">+49 Germany</Select.Option>
+                        <Select.Option value="+47">+47 Norway</Select.Option>
+                      </Select.OptionGroup>
+                    </Form.Field.Select>
+                  )
+                }}
+              />
+              <Form.Field
+                name="phoneNumber"
+                validators={{}}
+                children={(field) => {
+                  return (
+                    <div className="relative w-full">
+                      <Form.Field.Text
+                        className="rounded-l-none"
+                        field={field}
+                        label="Phone Number"
+                        type="tel"
+                        autoComplete="tel"
+                        maxLength={20}
+                        onChange={(e) => {
+                          const phoneNumberValue = e.target.value.replace(
+                            /[^0-9\s()+-]/g,
+                            '',
+                          )
+                          field.handleChange(phoneNumberValue)
+                        }}
+                      />
+                      <Form.Field.Error field={field} />
+                    </div>
+                  )
+                }}
+              />
+            </div>
+            <Form.Field
+              name="password"
+              validators={
+                useStore((state) => state.submissionAttempts) !== 0 && {
+                  onChange: z
+                    .string()
+                    .min(9, "Password can't be less than 9 characters")
+                    .max(20, "Password can't be more than 20 characters")
+                    .refine(
+                      (value) => /[A-Z]/.test(value),
+                      'Password must include a capital letter',
+                    )
+                    .refine(
+                      (value) => /\d/.test(value),
+                      'Password must include a number',
+                    ),
+                }
+              }
+              children={(field) => {
+                return (
+                  <div className="relative">
+                    <Form.Field.Text
+                      field={field}
+                      label="Password"
+                      type={
+                        useStore((state) => state.values.showPassword)
+                          ? 'text'
+                          : 'password'
+                      }
+                    />
+                    <Form.Field.Error field={field} />
+                  </div>
+                )
+              }}
+            />
+            <Form.Field
+              name="showPassword"
+              children={(field) => {
+                return (
+                  <Form.Field.Checkbox field={field} label="Show Password" />
+                )
+              }}
+            />
+
+            <button>submit</button>
+          </>
+        )}
       </Form>
     </div>
   )

--- a/examples/react/reusable-styled-form-component/src/index.tsx
+++ b/examples/react/reusable-styled-form-component/src/index.tsx
@@ -7,7 +7,7 @@ export default function App() {
   return (
     <div className="items-center justify-center flex h-full w-full">
       <Form
-        className="space-y-8 w-56"
+        className="space-y-8 w-72"
         formOptions={{
           defaultValues: {
             username: '',
@@ -28,15 +28,32 @@ export default function App() {
               .string()
               .min(9, "Password can't be less than 9 characters")
               .max(20, "Password can't be more than 20 characters")
-              .refine((value) => /[A-Z]/.test(value), {
-                message: 'Password must include a capital letter',
-              })
-              .refine((value) => /\d/.test(value), {
-                message: 'Password must include a number',
-              }),
+              .refine(
+                (value) => /[A-Z]/.test(value),
+                'Password must include a capital letter',
+              )
+              .refine(
+                (value) => /\d/.test(value),
+                'Password must include a number',
+              ),
           }}
           children={(field) => {
-            return <Form.Field.Text field={field} label="Password" />
+            return (
+              <Form.Field.Text field={field} label="Password">
+                <Form.Field.Error />
+              </Form.Field.Text>
+            )
+          }}
+        />
+
+        <Form.Field
+          name="showPassword"
+          children={(field) => {
+            return (
+              <Form.Field.Checkbox field={field} label="Show Password">
+                <Form.Field.Error />
+              </Form.Field.Checkbox>
+            )
           }}
         />
       </Form>

--- a/examples/react/reusable-styled-form-component/src/index.tsx
+++ b/examples/react/reusable-styled-form-component/src/index.tsx
@@ -1,10 +1,46 @@
 import * as React from 'react'
 import { createRoot } from 'react-dom/client'
+import { Form } from './Form'
 import { z } from 'zod'
 
 export default function App() {
   return (
-    <div className="items-center justify-center bg-red-500 h-full w-full"></div>
+    <div className="items-center justify-center flex h-full w-full">
+      <Form
+        className="space-y-8 w-56"
+        formOptions={{
+          defaultValues: {
+            username: '',
+            password: '',
+          },
+        }}
+      >
+        <Form.Field
+          name="username"
+          children={(field) => {
+            return <Form.Field.Text field={field} label="Username" />
+          }}
+        />
+        <Form.Field
+          name="password"
+          validators={{
+            onChange: z
+              .string()
+              .min(9, "Password can't be less than 9 characters")
+              .max(20, "Password can't be more than 20 characters")
+              .refine((value) => /[A-Z]/.test(value), {
+                message: 'Password must include a capital letter',
+              })
+              .refine((value) => /\d/.test(value), {
+                message: 'Password must include a number',
+              }),
+          }}
+          children={(field) => {
+            return <Form.Field.Text field={field} label="Password" />
+          }}
+        />
+      </Form>
+    </div>
   )
 }
 

--- a/examples/react/reusable-styled-form-component/src/index.tsx
+++ b/examples/react/reusable-styled-form-component/src/index.tsx
@@ -45,15 +45,10 @@ export default function App() {
             )
           }}
         />
-
         <Form.Field
           name="showPassword"
           children={(field) => {
-            return (
-              <Form.Field.Checkbox field={field} label="Show Password">
-                <Form.Field.Error />
-              </Form.Field.Checkbox>
-            )
+            return <Form.Field.Checkbox field={field} label="Show Password" />
           }}
         />
       </Form>

--- a/examples/react/reusable-styled-form-component/src/index.tsx
+++ b/examples/react/reusable-styled-form-component/src/index.tsx
@@ -2,16 +2,20 @@ import * as React from 'react'
 import { createRoot } from 'react-dom/client'
 import { Form } from './Form'
 import { z } from 'zod'
+import { Select } from './Select'
 
 export default function App() {
   return (
     <div className="items-center justify-center flex h-full w-full">
       <Form
-        className="space-y-8 w-72"
+        className="space-y-6 w-72"
         formOptions={{
           defaultValues: {
             username: '',
+            countryCode: '+1',
+            phoneNumber: '',
             password: '',
+            showPassword: false,
           },
         }}
       >
@@ -21,6 +25,45 @@ export default function App() {
             return <Form.Field.Text field={field} label="Username" />
           }}
         />
+        <div className="relative flex">
+          <Form.Field
+            name="countryCode"
+            children={(field) => {
+              return (
+                <Form.Field.Select
+                  className="rounded-r-none w-20"
+                  field={field}
+                  displayValue
+                >
+                  <Select.OptionGroup label="Country code">
+                    <Select.Option value="+1">+1 United States</Select.Option>
+                    <Select.Option value="+44">
+                      +44 United Kingdom
+                    </Select.Option>
+                    <Select.Option value="+49">+49 Germany</Select.Option>
+                    <Select.Option value="+47">+47 Norway</Select.Option>
+                  </Select.OptionGroup>
+                </Form.Field.Select>
+              )
+            }}
+          />
+          <Form.Field
+            name="phoneNumber"
+            validators={{}}
+            children={(field) => {
+              return (
+                <div className="relative w-full">
+                  <Form.Field.Text
+                    className="rounded-l-none"
+                    field={field}
+                    label="Phone Number"
+                  />
+                  <Form.Field.Error field={field} />
+                </div>
+              )
+            }}
+          />
+        </div>
         <Form.Field
           name="password"
           validators={{
@@ -39,9 +82,10 @@ export default function App() {
           }}
           children={(field) => {
             return (
-              <Form.Field.Text field={field} label="Password">
-                <Form.Field.Error />
-              </Form.Field.Text>
+              <div className="relative">
+                <Form.Field.Text field={field} label="Password" />
+                <Form.Field.Error field={field} />
+              </div>
             )
           }}
         />

--- a/examples/react/reusable-styled-form-component/src/index.tsx
+++ b/examples/react/reusable-styled-form-component/src/index.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+import { z } from 'zod'
+
+export default function App() {
+  return (
+    <div className="items-center justify-center bg-red-500 h-full w-full"></div>
+  )
+}
+
+const rootElement = document.getElementById('root')!
+
+createRoot(rootElement).render(<App />)

--- a/examples/react/reusable-styled-form-component/src/utils.ts
+++ b/examples/react/reusable-styled-form-component/src/utils.ts
@@ -1,0 +1,10 @@
+import { type VariantProps, defineConfig } from 'cva';
+import { twMerge } from 'tailwind-merge';
+
+const { cva, cx, compose } = defineConfig({
+  hooks: {
+    onComplete: (className) => twMerge(className),
+  },
+});
+
+export { cva, cx, compose, type VariantProps };

--- a/examples/react/reusable-styled-form-component/src/variants.ts
+++ b/examples/react/reusable-styled-form-component/src/variants.ts
@@ -7,6 +7,7 @@ const inputVariants = cva({
       text: 'flex h-10 w-full rounded-md bg-white dark:bg-black px-3 py-2 text-sm placeholder:text-gray-500',
       password:
         'flex h-10 w-full rounded-md bg-white dark:bg-black px-3 py-2 text-sm placeholder:text-gray-500',
+      tel: 'flex h-10 w-full rounded-md bg-white dark:bg-black px-3 py-2 text-sm placeholder:text-gray-500',
       checkbox:
         'h-4 w-4 cursor-pointer rounded-sm bg-white dark:bg-black transition-colors checked:border-blue-500 checked:bg-blue-500 checked:hover:bg-blue-500 checked:focus:bg-blue-500 checked:dark:border-blue-500',
       number:

--- a/examples/react/reusable-styled-form-component/src/variants.ts
+++ b/examples/react/reusable-styled-form-component/src/variants.ts
@@ -1,5 +1,34 @@
 import { type VariantProps, cva } from './utils'
 
+const buttonVariants = cva({
+  variants: {
+    base: {
+      true: 'relative inline-flex select-none items-center justify-center whitespace-nowrap rounded-md font-sora text-sm font-medium text-black dark:text-white transition-colors focus-visible:z-20 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 focus-visible:outline-blue-500 disabled:pointer-events-none disabled:opacity-50',
+    },
+    variant: {
+      primary:
+        'bg-blue-500 text-white dark:text-white transition duration-200 hover:-translate-y-1 hover:bg-blue-500/90 hover:shadow-lg hover:shadow-blue-600/90 focus-visible:-translate-y-1 focus-visible:bg-blue/90 focus-visible:shadow-lg focus-visible:shadow-blue-600/90',
+      secondary:
+        'bg-gray-500 text-white dark:text-white transition duration-200 hover:-translate-y-1 hover:bg-gray-500/90 hover:shadow-lg hover:shadow-gray-600/90 focus-visible:-translate-y-1 focus-visible:bg-gray-500/90 focus-visible:shadow-lg focus-visible:shadow-gray-600/90',
+      outline:
+        'border border-gray-300 bg-white dark:bg-black hover:bg-accent/50 focus-visible:bg-accent/50 dark:border-gray-700',
+      ghost:
+        'hover:bg-gray-200 focus-visible:bg-gray-200 hover:dark:bg-gray-800 focus-visible:dark:bg-gray-800',
+      opacity:
+        'opacity-75 transition-opacity hover:opacity-100 focus-visible:opacity-100',
+      link: 'underline-offset-4 hover:underline',
+    },
+    size: {
+      xs: 'h-6 px-2.5',
+      sm: 'h-8 p-1',
+      md: 'h-10 px-4 py-2',
+      icon: 'h-10 w-10',
+    },
+  },
+})
+
+type buttonVariantProps = VariantProps<typeof buttonVariants>
+
 const inputVariants = cva({
   base: 'peer select-none appearance-none border focus:ring-0 focus:ring-offset-0 border-gray-300 transition-colors focus-visible:border-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 focus-visible:dark:border-blue-500',
   variants: {
@@ -21,4 +50,9 @@ const inputVariants = cva({
 
 type inputVariantProps = VariantProps<typeof inputVariants>
 
-export { inputVariants, type inputVariantProps }
+export {
+  buttonVariants,
+  inputVariants,
+  type buttonVariantProps,
+  type inputVariantProps,
+}

--- a/examples/react/reusable-styled-form-component/src/variants.ts
+++ b/examples/react/reusable-styled-form-component/src/variants.ts
@@ -1,0 +1,23 @@
+import { type VariantProps, cva } from './utils'
+
+const inputVariants = cva({
+  base: 'peer select-none appearance-none border outline-none border-gray-300 transition-colors focus-visible:border-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 focus-visible:dark:border-blue-500',
+  variants: {
+    type: {
+      text: 'flex h-10 w-full rounded-md bg-white dark:bg-black px-3 py-2 text-sm placeholder:text-gray-500',
+      password:
+        'flex h-10 w-full rounded-md bg-white dark:bg-black px-3 py-2 text-sm placeholder:text-gray-500',
+      checkbox:
+        'h-4 w-4 cursor-pointer rounded-sm bg-white dark:bg-black transition-colors checked:border-blue-500 checked:bg-blue-500 checked:hover:bg-blue-500 checked:focus:bg-blue-500 checked:dark:border-blue-500',
+      number:
+        'flex h-10 w-full rounded-md bg-white dark:bg-black px-3 py-2 text-sm [appearance:textfield] placeholder:text-gray-500 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none',
+    },
+    invalid: {
+      true: 'border-red-500 focus-visible:border-red-500 dark:border-red-500 focus-visible:dark:border-red-500',
+    },
+  },
+})
+
+type inputVariantProps = VariantProps<typeof inputVariants>
+
+export { inputVariants, type inputVariantProps }

--- a/examples/react/reusable-styled-form-component/src/variants.ts
+++ b/examples/react/reusable-styled-form-component/src/variants.ts
@@ -1,7 +1,7 @@
 import { type VariantProps, cva } from './utils'
 
 const inputVariants = cva({
-  base: 'peer select-none appearance-none border outline-none border-gray-300 transition-colors focus-visible:border-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 focus-visible:dark:border-blue-500',
+  base: 'peer select-none appearance-none border focus:ring-0 focus:ring-offset-0 border-gray-300 transition-colors focus-visible:border-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 focus-visible:dark:border-blue-500',
   variants: {
     type: {
       text: 'flex h-10 w-full rounded-md bg-white dark:bg-black px-3 py-2 text-sm placeholder:text-gray-500',

--- a/examples/react/reusable-styled-form-component/tailwind.config.js
+++ b/examples/react/reusable-styled-form-component/tailwind.config.js
@@ -4,5 +4,5 @@ module.exports = {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [require('@tailwindcss/forms')],
 }

--- a/examples/react/reusable-styled-form-component/tailwind.config.js
+++ b/examples/react/reusable-styled-form-component/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./index.html', './src/**/*.{tsx,ts}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/examples/react/reusable-styled-form-component/tsconfig.json
+++ b/examples/react/reusable-styled-form-component/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "noEmit": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 3.6.1(@typescript-eslint/parser@6.4.1)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
       eslint-plugin-import:
         specifier: ^2.29.1
-        version: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+        version: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.0)(eslint@8.56.0)
       eslint-plugin-react:
         specifier: ^7.33.2
         version: 7.33.2(eslint@8.56.0)
@@ -161,13 +161,16 @@ importers:
         version: link:../../../packages/zod-form-adapter
       cva:
         specifier: 1.0.0-beta.1
-        version: 1.0.0-beta.1(typescript@5.2.2)
+        version: 1.0.0-beta.1
       react:
         specifier: ^18.0.0
         version: 18.2.0
       react-dom:
         specifier: ^18.0.0
         version: 18.2.0(react@18.2.0)
+      react-phone-number-input:
+        specifier: ^3.3.8
+        version: 3.3.9(react-dom@18.2.0)(react@18.2.0)
       zod:
         specifier: ^3.21.4
         version: 3.22.4
@@ -192,7 +195,7 @@ importers:
         version: 3.4.1
       vite:
         specifier: ^5.0.10
-        version: 5.0.10(@types/node@18.19.4)
+        version: 5.0.10
 
   examples/react/simple:
     dependencies:
@@ -4490,7 +4493,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.7)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.0.10(@types/node@18.19.4)
+      vite: 5.0.10
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5533,6 +5536,10 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /classnames@2.5.1:
+    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
+    dev: false
+
   /cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
     engines: {node: '>=8'}
@@ -5765,6 +5772,10 @@ packages:
       yaml: 1.10.2
     dev: false
 
+  /country-flag-icons@1.5.9:
+    resolution: {integrity: sha512-9jrjv2w7kRbqNtdtMdK2j3gmDIZzd5l9L2pZiQjF9J0mUcB+NKIGDNADTDHBEp8EQtjOkCOcciJGGSOpERdXPQ==}
+    dev: false
+
   /cross-spawn@5.1.0:
     resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
     dependencies:
@@ -5808,7 +5819,7 @@ packages:
       is-git-repository: 1.1.1
     dev: true
 
-  /cva@1.0.0-beta.1(typescript@5.2.2):
+  /cva@1.0.0-beta.1:
     resolution: {integrity: sha512-gznFqTgERU9q4wg7jfgqtt34+RUt9S5t0xDAAEuDwQEAXEgjdDkKXpLLNjwSxsB4Ln/sqWJEH7yhE8Ny0mxd0w==}
     peerDependencies:
       typescript: '>= 4.5.5 < 6'
@@ -5817,7 +5828,6 @@ packages:
         optional: true
     dependencies:
       clsx: 2.0.0
-      typescript: 5.2.2
     dev: false
 
   /damerau-levenshtein@1.0.8:
@@ -6368,7 +6378,7 @@ packages:
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.0(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.0)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -6408,7 +6418,7 @@ packages:
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.0)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.0)(eslint@8.56.0)
       fast-glob: 3.3.1
       get-tsconfig: 4.7.0
       is-core-module: 2.13.1
@@ -6431,7 +6441,7 @@ packages:
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.0)(eslint@8.56.0)
       fast-glob: 3.3.1
       get-tsconfig: 4.7.0
       is-core-module: 2.13.1
@@ -6503,7 +6513,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.0)(eslint@8.56.0):
     resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -7521,6 +7531,12 @@ packages:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
     dev: true
 
+  /input-format@0.3.9:
+    resolution: {integrity: sha512-99Gew2huiuYpNsyZoucauy5OT3oXEoWUeINGES4SlU74eFxbtYqNO+yEP6uKFhfB0UKTvq4gOC+6/3Oskru+IQ==}
+    dependencies:
+      prop-types: 15.8.1
+    dev: false
+
   /internal-slot@1.0.5:
     resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
     engines: {node: '>= 0.4'}
@@ -8290,6 +8306,10 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
     dev: true
+
+  /libphonenumber-js@1.10.54:
+    resolution: {integrity: sha512-P+38dUgJsmh0gzoRDoM4F5jLbyfztkU6PY6eSK6S5HwTi/LPvnwXqVCQZlAy1FxZ5c48q25QhxGQ0pq+WQcSlQ==}
+    dev: false
 
   /liftoff@4.0.0:
     resolution: {integrity: sha512-rMGwYF8q7g2XhG2ulBmmJgWv25qBsqRbDn5gH0+wnuyeFt7QBJlHJmtg5qEdn4pN6WVAUMgXnIxytMFRX9c1aA==}
@@ -9998,6 +10018,21 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /react-phone-number-input@3.3.9(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-TKK8VoFWR9RfPi90j/3Rr6j/S9V8/eovqUgNNNSyD0+WtaeLTlJVWb8DD7P57eZqkLv303sL8JMiZoExwKICxw==}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      classnames: 2.5.1
+      country-flag-icons: 1.5.9
+      input-format: 0.3.9
+      libphonenumber-js: 1.10.54
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /react-refresh@0.14.0:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
     engines: {node: '>=0.10.0'}
@@ -11418,6 +11453,7 @@ packages:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
     engines: {node: '>=14.17'}
     hasBin: true
+    dev: true
 
   /typescript@5.3.3:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
@@ -11737,6 +11773,41 @@ packages:
       vitefu: 0.2.5(vite@5.0.10)
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /vite@5.0.10:
+    resolution: {integrity: sha512-2P8J7WWgmc355HUMlFrwofacvr98DAjoE52BfdbwQtyLH06XKwaL/FMnmKM2crF0iX4MpmMKoDlNCB1ok7zHCw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.19.11
+      postcss: 8.4.32
+      rollup: 4.9.2
+    optionalDependencies:
+      fsevents: 2.3.3
     dev: true
 
   /vite@5.0.10(@types/node@18.19.4):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,7 +154,7 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1(react@18.2.0)
       '@tanstack/react-form':
-        specifier: <1.0.0
+        specifier: workspace:^
         version: link:../../../packages/react-form
       '@tanstack/zod-form-adapter':
         specifier: workspace:^

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 3.6.1(@typescript-eslint/parser@6.4.1)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
       eslint-plugin-import:
         specifier: ^2.29.1
-        version: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+        version: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.0)(eslint@8.56.0)
       eslint-plugin-react:
         specifier: ^7.33.2
         version: 7.33.2(eslint@8.56.0)
@@ -147,6 +147,46 @@ importers:
       typescript:
         specifier: ^5
         version: 5.2.2
+
+  examples/react/reusable-styled-form-component:
+    dependencies:
+      '@tanstack/react-form':
+        specifier: <1.0.0
+        version: link:../../../packages/react-form
+      '@tanstack/zod-form-adapter':
+        specifier: <1.0.0
+        version: link:../../../packages/zod-form-adapter
+      cva:
+        specifier: 1.0.0-beta.1
+        version: 1.0.0-beta.1(typescript@5.2.2)
+      react:
+        specifier: ^18.0.0
+        version: 18.2.0
+      react-dom:
+        specifier: ^18.0.0
+        version: 18.2.0(react@18.2.0)
+      zod:
+        specifier: ^3.21.4
+        version: 3.22.4
+    devDependencies:
+      '@vitejs/plugin-react':
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.10)
+      autoprefixer:
+        specifier: ^10.4.16
+        version: 10.4.16(postcss@8.4.32)
+      postcss:
+        specifier: 8.4.32
+        version: 8.4.32
+      tailwind-merge:
+        specifier: ^2.2.0
+        version: 2.2.0
+      tailwindcss:
+        specifier: ^3.4.1
+        version: 3.4.1
+      vite:
+        specifier: ^5.0.10
+        version: 5.0.10(@types/node@18.19.4)
 
   examples/react/simple:
     dependencies:
@@ -632,6 +672,11 @@ packages:
 
   /@adobe/css-tools@4.3.2:
     resolution: {integrity: sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==}
+    dev: true
+
+  /@alloc/quick-lru@5.2.0:
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
     dev: true
 
   /@ampproject/remapping@2.2.1:
@@ -4828,11 +4873,14 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
-    dev: false
 
   /appdirsjs@1.2.7:
     resolution: {integrity: sha512-Quji6+8kLBC3NnBeo14nPDq0+2jUs5s3/xEye+udFHumHhRk4M7aAMXp/PBJqkKYGuuyR9M/6Dq7d2AViiGmhw==}
     dev: false
+
+  /arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+    dev: true
 
   /argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -5029,6 +5077,22 @@ packages:
     dependencies:
       stubborn-fs: 1.2.5
       when-exit: 2.1.2
+    dev: true
+
+  /autoprefixer@10.4.16(postcss@8.4.32):
+    resolution: {integrity: sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+    dependencies:
+      browserslist: 4.22.2
+      caniuse-lite: 1.0.30001572
+      fraction.js: 4.3.7
+      normalize-range: 0.1.2
+      picocolors: 1.0.0
+      postcss: 8.4.32
+      postcss-value-parser: 4.2.0
     dev: true
 
   /available-typed-arrays@1.0.5:
@@ -5342,7 +5406,6 @@ packages:
   /camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
-    dev: false
 
   /camelcase-keys@8.0.2:
     resolution: {integrity: sha512-qMKdlOfsjlezMqxkUGGMaWWs17i2HoL15tM+wtx8ld4nLrUwU58TFdvyGOz/piNP842KeO8yXvggVQSdQ828NA==}
@@ -5421,6 +5484,21 @@ packages:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
     dependencies:
       get-func-name: 2.0.2
+    dev: true
+
+  /chokidar@3.5.3:
+    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
+    engines: {node: '>= 8.10.0'}
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.2
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
     dev: true
 
   /ci-info@2.0.0:
@@ -5540,6 +5618,11 @@ packages:
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: false
+
+  /commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+    dev: true
 
   /commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
@@ -5683,7 +5766,6 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: false
 
   /cssstyle@3.0.0:
     resolution: {integrity: sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==}
@@ -5702,6 +5784,18 @@ packages:
       execa: 0.6.3
       is-git-repository: 1.1.1
     dev: true
+
+  /cva@1.0.0-beta.1(typescript@5.2.2):
+    resolution: {integrity: sha512-gznFqTgERU9q4wg7jfgqtt34+RUt9S5t0xDAAEuDwQEAXEgjdDkKXpLLNjwSxsB4Ln/sqWJEH7yhE8Ny0mxd0w==}
+    peerDependencies:
+      typescript: '>= 4.5.5 < 6'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      clsx: 2.0.0
+      typescript: 5.2.2
+    dev: false
 
   /damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -5905,6 +5999,10 @@ packages:
     resolution: {integrity: sha512-/oD3At60ZfhgzpofJtyClNTrIACyMdRe+ih0YiHzAniN0IZnLdLpEzgR6RtGs3kowxUkTnvV/4t1FBxXMUdusQ==}
     dev: true
 
+  /didyoumean@1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+    dev: true
+
   /diff-sequences@26.6.2:
     resolution: {integrity: sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==}
     engines: {node: '>= 10.14.2'}
@@ -5920,6 +6018,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-type: 4.0.0
+    dev: true
+
+  /dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
     dev: true
 
   /doctrine@2.1.0:
@@ -6243,7 +6345,7 @@ packages:
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.0(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.0)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -6283,7 +6385,7 @@ packages:
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.0)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.0)(eslint@8.56.0)
       fast-glob: 3.3.1
       get-tsconfig: 4.7.0
       is-core-module: 2.13.1
@@ -6306,7 +6408,7 @@ packages:
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.0)(eslint@8.56.0)
       fast-glob: 3.3.1
       get-tsconfig: 4.7.0
       is-core-module: 2.13.1
@@ -6378,7 +6480,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.0)(eslint@8.56.0):
     resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -6868,6 +6970,10 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+    dev: true
+
+  /fraction.js@4.3.7:
+    resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
     dev: true
 
   /fresh@0.5.2:
@@ -7917,6 +8023,11 @@ packages:
       supports-color: 8.1.1
     dev: false
 
+  /jiti@1.21.0:
+    resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
+    hasBin: true
+    dev: true
+
   /jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
     dev: true
@@ -8169,6 +8280,16 @@ packages:
       object.map: 1.0.1
       rechoir: 0.8.0
       resolve: 1.22.4
+    dev: true
+
+  /lilconfig@2.1.0:
+    resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /lilconfig@3.0.0:
+    resolution: {integrity: sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==}
+    engines: {node: '>=14'}
     dev: true
 
   /lines-and-columns@1.2.4:
@@ -8842,6 +8963,14 @@ packages:
     resolution: {integrity: sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==}
     dev: true
 
+  /mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+    dev: true
+
   /nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -8979,7 +9108,11 @@ packages:
   /normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
-    dev: false
+
+  /normalize-range@0.1.2:
+    resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
 
   /npm-bundled@2.0.1:
     resolution: {integrity: sha512-gZLxXdjEzE/+mOstGDqR6b0EkhJ+kM6fxM6vUuckuctuVPh80Q6pw/rSZj9s4Gex9GxWtIicO1pc8DB9KZWudw==}
@@ -9102,6 +9235,11 @@ packages:
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  /object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+    dev: true
 
   /object-inspect@1.12.3:
     resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
@@ -9468,6 +9606,11 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  /pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
@@ -9483,7 +9626,6 @@ packages:
   /pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
-    dev: false
 
   /pkg-dir@3.0.0:
     resolution: {integrity: sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==}
@@ -9500,6 +9642,18 @@ packages:
       pathe: 1.1.1
     dev: true
 
+  /postcss-import@15.1.0(postcss@8.4.32):
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+    dependencies:
+      postcss: 8.4.32
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.4
+    dev: true
+
   /postcss-js@4.0.1(postcss@8.4.32):
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
     engines: {node: ^12 || ^14 || >= 16}
@@ -9508,7 +9662,23 @@ packages:
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.4.32
-    dev: false
+
+  /postcss-load-config@4.0.2(postcss@8.4.32):
+    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 3.0.0
+      postcss: 8.4.32
+      yaml: 2.3.4
+    dev: true
 
   /postcss-mixins@9.0.4(postcss@8.4.32):
     resolution: {integrity: sha512-XVq5jwQJDRu5M1XGkdpgASqLk37OqkH4JCFDXl/Dn7janOJjCTEKL+36cnRVy7bMtoBzALfO7bV7nTIsFnUWLA==}
@@ -9531,7 +9701,6 @@ packages:
     dependencies:
       postcss: 8.4.32
       postcss-selector-parser: 6.0.15
-    dev: false
 
   /postcss-preset-mantine@1.12.2(postcss@8.4.32):
     resolution: {integrity: sha512-a7W/lDSeMg/LeOKb/PNKp+pVzYSSxxWFHGihnwRBEGzeY0qCZnPluH5KsJMfxqbElcf5zoiXZIyElzI/0KmgjA==}
@@ -9549,7 +9718,6 @@ packages:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-    dev: false
 
   /postcss-simple-vars@7.0.1(postcss@8.4.32):
     resolution: {integrity: sha512-5GLLXaS8qmzHMOjVxqkk1TZPf1jMqesiI7qLhnlyERalG0sMbHIbJqrcnrpmZdKCLglHnRHoEBB61RtGTsj++A==}
@@ -9559,6 +9727,10 @@ packages:
     dependencies:
       postcss: 8.4.32
     dev: false
+
+  /postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+    dev: true
 
   /postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -9904,6 +10076,12 @@ packages:
     dependencies:
       loose-envify: 1.4.0
 
+  /read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+    dependencies:
+      pify: 2.3.0
+    dev: true
+
   /read-pkg-up@9.1.0:
     resolution: {integrity: sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -9941,6 +10119,13 @@ packages:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  /readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+    dependencies:
+      picomatch: 2.3.1
+    dev: true
 
   /readline@1.3.0:
     resolution: {integrity: sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg==}
@@ -10741,6 +10926,20 @@ packages:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
     dev: false
 
+  /sucrase@3.35.0:
+    resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.3
+      commander: 4.1.1
+      glob: 10.3.10
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.6
+      ts-interface-checker: 0.1.13
+    dev: true
+
   /sudo-prompt@9.2.1:
     resolution: {integrity: sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==}
     dev: false
@@ -10784,6 +10983,43 @@ packages:
   /tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
     dev: false
+
+  /tailwind-merge@2.2.0:
+    resolution: {integrity: sha512-SqqhhaL0T06SW59+JVNfAqKdqLs0497esifRrZ7jOaefP3o64fdFNDMrAQWZFMxTLJPiHVjRLUywT8uFz1xNWQ==}
+    dependencies:
+      '@babel/runtime': 7.23.7
+    dev: true
+
+  /tailwindcss@3.4.1:
+    resolution: {integrity: sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.5.3
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.1
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.0
+      lilconfig: 2.1.0
+      micromatch: 4.0.5
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.32
+      postcss-import: 15.1.0(postcss@8.4.32)
+      postcss-js: 4.0.1(postcss@8.4.32)
+      postcss-load-config: 4.0.2(postcss@8.4.32)
+      postcss-nested: 6.0.1(postcss@8.4.32)
+      postcss-selector-parser: 6.0.15
+      resolve: 1.22.4
+      sucrase: 3.35.0
+    transitivePeerDependencies:
+      - ts-node
+    dev: true
 
   /tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
@@ -10835,6 +11071,19 @@ packages:
 
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+    dev: true
+
+  /thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+    dependencies:
+      thenify: 3.3.1
+    dev: true
+
+  /thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+    dependencies:
+      any-promise: 1.3.0
     dev: true
 
   /throat@5.0.0:
@@ -11021,6 +11270,10 @@ packages:
       typescript: 5.3.3
     dev: true
 
+  /ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+    dev: true
+
   /tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
     dependencies:
@@ -11137,7 +11390,6 @@ packages:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
 
   /typescript@5.3.3:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
@@ -11901,6 +12153,11 @@ packages:
     resolution: {integrity: sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==}
     engines: {node: '>= 14'}
     dev: false
+
+  /yaml@2.3.4:
+    resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}
+    engines: {node: '>= 14'}
+    dev: true
 
   /yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,10 +154,10 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1(react@18.2.0)
       '@tanstack/react-form':
-        specifier: workspace:^
+        specifier: <1.0.0
         version: link:../../../packages/react-form
       '@tanstack/zod-form-adapter':
-        specifier: workspace:^
+        specifier: <1.0.0
         version: link:../../../packages/zod-form-adapter
       cva:
         specifier: 1.0.0-beta.1
@@ -172,6 +172,9 @@ importers:
         specifier: ^3.21.4
         version: 3.22.4
     devDependencies:
+      '@tailwindcss/forms':
+        specifier: ^0.5.7
+        version: 0.5.7(tailwindcss@3.4.1)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
         version: 4.2.1(vite@5.0.10)
@@ -3824,6 +3827,15 @@ packages:
 
   /@swc/types@0.1.5:
     resolution: {integrity: sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==}
+    dev: true
+
+  /@tailwindcss/forms@0.5.7(tailwindcss@3.4.1):
+    resolution: {integrity: sha512-QE7X69iQI+ZXwldE+rzasvbJiyV/ju1FGHH0Qn2W3FKbuYtqp8LKcy6iSw79fVUT5/Vvf+0XgLCeYVG+UV6hOw==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1'
+    dependencies:
+      mini-svg-data-uri: 1.4.4
+      tailwindcss: 3.4.1
     dev: true
 
   /@tanstack/config@0.1.8(@types/node@18.19.4)(esbuild@0.19.11)(typescript@5.2.2)(vite@5.0.10):
@@ -8888,6 +8900,11 @@ packages:
   /min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+    dev: true
+
+  /mini-svg-data-uri@1.4.4:
+    resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
+    hasBin: true
     dev: true
 
   /minimatch@3.0.5:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
 
   examples/react/reusable-styled-form-component:
     dependencies:
+      '@heroicons/react':
+        specifier: ^2.1.1
+        version: 2.1.1(react@18.2.0)
       '@tanstack/react-form':
         specifier: <1.0.0
         version: link:../../../packages/react-form
@@ -2626,6 +2629,14 @@ packages:
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
     dependencies:
       '@hapi/hoek': 9.3.0
+    dev: false
+
+  /@heroicons/react@2.1.1(react@18.2.0):
+    resolution: {integrity: sha512-JyyN9Lo66kirbCMuMMRPtJxtKJoIsXKS569ebHGGRKbl8s4CtUfLnyKJxteA+vIKySocO4s1SkTkGS4xtG/yEA==}
+    peerDependencies:
+      react: '>= 16'
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /@humanwhocodes/config-array@0.11.13:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 3.6.1(@typescript-eslint/parser@6.4.1)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
       eslint-plugin-import:
         specifier: ^2.29.1
-        version: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.0)(eslint@8.56.0)
+        version: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-react:
         specifier: ^7.33.2
         version: 7.33.2(eslint@8.56.0)
@@ -157,7 +157,7 @@ importers:
         specifier: <1.0.0
         version: link:../../../packages/react-form
       '@tanstack/zod-form-adapter':
-        specifier: <1.0.0
+        specifier: workspace:^
         version: link:../../../packages/zod-form-adapter
       cva:
         specifier: 1.0.0-beta.1
@@ -6356,7 +6356,7 @@ packages:
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.0(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -6396,7 +6396,7 @@ packages:
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.0)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.1
       get-tsconfig: 4.7.0
       is-core-module: 2.13.1
@@ -6419,7 +6419,7 @@ packages:
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.1
       get-tsconfig: 4.7.0
       is-core-module: 2.13.1
@@ -6491,7 +6491,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.0)(eslint@8.56.0):
+  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
     engines: {node: '>=4'}
     peerDependencies:


### PR DESCRIPTION
This is currently a WIP. Please close the pull request if you feel like this addition is unnecessary, I don't want to waste anybody's time. 

### Current issues
Current issues I have been unable to solve and need help with (there may be more, and I will add them if I remember):
- Typescript types for the Reusable Form Component. I have looked through the type definitions but no matter how I define them I can't get them to work. Right now I have set them all to `any` for the time being.
- Updating validation of a field when another field is updated. In the example, I want the validation of the `phoneNumber` field to re-trigger when the `country` field is updated. This is because the validation of the phone number is based on which country is selected.
- Adding a minor delay to the removal of validation error messages so that it has time to do the opacity animation. I can implement this in the `<Form.Field.Error>` with `useEffect` and `setTimeout`, but maybe there is a better solution.

### Use case
I feel like creating a component like this can be useful for big applications that have many forms. It can be argued for that it is unnecessary because you can create the components separately from the Form logic, but there is still a lot of boilerplate that a solutions like this removes.

### Additions
- If you feel like it is needed I can also add a radio menu component to the reusable form component, but as it is mostly meant to be an example of an approach on a way to use Tanstack Form. I don't feel like it is necessary.
- The styles I have added in the example works in both dark mode and light mode. Which is currently set based on the system preferred theme. Should I add a button to toggle it?

Here is a screenshot of the example, keep in mind that the validation is triggered only after the first submit:
![Localhost](https://github.com/TanStack/form/assets/56915010/b5dbfe3d-b1b2-4bdd-981b-e65a3acb44c8)
