### PR TITLE
feat: add initial implementation of linked fields

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -95,6 +95,10 @@
               "to": "framework/react/guides/arrays"
             },
             {
+              "label": "Linked Fields",
+              "to": "framework/react/guides/linked-fields"
+            },
+            {
               "label": "UI Libraries",
               "to": "framework/react/guides/ui-libraries"
             },

--- a/docs/framework/react/guides/linked-fields.md
+++ b/docs/framework/react/guides/linked-fields.md
@@ -1,0 +1,74 @@
+# Link Two Form Fields Together
+
+You may find yourself needing to link two fields together; when one is validated as another field's value has changed.
+One such usage is when you have both a `password` and `confirm_password` field,
+where you want to `confirm_password` to error out when `password`'s value does not match;
+regardless of which field triggered the value change.
+
+Imagine the following userflow:
+
+- User updates confirm password field.
+- User updates the non-confirm password field.
+
+In this example, the form will still have errors present,
+as the "confirm password" field validation has not been re-ran to mark as accepted.
+
+To solve this, we need to make sure that the "confirm password" validation is re-run when the password field is updated.
+To do this, you can add a `onChangeListenTo` property to the `confirm_password` field.
+
+```tsx
+ function App() {
+  const form = useForm({
+    defaultValues: {
+      password: '',
+      confirm_password: '',
+    },
+    // ...
+  })
+
+  return (
+    <div>
+      <form.Field name="password">
+        {(field) => (
+          <label>
+            <div>Password</div>
+            <input
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+            />
+          </label>
+        )}
+      </form.Field>
+      <form.Field
+        name="confirm_password"
+        validators={{
+          onChangeListenTo: ['password'],
+          onChange: ({ value, fieldApi }) => {
+            if (value !== fieldApi.form.getFieldValue('password')) {
+              return 'Passwords do not match'
+            }
+            return undefined
+          },
+        }}
+      >
+        {(field) => (
+          <div>
+            <label>
+              <div>Confirm Password</div>
+              <input
+                value={field.state.value}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+            </label>
+            {field.state.meta.errors.map((err) => (
+              <div key={err}>{err}</div>
+            ))}
+          </div>
+        )}
+      </form.Field>
+    </div>
+  )
+}
+```
+
+This similarly works with `onBlurListenTo` property, which will re-run the validation when the field is blurred.

--- a/docs/reference/fieldApi.md
+++ b/docs/reference/fieldApi.md
@@ -90,6 +90,12 @@ An object type representing the options for a field in a form.
   - If set to a number larger than 0, will debounce the async validation event by this length of time in milliseconds
 
 - ```tsx
+  onChangeListenTo?: DeepKeys<TParentData>[]
+  ```
+
+  - An optional list of field names that should trigger **this** field's `onChange` and `onChangeAsync` events when **its** value changes
+
+- ```tsx
   onBlur?: ValidateFn<TData, TParentData>
   ```
 
@@ -107,6 +113,12 @@ An object type representing the options for a field in a form.
 
   - An optional number to represent how long the `onBlurAsyncDebounceMs` should wait before running
   - If set to a number larger than 0, will debounce the async validation event by this length of time in milliseconds
+
+- ```tsx
+  onBlurListenTo?: DeepKeys<TParentData>[]
+  ```
+
+  - An optional list of field names that should trigger **this** field's `onBlur` and `onBlurAsync` events when **its** field blurs
 
 - ```tsx
   onSubmit?: ValidateFn<TData, TParentData>

--- a/examples/react/simple/src/index.tsx
+++ b/examples/react/simple/src/index.tsx
@@ -17,8 +17,8 @@ function FieldInfo({ field }: { field: FieldApi<any, any, any, any> }) {
 export default function App() {
   const form = useForm({
     defaultValues: {
-      password: '',
-      password_confirm: '',
+      firstName: '',
+      lastName: '',
     },
     onSubmit: async ({ value }) => {
       // Do something with form data
@@ -37,30 +37,23 @@ export default function App() {
         }}
       >
         <div>
+          {/* A type-safe field component*/}
           <form.Field
-            name="password"
-            children={(field) => (
-              <>
-                <label htmlFor={field.name}>Last Name:</label>
-                <input
-                  id={field.name}
-                  name={field.name}
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                />
-                <FieldInfo field={field} />
-              </>
-            )}
-          />
-        </div>
-        <div>
-          <form.Field
-            name="password_confirm"
+            name="firstName"
             validators={{
-              onChangeListenTo: ['password'],
-              onChange: ({ value, fieldApi }) =>
-                fieldApi.form.getFieldValue('password') === value ? undefined : 'Passwords do not match'
+              onChange: ({ value }) =>
+                !value
+                  ? 'A first name is required'
+                  : value.length < 3
+                    ? 'First name must be at least 3 characters'
+                    : undefined,
+              onChangeAsyncDebounceMs: 500,
+              onChangeAsync: async ({ value }) => {
+                await new Promise((resolve) => setTimeout(resolve, 1000))
+                return (
+                  value.includes('error') && 'No "error" allowed in first name'
+                )
+              },
             }}
             children={(field) => {
               // Avoid hasty abstractions. Render props are great!
@@ -79,7 +72,26 @@ export default function App() {
               )
             }}
           />
-        </div>        <form.Subscribe
+        </div>
+        <div>
+          <form.Field
+            name="lastName"
+            children={(field) => (
+              <>
+                <label htmlFor={field.name}>Last Name:</label>
+                <input
+                  id={field.name}
+                  name={field.name}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                />
+                <FieldInfo field={field} />
+              </>
+            )}
+          />
+        </div>
+        <form.Subscribe
           selector={(state) => [state.canSubmit, state.isSubmitting]}
           children={([canSubmit, isSubmitting]) => (
             <button type="submit" disabled={!canSubmit}>

--- a/examples/react/simple/src/index.tsx
+++ b/examples/react/simple/src/index.tsx
@@ -17,8 +17,8 @@ function FieldInfo({ field }: { field: FieldApi<any, any, any, any> }) {
 export default function App() {
   const form = useForm({
     defaultValues: {
-      firstName: '',
-      lastName: '',
+      password: '',
+      password_confirm: '',
     },
     onSubmit: async ({ value }) => {
       // Do something with form data
@@ -37,23 +37,30 @@ export default function App() {
         }}
       >
         <div>
-          {/* A type-safe field component*/}
           <form.Field
-            name="firstName"
+            name="password"
+            children={(field) => (
+              <>
+                <label htmlFor={field.name}>Last Name:</label>
+                <input
+                  id={field.name}
+                  name={field.name}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                />
+                <FieldInfo field={field} />
+              </>
+            )}
+          />
+        </div>
+        <div>
+          <form.Field
+            name="password_confirm"
             validators={{
-              onChange: ({ value }) =>
-                !value
-                  ? 'A first name is required'
-                  : value.length < 3
-                    ? 'First name must be at least 3 characters'
-                    : undefined,
-              onChangeAsyncDebounceMs: 500,
-              onChangeAsync: async ({ value }) => {
-                await new Promise((resolve) => setTimeout(resolve, 1000))
-                return (
-                  value.includes('error') && 'No "error" allowed in first name'
-                )
-              },
+              onChangeListenTo: ['password'],
+              onChange: ({ value, fieldApi }) =>
+                fieldApi.form.getFieldValue('password') === value ? undefined : 'Passwords do not match'
             }}
             children={(field) => {
               // Avoid hasty abstractions. Render props are great!
@@ -72,26 +79,7 @@ export default function App() {
               )
             }}
           />
-        </div>
-        <div>
-          <form.Field
-            name="lastName"
-            children={(field) => (
-              <>
-                <label htmlFor={field.name}>Last Name:</label>
-                <input
-                  id={field.name}
-                  name={field.name}
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                />
-                <FieldInfo field={field} />
-              </>
-            )}
-          />
-        </div>
-        <form.Subscribe
+        </div>        <form.Subscribe
           selector={(state) => [state.canSubmit, state.isSubmitting]}
           children={([canSubmit, isSubmitting]) => (
             <button type="submit" disabled={!canSubmit}>

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -1,24 +1,24 @@
 import { Store } from '@tanstack/store'
 import { getAsyncValidatorArray, getSyncValidatorArray } from './utils'
-import type { FormApi } from './FormApi'
+import type { FieldInfo, FormApi } from './FormApi'
 import type {
   ValidationCause,
   ValidationError,
   ValidationErrorMap,
   Validator,
 } from './types'
-import type { Updater } from './utils'
+import type { SyncValidator, Updater } from './utils'
 import type { DeepKeys, DeepValue, NoInfer } from './util-types'
 
 export type FieldValidateFn<
   TParentData,
   TName extends DeepKeys<TParentData>,
   TFieldValidator extends
-    | Validator<DeepValue<TParentData, TName>, unknown>
-    | undefined = undefined,
+  | Validator<DeepValue<TParentData, TName>, unknown>
+  | undefined = undefined,
   TFormValidator extends
-    | Validator<TParentData, unknown>
-    | undefined = undefined,
+  | Validator<TParentData, unknown>
+  | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > = (props: {
   value: TData
@@ -29,49 +29,49 @@ export type FieldValidateOrFn<
   TParentData,
   TName extends DeepKeys<TParentData>,
   TFieldValidator extends
-    | Validator<DeepValue<TParentData, TName>, unknown>
-    | undefined = undefined,
+  | Validator<DeepValue<TParentData, TName>, unknown>
+  | undefined = undefined,
   TFormValidator extends
-    | Validator<TParentData, unknown>
-    | undefined = undefined,
+  | Validator<TParentData, unknown>
+  | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > = TFieldValidator extends Validator<TData, infer TFN>
   ?
-      | TFN
-      | FieldValidateFn<
-          TParentData,
-          TName,
-          TFieldValidator,
-          TFormValidator,
-          TData
-        >
+  | TFN
+  | FieldValidateFn<
+    TParentData,
+    TName,
+    TFieldValidator,
+    TFormValidator,
+    TData
+  >
   : TFormValidator extends Validator<TParentData, infer FFN>
-    ?
-        | FFN
-        | FieldValidateFn<
-            TParentData,
-            TName,
-            TFieldValidator,
-            TFormValidator,
-            TData
-          >
-    : FieldValidateFn<
-        TParentData,
-        TName,
-        TFieldValidator,
-        TFormValidator,
-        TData
-      >
+  ?
+  | FFN
+  | FieldValidateFn<
+    TParentData,
+    TName,
+    TFieldValidator,
+    TFormValidator,
+    TData
+  >
+  : FieldValidateFn<
+    TParentData,
+    TName,
+    TFieldValidator,
+    TFormValidator,
+    TData
+  >
 
 export type FieldValidateAsyncFn<
   TParentData,
   TName extends DeepKeys<TParentData>,
   TFieldValidator extends
-    | Validator<DeepValue<TParentData, TName>, unknown>
-    | undefined = undefined,
+  | Validator<DeepValue<TParentData, TName>, unknown>
+  | undefined = undefined,
   TFormValidator extends
-    | Validator<TParentData, unknown>
-    | undefined = undefined,
+  | Validator<TParentData, unknown>
+  | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > = (options: {
   value: TData
@@ -83,49 +83,49 @@ export type FieldAsyncValidateOrFn<
   TParentData,
   TName extends DeepKeys<TParentData>,
   TFieldValidator extends
-    | Validator<DeepValue<TParentData, TName>, unknown>
-    | undefined = undefined,
+  | Validator<DeepValue<TParentData, TName>, unknown>
+  | undefined = undefined,
   TFormValidator extends
-    | Validator<TParentData, unknown>
-    | undefined = undefined,
+  | Validator<TParentData, unknown>
+  | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > = TFieldValidator extends Validator<TData, infer TFN>
   ?
-      | TFN
-      | FieldValidateAsyncFn<
-          TParentData,
-          TName,
-          TFieldValidator,
-          TFormValidator,
-          TData
-        >
+  | TFN
+  | FieldValidateAsyncFn<
+    TParentData,
+    TName,
+    TFieldValidator,
+    TFormValidator,
+    TData
+  >
   : TFormValidator extends Validator<TParentData, infer FFN>
-    ?
-        | FFN
-        | FieldValidateAsyncFn<
-            TParentData,
-            TName,
-            TFieldValidator,
-            TFormValidator,
-            TData
-          >
-    : FieldValidateAsyncFn<
-        TParentData,
-        TName,
-        TFieldValidator,
-        TFormValidator,
-        TData
-      >
+  ?
+  | FFN
+  | FieldValidateAsyncFn<
+    TParentData,
+    TName,
+    TFieldValidator,
+    TFormValidator,
+    TData
+  >
+  : FieldValidateAsyncFn<
+    TParentData,
+    TName,
+    TFieldValidator,
+    TFormValidator,
+    TData
+  >
 
 export interface FieldValidators<
   TParentData,
   TName extends DeepKeys<TParentData>,
   TFieldValidator extends
-    | Validator<DeepValue<TParentData, TName>, unknown>
-    | undefined = undefined,
+  | Validator<DeepValue<TParentData, TName>, unknown>
+  | undefined = undefined,
   TFormValidator extends
-    | Validator<TParentData, unknown>
-    | undefined = undefined,
+  | Validator<TParentData, unknown>
+  | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > {
   onMount?: FieldValidateOrFn<
@@ -150,6 +150,7 @@ export interface FieldValidators<
     TData
   >
   onChangeAsyncDebounceMs?: number
+  onChangeListenTo?: DeepKeys<TParentData>[]
   onBlur?: FieldValidateOrFn<
     TParentData,
     TName,
@@ -165,6 +166,7 @@ export interface FieldValidators<
     TData
   >
   onBlurAsyncDebounceMs?: number
+  onBlurListenTo?: DeepKeys<TParentData>[]
   onSubmit?: FieldValidateOrFn<
     TParentData,
     TName,
@@ -186,11 +188,11 @@ export interface FieldOptions<
   TParentData,
   TName extends DeepKeys<TParentData>,
   TFieldValidator extends
-    | Validator<DeepValue<TParentData, TName>, unknown>
-    | undefined = undefined,
+  | Validator<DeepValue<TParentData, TName>, unknown>
+  | undefined = undefined,
   TFormValidator extends
-    | Validator<TParentData, unknown>
-    | undefined = undefined,
+  | Validator<TParentData, unknown>
+  | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > {
   name: TName
@@ -213,19 +215,19 @@ export interface FieldApiOptions<
   TParentData,
   TName extends DeepKeys<TParentData>,
   TFieldValidator extends
-    | Validator<DeepValue<TParentData, TName>, unknown>
-    | undefined = undefined,
+  | Validator<DeepValue<TParentData, TName>, unknown>
+  | undefined = undefined,
   TFormValidator extends
-    | Validator<TParentData, unknown>
-    | undefined = undefined,
+  | Validator<TParentData, unknown>
+  | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > extends FieldOptions<
-    TParentData,
-    TName,
-    TFieldValidator,
-    TFormValidator,
-    TData
-  > {
+  TParentData,
+  TName,
+  TFieldValidator,
+  TFormValidator,
+  TData
+> {
   form: FormApi<TParentData, TFormValidator>
 }
 
@@ -252,11 +254,11 @@ export class FieldApi<
   TParentData,
   TName extends DeepKeys<TParentData>,
   TFieldValidator extends
-    | Validator<DeepValue<TParentData, TName>, unknown>
-    | undefined = undefined,
+  | Validator<DeepValue<TParentData, TName>, unknown>
+  | undefined = undefined,
   TFormValidator extends
-    | Validator<TParentData, unknown>
-    | undefined = undefined,
+  | Validator<TParentData, unknown>
+  | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > {
   form: FieldApiOptions<
@@ -339,8 +341,8 @@ export class FieldApi<
     TType extends 'validate' | 'validateAsync',
   >(props: {
     validate: TType extends 'validate'
-      ? FieldValidateOrFn<any, any, any, any>
-      : FieldAsyncValidateOrFn<any, any, any, any>
+    ? FieldValidateOrFn<any, any, any, any>
+    : FieldAsyncValidateOrFn<any, any, any, any>
     value: TValue
     type: TType
   }): ReturnType<ReturnType<Validator<any>>[TType]> {
@@ -482,8 +484,35 @@ export class FieldApi<
   swapValues = (aIndex: number, bIndex: number) =>
     this.form.swapFieldValues(this.name, aIndex, bIndex)
 
+  getLinkedFields = (cause: ValidationCause) => {
+    const fields = Object.values(this.form.fieldInfo) as FieldInfo<any, TFormValidator>[]
+
+    let linkedFields: FieldApi<any, any, any, any>[] = []
+    for (let field of fields) {
+      if (!field.instance) continue;
+      const { onChangeListenTo, onBlurListenTo } = field.instance.options.validators || {}
+      if (cause === 'change' && onChangeListenTo?.includes(this.name as string)) {
+        linkedFields.push(field.instance)
+      }
+      if (cause === 'blur' && onBlurListenTo?.includes(this.name as string)) {
+        linkedFields.push(field.instance)
+      }
+    }
+
+    return linkedFields
+  }
+
   validateSync = (value = this.state.value, cause: ValidationCause) => {
-    const validates = getSyncValidatorArray(cause, this.options)
+    let validates = getSyncValidatorArray(cause, this.options)
+
+    const linkedFields = this.getLinkedFields(cause)
+    const linkedFieldValidates = linkedFields.reduce((acc, field) => {
+      const fieldValidates = getSyncValidatorArray(cause, field.options)
+      fieldValidates.forEach((validate) => {
+        (validate as any).field = field
+      })
+      return acc.concat(fieldValidates as never)
+    }, [] as Array<SyncValidator<any> & {field: FieldApi<any, any, any, any>}>)
 
     // Needs type cast as eslint errantly believes this is always falsy
     let hasErrored = false as boolean
@@ -505,6 +534,29 @@ export class FieldApi<
             errorMap: {
               ...prev.errorMap,
               [getErrorMapKey(validateObj.cause)]: error,
+            },
+          }))
+        }
+        if (error) {
+          hasErrored = true
+        }
+      }
+      for (const fieldValitateObj of linkedFieldValidates) {
+        if (!fieldValitateObj.validate) continue
+        const error = normalizeError(
+          fieldValitateObj.field.runValidator({
+            validate: fieldValitateObj.validate,
+            value: { value: fieldValitateObj.field.getValue(), fieldApi: fieldValitateObj.field },
+            type: 'validate',
+          }),
+        )
+        const errorMapKey = getErrorMapKey(fieldValitateObj.cause)
+        if (fieldValitateObj.field.state.meta.errorMap[errorMapKey] !== error) {
+          fieldValitateObj.field.setMeta((prev) => ({
+            ...prev,
+            errorMap: {
+              ...prev.errorMap,
+              [getErrorMapKey(fieldValitateObj.cause)]: error,
             },
           }))
         }
@@ -624,7 +676,7 @@ export class FieldApi<
 
     try {
       this.form.validate(cause)
-    } catch (_) {}
+    } catch (_) { }
 
     // Attempt to sync validate first
     const { hasErrored } = this.validateSync(value, cause)

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -14,11 +14,11 @@ export type FieldValidateFn<
   TParentData,
   TName extends DeepKeys<TParentData>,
   TFieldValidator extends
-  | Validator<DeepValue<TParentData, TName>, unknown>
-  | undefined = undefined,
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
   TFormValidator extends
-  | Validator<TParentData, unknown>
-  | undefined = undefined,
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > = (props: {
   value: TData
@@ -29,49 +29,49 @@ export type FieldValidateOrFn<
   TParentData,
   TName extends DeepKeys<TParentData>,
   TFieldValidator extends
-  | Validator<DeepValue<TParentData, TName>, unknown>
-  | undefined = undefined,
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
   TFormValidator extends
-  | Validator<TParentData, unknown>
-  | undefined = undefined,
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > = TFieldValidator extends Validator<TData, infer TFN>
   ?
-  | TFN
-  | FieldValidateFn<
-    TParentData,
-    TName,
-    TFieldValidator,
-    TFormValidator,
-    TData
-  >
+      | TFN
+      | FieldValidateFn<
+          TParentData,
+          TName,
+          TFieldValidator,
+          TFormValidator,
+          TData
+        >
   : TFormValidator extends Validator<TParentData, infer FFN>
-  ?
-  | FFN
-  | FieldValidateFn<
-    TParentData,
-    TName,
-    TFieldValidator,
-    TFormValidator,
-    TData
-  >
-  : FieldValidateFn<
-    TParentData,
-    TName,
-    TFieldValidator,
-    TFormValidator,
-    TData
-  >
+    ?
+        | FFN
+        | FieldValidateFn<
+            TParentData,
+            TName,
+            TFieldValidator,
+            TFormValidator,
+            TData
+          >
+    : FieldValidateFn<
+        TParentData,
+        TName,
+        TFieldValidator,
+        TFormValidator,
+        TData
+      >
 
 export type FieldValidateAsyncFn<
   TParentData,
   TName extends DeepKeys<TParentData>,
   TFieldValidator extends
-  | Validator<DeepValue<TParentData, TName>, unknown>
-  | undefined = undefined,
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
   TFormValidator extends
-  | Validator<TParentData, unknown>
-  | undefined = undefined,
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > = (options: {
   value: TData
@@ -83,49 +83,49 @@ export type FieldAsyncValidateOrFn<
   TParentData,
   TName extends DeepKeys<TParentData>,
   TFieldValidator extends
-  | Validator<DeepValue<TParentData, TName>, unknown>
-  | undefined = undefined,
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
   TFormValidator extends
-  | Validator<TParentData, unknown>
-  | undefined = undefined,
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > = TFieldValidator extends Validator<TData, infer TFN>
   ?
-  | TFN
-  | FieldValidateAsyncFn<
-    TParentData,
-    TName,
-    TFieldValidator,
-    TFormValidator,
-    TData
-  >
+      | TFN
+      | FieldValidateAsyncFn<
+          TParentData,
+          TName,
+          TFieldValidator,
+          TFormValidator,
+          TData
+        >
   : TFormValidator extends Validator<TParentData, infer FFN>
-  ?
-  | FFN
-  | FieldValidateAsyncFn<
-    TParentData,
-    TName,
-    TFieldValidator,
-    TFormValidator,
-    TData
-  >
-  : FieldValidateAsyncFn<
-    TParentData,
-    TName,
-    TFieldValidator,
-    TFormValidator,
-    TData
-  >
+    ?
+        | FFN
+        | FieldValidateAsyncFn<
+            TParentData,
+            TName,
+            TFieldValidator,
+            TFormValidator,
+            TData
+          >
+    : FieldValidateAsyncFn<
+        TParentData,
+        TName,
+        TFieldValidator,
+        TFormValidator,
+        TData
+      >
 
 export interface FieldValidators<
   TParentData,
   TName extends DeepKeys<TParentData>,
   TFieldValidator extends
-  | Validator<DeepValue<TParentData, TName>, unknown>
-  | undefined = undefined,
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
   TFormValidator extends
-  | Validator<TParentData, unknown>
-  | undefined = undefined,
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > {
   onMount?: FieldValidateOrFn<
@@ -188,11 +188,11 @@ export interface FieldOptions<
   TParentData,
   TName extends DeepKeys<TParentData>,
   TFieldValidator extends
-  | Validator<DeepValue<TParentData, TName>, unknown>
-  | undefined = undefined,
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
   TFormValidator extends
-  | Validator<TParentData, unknown>
-  | undefined = undefined,
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > {
   name: TName
@@ -215,19 +215,19 @@ export interface FieldApiOptions<
   TParentData,
   TName extends DeepKeys<TParentData>,
   TFieldValidator extends
-  | Validator<DeepValue<TParentData, TName>, unknown>
-  | undefined = undefined,
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
   TFormValidator extends
-  | Validator<TParentData, unknown>
-  | undefined = undefined,
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > extends FieldOptions<
-  TParentData,
-  TName,
-  TFieldValidator,
-  TFormValidator,
-  TData
-> {
+    TParentData,
+    TName,
+    TFieldValidator,
+    TFormValidator,
+    TData
+  > {
   form: FormApi<TParentData, TFormValidator>
 }
 
@@ -254,11 +254,11 @@ export class FieldApi<
   TParentData,
   TName extends DeepKeys<TParentData>,
   TFieldValidator extends
-  | Validator<DeepValue<TParentData, TName>, unknown>
-  | undefined = undefined,
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
   TFormValidator extends
-  | Validator<TParentData, unknown>
-  | undefined = undefined,
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
   TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
 > {
   form: FieldApiOptions<
@@ -341,8 +341,8 @@ export class FieldApi<
     TType extends 'validate' | 'validateAsync',
   >(props: {
     validate: TType extends 'validate'
-    ? FieldValidateOrFn<any, any, any, any>
-    : FieldAsyncValidateOrFn<any, any, any, any>
+      ? FieldValidateOrFn<any, any, any, any>
+      : FieldAsyncValidateOrFn<any, any, any, any>
     value: TValue
     type: TType
   }): ReturnType<ReturnType<Validator<any>>[TType]> {
@@ -485,13 +485,20 @@ export class FieldApi<
     this.form.swapFieldValues(this.name, aIndex, bIndex)
 
   getLinkedFields = (cause: ValidationCause) => {
-    const fields = Object.values(this.form.fieldInfo) as FieldInfo<any, TFormValidator>[]
+    const fields = Object.values(this.form.fieldInfo) as FieldInfo<
+      any,
+      TFormValidator
+    >[]
 
-    let linkedFields: FieldApi<any, any, any, any>[] = []
-    for (let field of fields) {
-      if (!field.instance) continue;
-      const { onChangeListenTo, onBlurListenTo } = field.instance.options.validators || {}
-      if (cause === 'change' && onChangeListenTo?.includes(this.name as string)) {
+    const linkedFields: FieldApi<any, any, any, any>[] = []
+    for (const field of fields) {
+      if (!field.instance) continue
+      const { onChangeListenTo, onBlurListenTo } =
+        field.instance.options.validators || {}
+      if (
+        cause === 'change' &&
+        onChangeListenTo?.includes(this.name as string)
+      ) {
         linkedFields.push(field.instance)
       }
       if (cause === 'blur' && onBlurListenTo?.includes(this.name as string)) {
@@ -503,16 +510,19 @@ export class FieldApi<
   }
 
   validateSync = (value = this.state.value, cause: ValidationCause) => {
-    let validates = getSyncValidatorArray(cause, this.options)
+    const validates = getSyncValidatorArray(cause, this.options)
 
     const linkedFields = this.getLinkedFields(cause)
-    const linkedFieldValidates = linkedFields.reduce((acc, field) => {
-      const fieldValidates = getSyncValidatorArray(cause, field.options)
-      fieldValidates.forEach((validate) => {
-        (validate as any).field = field
-      })
-      return acc.concat(fieldValidates as never)
-    }, [] as Array<SyncValidator<any> & {field: FieldApi<any, any, any, any>}>)
+    const linkedFieldValidates = linkedFields.reduce(
+      (acc, field) => {
+        const fieldValidates = getSyncValidatorArray(cause, field.options)
+        fieldValidates.forEach((validate) => {
+          ;(validate as any).field = field
+        })
+        return acc.concat(fieldValidates as never)
+      },
+      [] as Array<SyncValidator<any> & { field: FieldApi<any, any, any, any> }>,
+    )
 
     // Needs type cast as eslint errantly believes this is always falsy
     let hasErrored = false as boolean
@@ -546,7 +556,10 @@ export class FieldApi<
         const error = normalizeError(
           fieldValitateObj.field.runValidator({
             validate: fieldValitateObj.validate,
-            value: { value: fieldValitateObj.field.getValue(), fieldApi: fieldValitateObj.field },
+            value: {
+              value: fieldValitateObj.field.getValue(),
+              fieldApi: fieldValitateObj.field,
+            },
             type: 'validate',
           }),
         )
@@ -676,7 +689,7 @@ export class FieldApi<
 
     try {
       this.form.validate(cause)
-    } catch (_) { }
+    } catch (_) {}
 
     // Attempt to sync validate first
     const { hasErrored } = this.validateSync(value, cause)

--- a/packages/form-core/src/tests/FieldApi.spec.ts
+++ b/packages/form-core/src/tests/FieldApi.spec.ts
@@ -795,4 +795,71 @@ describe('field api', () => {
       'Passwords do not match',
     ])
   })
+
+  it('should run onChangeAsync on a linked field', async () => {
+    vi.useRealTimers()
+    let resolve!: () => void
+    let promise = new Promise((r) => {
+      resolve = r as never
+    })
+
+    const fn = vi.fn()
+
+    const form = new FormApi({
+      defaultValues: {
+        password: '',
+        confirm_password: '',
+      },
+    })
+
+    const passField = new FieldApi({
+      form,
+      name: 'password',
+    })
+
+    const passconfirmField = new FieldApi({
+      form,
+      name: 'confirm_password',
+      validators: {
+        onChangeListenTo: ['password'],
+        onChangeAsync: async ({ value, fieldApi }) => {
+          await promise
+          fn()
+          if (value !== fieldApi.form.getFieldValue('password')) {
+            return 'Passwords do not match'
+          }
+          return undefined
+        },
+      },
+    })
+
+    passField.mount()
+    passconfirmField.mount()
+
+    passField.setValue('one', { touch: true })
+    resolve()
+    // Allow for a micro-tick to allow the promise to resolve
+    await sleep(1)
+    expect(passconfirmField.state.meta.errors).toStrictEqual([
+      'Passwords do not match',
+    ])
+    promise = new Promise((r) => {
+      resolve = r as never
+    })
+    passconfirmField.setValue('one', { touch: true })
+    resolve()
+    // Allow for a micro-tick to allow the promise to resolve
+    await sleep(1)
+    expect(passconfirmField.state.meta.errors).toStrictEqual([])
+    promise = new Promise((r) => {
+      resolve = r as never
+    })
+    passField.setValue('two', { touch: true })
+    resolve()
+    // Allow for a micro-tick to allow the promise to resolve
+    await sleep(1)
+    expect(passconfirmField.state.meta.errors).toStrictEqual([
+      'Passwords do not match',
+    ])
+  })
 })

--- a/packages/form-core/src/tests/FieldApi.spec.ts
+++ b/packages/form-core/src/tests/FieldApi.spec.ts
@@ -704,4 +704,85 @@ describe('field api', () => {
     await sleep(1)
     expect(fn).toHaveBeenCalledTimes(1)
   })
+
+  it('should run onChange on a linked field', () => {
+    const form = new FormApi({
+      defaultValues: {
+        password: '',
+        confirm_password: '',
+      },
+    })
+
+    const passField = new FieldApi({
+      form,
+      name: 'password',
+    })
+
+    const passconfirmField = new FieldApi({
+      form,
+      name: 'confirm_password',
+      validators: {
+        onChangeListenTo: ['password'],
+        onChange: ({ value, fieldApi }) => {
+          if (value !== fieldApi.form.getFieldValue('password')) {
+            return 'Passwords do not match'
+          }
+          return undefined
+        },
+      },
+    })
+
+    passField.mount()
+    passconfirmField.mount()
+
+    passField.setValue('one', { touch: true })
+    expect(passconfirmField.state.meta.errors).toStrictEqual(['Passwords do not match'])
+    passconfirmField.setValue('one', { touch: true })
+    expect(passconfirmField.state.meta.errors).toStrictEqual([])
+    passField.setValue('two', { touch: true })
+    expect(passconfirmField.state.meta.errors).toStrictEqual(['Passwords do not match'])
+  })
+
+  it('should run onBlur on a linked field', () => {
+    const form = new FormApi({
+      defaultValues: {
+        password: '',
+        confirm_password: '',
+      },
+    })
+
+    const passField = new FieldApi({
+      form,
+      name: 'password',
+    })
+
+    const passconfirmField = new FieldApi({
+      form,
+      name: 'confirm_password',
+      validators: {
+        onBlurListenTo: ['password'],
+        onBlur: ({ value, fieldApi }) => {
+          if (value !== fieldApi.form.getFieldValue('password')) {
+            return 'Passwords do not match'
+          }
+          return undefined
+        },
+      },
+    })
+
+    passField.mount()
+    passconfirmField.mount()
+
+    passField.setValue('one', { touch: true })
+    expect(passconfirmField.state.meta.errors).toStrictEqual([])
+    passField.handleBlur();
+    expect(passconfirmField.state.meta.errors).toStrictEqual(['Passwords do not match'])
+    passconfirmField.setValue('one', { touch: true })
+    expect(passconfirmField.state.meta.errors).toStrictEqual(['Passwords do not match'])
+    passField.handleBlur();
+    expect(passconfirmField.state.meta.errors).toStrictEqual([])
+    passField.setValue('two', { touch: true })
+    passField.handleBlur();
+    expect(passconfirmField.state.meta.errors).toStrictEqual(['Passwords do not match'])
+  })
 })

--- a/packages/form-core/src/tests/FieldApi.spec.ts
+++ b/packages/form-core/src/tests/FieldApi.spec.ts
@@ -736,11 +736,15 @@ describe('field api', () => {
     passconfirmField.mount()
 
     passField.setValue('one', { touch: true })
-    expect(passconfirmField.state.meta.errors).toStrictEqual(['Passwords do not match'])
+    expect(passconfirmField.state.meta.errors).toStrictEqual([
+      'Passwords do not match',
+    ])
     passconfirmField.setValue('one', { touch: true })
     expect(passconfirmField.state.meta.errors).toStrictEqual([])
     passField.setValue('two', { touch: true })
-    expect(passconfirmField.state.meta.errors).toStrictEqual(['Passwords do not match'])
+    expect(passconfirmField.state.meta.errors).toStrictEqual([
+      'Passwords do not match',
+    ])
   })
 
   it('should run onBlur on a linked field', () => {
@@ -775,14 +779,20 @@ describe('field api', () => {
 
     passField.setValue('one', { touch: true })
     expect(passconfirmField.state.meta.errors).toStrictEqual([])
-    passField.handleBlur();
-    expect(passconfirmField.state.meta.errors).toStrictEqual(['Passwords do not match'])
+    passField.handleBlur()
+    expect(passconfirmField.state.meta.errors).toStrictEqual([
+      'Passwords do not match',
+    ])
     passconfirmField.setValue('one', { touch: true })
-    expect(passconfirmField.state.meta.errors).toStrictEqual(['Passwords do not match'])
-    passField.handleBlur();
+    expect(passconfirmField.state.meta.errors).toStrictEqual([
+      'Passwords do not match',
+    ])
+    passField.handleBlur()
     expect(passconfirmField.state.meta.errors).toStrictEqual([])
     passField.setValue('two', { touch: true })
-    passField.handleBlur();
-    expect(passconfirmField.state.meta.errors).toStrictEqual(['Passwords do not match'])
+    passField.handleBlur()
+    expect(passconfirmField.state.meta.errors).toStrictEqual([
+      'Passwords do not match',
+    ])
   })
 })

--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -157,7 +157,7 @@ interface AsyncValidatorArrayPartialOptions<T> {
   asyncDebounceMs?: number
 }
 
-interface AsyncValidator<T> {
+export interface AsyncValidator<T> {
   cause: ValidationCause
   validate: T
   debounceMs: number

--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -226,7 +226,7 @@ interface SyncValidatorArrayPartialOptions<T> {
   validators?: T
 }
 
-interface SyncValidator<T> {
+export interface SyncValidator<T> {
   cause: ValidationCause
   validate: T
 }


### PR DESCRIPTION
This PR adds an initial implementatin of linked fields into TanStack Form. The usage looks something like this:

```tsx
<div>
  <form.Field
    name="password"
    children={(field) => (
      // ...
    )}
  />
</div>
<div>
  <form.Field
    name="password_confirm"
    validators={{
      onChangeListenTo: ['password'],
      onChange: ({ value, fieldApi }) =>
        fieldApi.form.getFieldValue('password') === value ? undefined : 'Passwords do not match'
    }}
    children={(field) => {
      // ...
    }}
  />
</div>
```

## TODO

- [x] Functionality for sync validators
- [x] Functionality for async validators
- [x] Core package tests for sync validators
- [x] React package tests for sync validators
- [x] Core package tests for async validators
- [x] Docs
