### PR TITLE
fix: transform valid values for number and boolean HTML attributes

### DIFF
--- a/packages/angular-form/src/tanstack-field.directive.ts
+++ b/packages/angular-form/src/tanstack-field.directive.ts
@@ -4,6 +4,8 @@ import {
   type OnChanges,
   type OnDestroy,
   type OnInit,
+  booleanAttribute,
+  numberAttribute,
 } from '@angular/core'
 import {
   type DeepKeys,
@@ -44,9 +46,9 @@ export class TanStackField<
   // This can be removed when TanStack Form Core is moved to TS min of 5.4
   // and the NoInfer internal util type is rm-rf'd
   @Input() defaultValue?: NoInferHack<TData>
-  @Input() asyncDebounceMs?: number
-  @Input() asyncAlways?: boolean
-  @Input() preserveValue?: boolean
+  @Input({ transform: numberAttribute }) asyncDebounceMs?: number
+  @Input({ transform: booleanAttribute }) asyncAlways?: boolean
+  @Input({ transform: booleanAttribute }) preserveValue?: boolean
   @Input() validatorAdapter?: TFieldValidator
   @Input({ required: true }) tanstackField!: FormApi<
     TParentData,


### PR DESCRIPTION
Fix: #645

This is the quickest, closest-to-how-Angular-does-it fix. It does allow _any_ value as an input, however:
| Input value | Previous result | New result |
|---|---|---|
| **Boolean transform** | | |
| `[asyncAlways]="true"` | `true` | `true` |
| `[asyncAlways]="false"` | `false` | `false` |
| `asyncAlways` | Error (should be `true`) | `true` |
| `asyncAlways="true"` | Error (should be `true`) | `true` |
| `asyncAlways="false"` | Error (should be `false`) | `false` |
| `asyncAlways="fasle"` | Error | `true` (should be an error) |
| **Number transform** |||
| `[asyncDebounceMs]="500"` | `500` | `500` |
| `asyncDebounceMs="500"` | Error (should be `500`) | `500` |
| `asyncDebounceMs` | Error | `NaN` (should be an error) |
| `asyncDebounceMs="123abc"` | Error | `NaN` (should be an error) |

Alternatively, we could wrap the transform functions and have them only accept valid values. This would fix everything.
```ts
function strictBooleanAttribute(
  value: 'true' | 'false' | '' | boolean | null | undefined,
): boolean {
  return booleanAttribute(value)
}

function strictNumberAttribute(value: `${number}` | number | null | undefined) {
  return numberAttribute(value)
}
```

This would fix all of the above problems
| Input value | Previous result | New result |
|---|---|---|
| **Boolean transform** | | |
| `[asyncAlways]="true"` | `true` | `true` |
| `[asyncAlways]="false"` | `false` | `false` |
| `asyncAlways` | Error (should be `true`) | `true` |
| `asyncAlways="true"` | Error (should be `true`) | `true` |
| `asyncAlways="false"` | Error (should be `false`) | `false` |
| `asyncAlways="fasle"` | Error | Error |
| **Number transform** |||
| `[asyncDebounceMs]="500"` | `500` | `500` |
| `asyncDebounceMs="500"` | Error (should be `500`) | `500` |
| `asyncDebounceMs` | Error | Error |
| `asyncDebounceMs="123abc"` | Error | Error |
