### PR TITLE
chore: Use tsconfig paths to improve local DX

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "namespace": "@tanstack",
   "devDependencies": {
     "@solidjs/testing-library": "^0.8.5",
-    "@tanstack/config": "^0.4.2",
+    "@tanstack/config": "^0.6.0",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.4.3",

--- a/packages/react-form/tsconfig.json
+++ b/packages/react-form/tsconfig.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "jsx": "react",
     "moduleResolution": "Bundler",
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
+    "paths": {
+      "@tanstack/form-core": ["../form-core/src"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "vite.config.ts"]
 }

--- a/packages/react-form/tsconfig.legacy.json
+++ b/packages/react-form/tsconfig.legacy.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react",
-    "moduleResolution": "Node"
+    "moduleResolution": "Node",
+    "paths": {
+      "@tanstack/form-core": ["../form-core/src"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["src/tests/**"]

--- a/packages/solid-form/tsconfig.json
+++ b/packages/solid-form/tsconfig.json
@@ -4,7 +4,10 @@
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
     "moduleResolution": "Bundler",
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
+    "paths": {
+      "@tanstack/form-core": ["../form-core/src"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "vite.config.ts"]
 }

--- a/packages/solid-form/tsconfig.legacy.json
+++ b/packages/solid-form/tsconfig.legacy.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "moduleResolution": "Node"
+    "moduleResolution": "Node",
+    "paths": {
+      "@tanstack/form-core": ["../form-core/src"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["src/tests/**"]

--- a/packages/valibot-form-adapter/tsconfig.json
+++ b/packages/valibot-form-adapter/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "moduleResolution": "Bundler",
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
+    "paths": {
+      "@tanstack/form-core": ["../form-core/src"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "vite.config.ts"]
 }

--- a/packages/valibot-form-adapter/tsconfig.legacy.json
+++ b/packages/valibot-form-adapter/tsconfig.legacy.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "moduleResolution": "Node"
+    "moduleResolution": "Node",
+    "paths": {
+      "@tanstack/form-core": ["../form-core/src"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["src/tests/**"]

--- a/packages/vue-form/tsconfig.json
+++ b/packages/vue-form/tsconfig.json
@@ -4,7 +4,10 @@
     "jsx": "preserve",
     "jsxImportSource": "vue",
     "moduleResolution": "Bundler",
-    "types": ["vitest/globals", "vue/jsx"]
+    "types": ["vitest/globals", "vue/jsx"],
+    "paths": {
+      "@tanstack/form-core": ["../form-core/src"]
+    }
   },
   "include": [
     "src/**/*.ts",

--- a/packages/vue-form/tsconfig.legacy.json
+++ b/packages/vue-form/tsconfig.legacy.json
@@ -4,7 +4,10 @@
     "jsx": "preserve",
     "jsxImportSource": "vue",
     "moduleResolution": "Node",
-    "types": ["vue/jsx"]
+    "types": ["vue/jsx"],
+    "paths": {
+      "@tanstack/form-core": ["../form-core/src"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["src/tests/**"]

--- a/packages/yup-form-adapter/tsconfig.json
+++ b/packages/yup-form-adapter/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "moduleResolution": "Bundler",
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
+    "paths": {
+      "@tanstack/form-core": ["../form-core/src"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "vite.config.ts"]
 }

--- a/packages/yup-form-adapter/tsconfig.legacy.json
+++ b/packages/yup-form-adapter/tsconfig.legacy.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "moduleResolution": "Node"
+    "moduleResolution": "Node",
+    "paths": {
+      "@tanstack/form-core": ["../form-core/src"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["src/tests/**"]

--- a/packages/zod-form-adapter/tsconfig.json
+++ b/packages/zod-form-adapter/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "moduleResolution": "Bundler",
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
+    "paths": {
+      "@tanstack/form-core": ["../form-core/src"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "vite.config.ts"]
 }

--- a/packages/zod-form-adapter/tsconfig.legacy.json
+++ b/packages/zod-form-adapter/tsconfig.legacy.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "moduleResolution": "Node"
+    "moduleResolution": "Node",
+    "paths": {
+      "@tanstack/form-core": ["../form-core/src"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["src/tests/**"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.8.5
         version: 0.8.5(@solidjs/router@0.8.3)(solid-js@1.7.12)
       '@tanstack/config':
-        specifier: ^0.4.2
-        version: 0.4.2(@types/node@18.19.4)(esbuild@0.19.11)(rollup@4.9.2)(typescript@5.2.2)(vite@5.0.12)
+        specifier: ^0.6.0
+        version: 0.6.0(@types/node@18.19.4)(esbuild@0.19.11)(rollup@4.9.2)(typescript@5.2.2)(vite@5.0.12)
       '@testing-library/jest-dom':
         specifier: ^6.1.5
         version: 6.1.6(@types/jest@26.0.24)(vitest@1.2.2)
@@ -966,17 +966,17 @@ packages:
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
 
-  /@commitlint/parse@18.6.0:
-    resolution: {integrity: sha512-Y/G++GJpATFw54O0jikc/h2ibyGHgghtPnwsOk3O/aU092ydJ5XEHYcd7xGNQYuLweLzQis2uEwRNk9AVIPbQQ==}
+  /@commitlint/parse@18.6.1:
+    resolution: {integrity: sha512-eS/3GREtvVJqGZrwAGRwR9Gdno3YcZ6Xvuaa+vUF8j++wsmxrA2En3n0ccfVO2qVOLJC41ni7jSZhQiJpMPGOQ==}
     engines: {node: '>=v18'}
     dependencies:
-      '@commitlint/types': 18.6.0
+      '@commitlint/types': 18.6.1
       conventional-changelog-angular: 7.0.0
       conventional-commits-parser: 5.0.0
     dev: true
 
-  /@commitlint/types@18.6.0:
-    resolution: {integrity: sha512-oavoKLML/eJa2rJeyYSbyGAYzTxQ6voG5oeX3OrxpfrkRWhJfm4ACnhoRf5tgiybx2MZ+EVFqC1Lw3W8/uwpZA==}
+  /@commitlint/types@18.6.1:
+    resolution: {integrity: sha512-gwRLBLra/Dozj2OywopeuHj2ac26gjGkz2cZ+86cTJOdtWfiRRr4+e77ZDAGc6MDWxaWheI+mAV5TLWWRwqrFg==}
     engines: {node: '>=v18'}
     dependencies:
       chalk: 4.1.2
@@ -2495,14 +2495,15 @@ packages:
     resolution: {integrity: sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==}
     dev: true
 
-  /@tanstack/config@0.4.2(@types/node@18.19.4)(esbuild@0.19.11)(rollup@4.9.2)(typescript@5.2.2)(vite@5.0.12):
-    resolution: {integrity: sha512-PHlybqEA/4cJmu5aB9Yw4/OmdBqQY8pMW9Q1f3IJymAj0hRcTTfVRHMeI9yvEEP9lO74FN2EhIAwsKiXQb+FkQ==}
+  /@tanstack/config@0.6.0(@types/node@18.19.4)(esbuild@0.19.11)(rollup@4.9.2)(typescript@5.2.2)(vite@5.0.12):
+    resolution: {integrity: sha512-ndVPsyXWZFz3RcpRF7q5L4Ol5zY+m1H2lAiufw+J4BrV09042PETU2OZAREYz88ZcLtu6p+LZAHKltmqrL8gDg==}
     engines: {node: '>=18'}
     hasBin: true
+    requiresBuild: true
     dependencies:
-      '@commitlint/parse': 18.6.0
+      '@commitlint/parse': 18.6.1
       chalk: 5.3.0
-      commander: 11.1.0
+      commander: 12.0.0
       current-git-branch: 1.1.0
       esbuild-register: 3.5.0(esbuild@0.19.11)
       git-log-parser: 1.2.0
@@ -2511,12 +2512,13 @@ packages:
       liftoff: 4.0.0
       luxon: 3.4.4
       minimist: 1.2.8
-      rollup-plugin-preserve-directives: 0.3.1(rollup@4.9.2)
+      rollup-plugin-preserve-directives: 0.4.0(rollup@4.9.2)
       semver: 7.6.0
       stream-to-array: 2.3.0
       v8flags: 4.0.1
       vite-plugin-dts: 3.7.2(@types/node@18.19.4)(rollup@4.9.2)(typescript@5.2.2)(vite@5.0.12)
       vite-plugin-externalize-deps: 0.8.0(vite@5.0.12)
+      vite-tsconfig-paths: 4.3.1(typescript@5.2.2)(vite@5.0.12)
     transitivePeerDependencies:
       - '@types/node'
       - esbuild
@@ -3726,6 +3728,7 @@ packages:
   /clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+    requiresBuild: true
     dev: true
 
   /clsx@2.0.0:
@@ -3774,9 +3777,9 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
-  /commander@11.1.0:
-    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
-    engines: {node: '>=16'}
+  /commander@12.0.0:
+    resolution: {integrity: sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==}
+    engines: {node: '>=18'}
     dev: true
 
   /commander@4.1.1:
@@ -4015,6 +4018,7 @@ packages:
 
   /defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+    requiresBuild: true
     dependencies:
       clone: 1.0.4
     dev: true
@@ -5139,6 +5143,10 @@ packages:
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
+    dev: true
+
+  /globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
     dev: true
 
   /gopd@1.0.1:
@@ -7547,11 +7555,12 @@ packages:
       glob: 10.3.10
     dev: true
 
-  /rollup-plugin-preserve-directives@0.3.1(rollup@4.9.2):
-    resolution: {integrity: sha512-Jn1gWU7G55A1sU6eFpXmwknfBasF0XbBzRqsE6nqrb/gun+mGV7nx++CwOSGPJQpFzFqvKm5U4XNKo3LTLi4Hg==}
+  /rollup-plugin-preserve-directives@0.4.0(rollup@4.9.2):
+    resolution: {integrity: sha512-gx4nBxYm5BysmEQS+e2tAMrtFxrGvk+Pe5ppafRibQi0zlW7VYAbEGk6IKDw9sJGPdFWgVTE0o4BU4cdG0Fylg==}
     peerDependencies:
       rollup: 2.x || 3.x || 4.x
     dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.9.2)
       magic-string: 0.30.5
       rollup: 4.9.2
     dev: true
@@ -8356,6 +8365,19 @@ packages:
       typescript: 5.2.2
     dev: true
 
+  /tsconfck@3.0.2(typescript@5.2.2):
+    resolution: {integrity: sha512-6lWtFjwuhS3XI4HsX4Zg0izOI3FU/AI9EGVlPEUMDIhvLPMD4wkiof0WCoDgW7qY+Dy198g4d9miAqUHWHFH6Q==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.2.2
+    dev: true
+
   /tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
     dependencies:
@@ -8740,6 +8762,23 @@ packages:
       vitefu: 0.2.5(vite@5.0.12)
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /vite-tsconfig-paths@4.3.1(typescript@5.2.2)(vite@5.0.12):
+    resolution: {integrity: sha512-cfgJwcGOsIxXOLU/nELPny2/LUD/lcf1IbfyeKTv2bsupVbTH/xpFtdQlBmIP1GEK2CjjLxYhFfB+QODFAx5aw==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      debug: 4.3.4
+      globrex: 0.1.2
+      tsconfck: 3.0.2(typescript@5.2.2)
+      vite: 5.0.12(@types/node@18.19.4)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
     dev: true
 
   /vite@5.0.12(@types/node@18.19.4):


### PR DESCRIPTION
- "Go to source" will now take you to the source `.ts` rather than the dist `.js` or `.d.ts`
- Can run project tasks (e.g. build react-form) without needing dependencies (i.e. form-core) to be built first
- Related PR: https://github.com/TanStack/config/pull/63