### PR TITLE
refactor: remove void keyword from code handlers and documentation

### DIFF
--- a/docs/framework/angular/guides/arrays.md
+++ b/docs/framework/angular/guides/arrays.md
@@ -153,7 +153,7 @@ export class AppComponent {
   handleSubmit(event: SubmitEvent) {
     event.preventDefault()
     event.stopPropagation()
-    void this.form.handleSubmit()
+    this.form.handleSubmit()
   }
 }
 ```

--- a/docs/framework/angular/quick-start.md
+++ b/docs/framework/angular/quick-start.md
@@ -49,7 +49,7 @@ export class AppComponent {
   handleSubmit(event: SubmitEvent) {
     event.preventDefault()
     event.stopPropagation()
-    void this.form.handleSubmit()
+    this.form.handleSubmit()
   }
 }
 

--- a/docs/framework/react/guides/arrays.md
+++ b/docs/framework/react/guides/arrays.md
@@ -76,7 +76,7 @@ function App() {
         onSubmit={(e) => {
           e.preventDefault()
           e.stopPropagation()
-          void form.handleSubmit()
+          form.handleSubmit()
         }}
       >
         <form.Field name="people">

--- a/docs/framework/react/quick-start.md
+++ b/docs/framework/react/quick-start.md
@@ -27,7 +27,7 @@ export default function App() {
           onSubmit={(e) => {
             e.preventDefault();
             e.stopPropagation();
-            void form.handleSubmit();
+            form.handleSubmit();
           }}
         >
           <div>

--- a/docs/framework/solid/guides/arrays.md
+++ b/docs/framework/solid/guides/arrays.md
@@ -83,7 +83,7 @@ function App() {
         onSubmit={(e) => {
           e.preventDefault()
           e.stopPropagation()
-          void form.handleSubmit()
+          form.handleSubmit()
         }}
       >
         <form.Field name="people">

--- a/docs/framework/solid/quick-start.md
+++ b/docs/framework/solid/quick-start.md
@@ -26,7 +26,7 @@ function App() {
           onSubmit={(e) => {
             e.preventDefault()
             e.stopPropagation()
-            void form.handleSubmit()
+            form.handleSubmit()
           }}
         >
           <div>

--- a/docs/framework/vue/guides/arrays.md
+++ b/docs/framework/vue/guides/arrays.md
@@ -99,7 +99,7 @@ Finally, you can use a subfield like so:
       (e) => {
         e.preventDefault()
         e.stopPropagation()
-        void form.handleSubmit()
+        form.handleSubmit()
       }
     "
   >

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -61,7 +61,7 @@ export default function App() {
           onSubmit={(e) => {
             e.preventDefault()
             e.stopPropagation()
-            void form.handleSubmit()
+            form.handleSubmit()
           }}
         >
           <div>

--- a/examples/angular/array/src/app/app.component.ts
+++ b/examples/angular/array/src/app/app.component.ts
@@ -61,6 +61,6 @@ export class AppComponent {
   handleSubmit(event: SubmitEvent) {
     event.preventDefault()
     event.stopPropagation()
-    void this.form.handleSubmit()
+    this.form.handleSubmit()
   }
 }

--- a/examples/angular/simple/src/app/app.component.ts
+++ b/examples/angular/simple/src/app/app.component.ts
@@ -91,6 +91,6 @@ export class AppComponent {
   handleSubmit(event: SubmitEvent) {
     event.preventDefault()
     event.stopPropagation()
-    void this.form.handleSubmit()
+    this.form.handleSubmit()
   }
 }

--- a/examples/angular/valibot/src/app/app.component.ts
+++ b/examples/angular/valibot/src/app/app.component.ts
@@ -87,6 +87,6 @@ export class AppComponent {
   handleSubmit(event: SubmitEvent) {
     event.preventDefault()
     event.stopPropagation()
-    void this.form.handleSubmit()
+    this.form.handleSubmit()
   }
 }

--- a/examples/angular/yup/src/app/app.component.ts
+++ b/examples/angular/yup/src/app/app.component.ts
@@ -87,6 +87,6 @@ export class AppComponent {
   handleSubmit(event: SubmitEvent) {
     event.preventDefault()
     event.stopPropagation()
-    void this.form.handleSubmit()
+    this.form.handleSubmit()
   }
 }

--- a/examples/angular/zod/src/app/app.component.ts
+++ b/examples/angular/zod/src/app/app.component.ts
@@ -90,6 +90,6 @@ export class AppComponent {
   handleSubmit(event: SubmitEvent) {
     event.preventDefault()
     event.stopPropagation()
-    void this.form.handleSubmit()
+    this.form.handleSubmit()
   }
 }

--- a/examples/react/array/src/index.tsx
+++ b/examples/react/array/src/index.tsx
@@ -18,7 +18,7 @@ function App() {
         onSubmit={(e) => {
           e.preventDefault()
           e.stopPropagation()
-          void form.handleSubmit()
+          form.handleSubmit()
         }}
       >
         <form.Field name="people" mode="array">

--- a/examples/react/simple/src/index.tsx
+++ b/examples/react/simple/src/index.tsx
@@ -33,7 +33,7 @@ export default function App() {
         onSubmit={(e) => {
           e.preventDefault()
           e.stopPropagation()
-          void form.handleSubmit()
+          form.handleSubmit()
         }}
       >
         <div>

--- a/examples/react/ui-libraries/src/MainComponent.tsx
+++ b/examples/react/ui-libraries/src/MainComponent.tsx
@@ -27,7 +27,7 @@ export default function MainComponent() {
         onSubmit={(e) => {
           e.preventDefault()
           e.stopPropagation()
-          void handleSubmit()
+          handleSubmit()
         }}
       >
         <Field

--- a/examples/react/valibot/src/index.tsx
+++ b/examples/react/valibot/src/index.tsx
@@ -37,7 +37,7 @@ export default function App() {
         onSubmit={(e) => {
           e.preventDefault()
           e.stopPropagation()
-          void form.handleSubmit()
+          form.handleSubmit()
         }}
       >
         <div>

--- a/examples/react/yup/src/index.tsx
+++ b/examples/react/yup/src/index.tsx
@@ -37,7 +37,7 @@ export default function App() {
         onSubmit={(e) => {
           e.preventDefault()
           e.stopPropagation()
-          void form.handleSubmit()
+          form.handleSubmit()
         }}
       >
         <div>

--- a/examples/react/zod/src/index.tsx
+++ b/examples/react/zod/src/index.tsx
@@ -37,7 +37,7 @@ export default function App() {
         onSubmit={(e) => {
           e.preventDefault()
           e.stopPropagation()
-          void form.handleSubmit()
+          form.handleSubmit()
         }}
       >
         <div>

--- a/examples/solid/array/src/index.tsx
+++ b/examples/solid/array/src/index.tsx
@@ -18,7 +18,7 @@ function App() {
         onSubmit={(e) => {
           e.preventDefault()
           e.stopPropagation()
-          void form.handleSubmit()
+          form.handleSubmit()
         }}
       >
         <form.Field name="people">

--- a/examples/solid/simple/src/index.tsx
+++ b/examples/solid/simple/src/index.tsx
@@ -38,7 +38,7 @@ function App() {
         onSubmit={(e) => {
           e.preventDefault()
           e.stopPropagation()
-          void form.handleSubmit()
+          form.handleSubmit()
         }}
       >
         <div>

--- a/examples/solid/valibot/src/index.tsx
+++ b/examples/solid/valibot/src/index.tsx
@@ -42,7 +42,7 @@ function App() {
         onSubmit={(e) => {
           e.preventDefault()
           e.stopPropagation()
-          void form.handleSubmit()
+          form.handleSubmit()
         }}
       >
         <div>

--- a/examples/solid/yup/src/index.tsx
+++ b/examples/solid/yup/src/index.tsx
@@ -42,7 +42,7 @@ function App() {
         onSubmit={(e) => {
           e.preventDefault()
           e.stopPropagation()
-          void form.handleSubmit()
+          form.handleSubmit()
         }}
       >
         <div>

--- a/examples/solid/zod/src/index.tsx
+++ b/examples/solid/zod/src/index.tsx
@@ -42,7 +42,7 @@ function App() {
         onSubmit={(e) => {
           e.preventDefault()
           e.stopPropagation()
-          void form.handleSubmit()
+          form.handleSubmit()
         }}
       >
         <div>

--- a/examples/vue/array/src/App.vue
+++ b/examples/vue/array/src/App.vue
@@ -15,7 +15,7 @@ const form = useForm({
       (e) => {
         e.preventDefault()
         e.stopPropagation()
-        void form.handleSubmit()
+        form.handleSubmit()
       }
     "
   >

--- a/examples/vue/simple/src/App.vue
+++ b/examples/vue/simple/src/App.vue
@@ -25,7 +25,7 @@ async function onChangeFirstName({ value }: { value: string }) {
       (e) => {
         e.preventDefault()
         e.stopPropagation()
-        void form.handleSubmit()
+        form.handleSubmit()
       }
     "
   >

--- a/examples/vue/valibot/src/App.vue
+++ b/examples/vue/valibot/src/App.vue
@@ -31,7 +31,7 @@ const onChangeFirstName = stringAsync([
       (e) => {
         e.preventDefault()
         e.stopPropagation()
-        void form.handleSubmit()
+        form.handleSubmit()
       }
     "
   >

--- a/examples/vue/yup/src/App.vue
+++ b/examples/vue/yup/src/App.vue
@@ -31,7 +31,7 @@ const onChangeFirstName = yup
       (e) => {
         e.preventDefault()
         e.stopPropagation()
-        void form.handleSubmit()
+        form.handleSubmit()
       }
     "
   >

--- a/examples/vue/zod/src/App.vue
+++ b/examples/vue/zod/src/App.vue
@@ -34,7 +34,7 @@ const onChangeFirstName = z.string().refine(
       (e) => {
         e.preventDefault()
         e.stopPropagation()
-        void form.handleSubmit()
+        form.handleSubmit()
       }
     "
   >

--- a/packages/react-form/src/tests/useField.test.tsx
+++ b/packages/react-form/src/tests/useField.test.tsx
@@ -532,7 +532,7 @@ describe('useField', () => {
             onSubmit={(e) => {
               e.preventDefault()
               e.stopPropagation()
-              void form.handleSubmit()
+              form.handleSubmit()
             }}
           >
             <div>
@@ -624,7 +624,7 @@ describe('useField', () => {
             onSubmit={(e) => {
               e.preventDefault()
               e.stopPropagation()
-              void form.handleSubmit()
+              form.handleSubmit()
             }}
           >
             <form.Field name="people">
@@ -720,7 +720,7 @@ describe('useField', () => {
             onSubmit={(e) => {
               e.preventDefault()
               e.stopPropagation()
-              void form.handleSubmit()
+              form.handleSubmit()
             }}
           >
             <form.Field name="people">

--- a/packages/solid-form/src/tests/createField.test.tsx
+++ b/packages/solid-form/src/tests/createField.test.tsx
@@ -402,7 +402,7 @@ describe('createField', () => {
             onSubmit={(e) => {
               e.preventDefault()
               e.stopPropagation()
-              void form.handleSubmit()
+              form.handleSubmit()
             }}
           >
             <form.Field name="people">
@@ -496,7 +496,7 @@ describe('createField', () => {
             onSubmit={(e) => {
               e.preventDefault()
               e.stopPropagation()
-              void form.handleSubmit()
+              form.handleSubmit()
             }}
           >
             <form.Field name="people">

--- a/packages/vue-form/src/tests/useField.test.tsx
+++ b/packages/vue-form/src/tests/useField.test.tsx
@@ -270,7 +270,7 @@ describe('useField', () => {
             onSubmit={(e) => {
               e.preventDefault()
               e.stopPropagation()
-              void form.handleSubmit()
+              form.handleSubmit()
             }}
           >
             <form.Field name="people">
@@ -370,7 +370,7 @@ describe('useField', () => {
             onSubmit={(e) => {
               e.preventDefault()
               e.stopPropagation()
-              void form.handleSubmit()
+              form.handleSubmit()
             }}
           >
             <form.Field name="people">


### PR DESCRIPTION
It seems they are many questions related to the usage of the `void` keyword, and it was suggested to raise a PR to remove them here: https://github.com/TanStack/form/pull/484#issuecomment-2057585975

This is my 1st contribution, I attempted to follow the guidelines and specifically the [Commit messages conventions](https://github.com/TanStack/form/pull/484#issuecomment-2057585975)

However I'm not familiar with the stack (pnpm / ts), so I'm trusting the CI to detect any issue. Please double-check carefully too :) 
