### PR TITLE
perf: terminate infinite recursion of DeepValue when `any` is passed

### DIFF
--- a/packages/form-core/src/tests/util-types.test-d.ts
+++ b/packages/form-core/src/tests/util-types.test-d.ts
@@ -135,3 +135,17 @@ type FormDefinitionValue = DeepValue<
 >
 
 assertType<string>(0 as never as FormDefinitionValue)
+
+type DoubleDeepArray = DeepValue<
+  {
+    people: {
+      parents: {
+        name: string
+        age: number
+      }[]
+    }[]
+  },
+  `people[${0}].parents[${0}].name`
+>
+
+assertType<string>(0 as never as DoubleDeepArray)


### PR DESCRIPTION
- Ensure termination of recursive type when `any` is passed to it
- Eliminate depth as this is not necessary