### PR TITLE
Expose useFormContext

### DIFF
--- a/packages/react-form/src/index.ts
+++ b/packages/react-form/src/index.ts
@@ -27,6 +27,7 @@ export { useForm } from './useForm'
 
 export type { UseField, FieldComponent } from './useField'
 export { useField, Field } from './useField'
+export { useFormContext } from './formContext'
 
 export type { FormFactory } from './createFormFactory'
 export { createFormFactory } from './createFormFactory'


### PR DESCRIPTION
Exposes the form context via the already made hook.

Stop prop drilling the `formAPI` down the tree.