### PR TITLE
Handle a bug in older versions of TypeScript (<5.1.6)

### DIFF
--- a/docs/framework/react/reference/formApi.md
+++ b/docs/framework/react/reference/formApi.md
@@ -32,3 +32,4 @@ When using `@tanstack/react-form`, the [core form API](../../reference/formApi) 
   }) => JSX.Element
   ```
   - A `Subscribe` function that allows you to listen and react to changes in the form's state. It's especially useful when you need to execute side effects or render specific components in response to state updates.
+      > Note that TypeScript `5.0.4` and older versions will incorrectly complain if the `selector` method doesn't return the form's full state (`state`). This is caused by a [bug in TypeScript](https://github.com/TanStack/form/pull/606#discussion_r1506715714), and you can safely ignore it with `//@ts-expect-error` directive.

--- a/packages/react-form/package.json
+++ b/packages/react-form/package.json
@@ -15,7 +15,7 @@
     "clean": "rimraf ./dist && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
     "test:types:versions49": "node ../../node_modules/typescript49/lib/tsc.js --project tsconfig.legacy.json",
-    "test:types:versions50": "node ../../node_modules/typescript50/lib/tsc.js",
+    "test:types:versions50": "node ../../node_modules/typescript50/lib/tsc.js --project tsconfig.50.json",
     "test:types:versions51": "node ../../node_modules/typescript51/lib/tsc.js",
     "test:types:versions52": "tsc",
     "test:types": "pnpm run \"/^test:types:versions.*/\"",

--- a/packages/react-form/src/useForm.tsx
+++ b/packages/react-form/src/useForm.tsx
@@ -22,6 +22,17 @@ declare module '@tanstack/form-core' {
       selector?: (state: NoInfer<FormState<TFormData>>) => TSelected,
     ) => TSelected
     Subscribe: <TSelected = NoInfer<FormState<TFormData>>>(props: {
+      /**
+      TypeScript versions <=5.0.4 have a bug that prevents
+      the type of the `TSelected` generic from being inferred
+      from the return type of this method.
+
+      In these versions, `TSelected` will fall back to the default
+      type (or `unknown` if that's not defined).
+
+      @see {@link https://github.com/TanStack/form/pull/606/files#r1506715714 | This discussion on GitHub for the details}
+      @see {@link https://github.com/microsoft/TypeScript/issues/52786 | The bug report in `microsoft/TypeScript`}
+      */
       selector?: (state: NoInfer<FormState<TFormData>>) => TSelected
       children: ((state: NoInfer<TSelected>) => ReactNode) | ReactNode
     }) => JSX.Element

--- a/packages/react-form/tsconfig.50.json
+++ b/packages/react-form/tsconfig.50.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/tests/**"]
+}


### PR DESCRIPTION
We run into a bug in older TypeScript versions in another PR. See [this discussion](https://github.com/TanStack/form/pull/606#discussion_r1506715714) for a detailed report and the solution we decided on.

**TODO**
- [x] ignore the react test files in 5.0.4
- [x] write a comment about it on the type definition [0]
- [x] mention it in the TypeScript docs page

[0] This is how the comment is rendered:

https://github.com/TanStack/form/assets/43729152/ecf52d2f-2ff9-4393-a9a6-c9e6ed3a9b45


