### PR TITLE
fix: nested values should not disappear in strictmode

### DIFF
--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -1,5 +1,5 @@
 import { Store } from '@tanstack/store'
-import { getAsyncValidatorArray, getSyncValidatorArray } from './utils'
+import { getAsyncValidatorArray, getBy, getSyncValidatorArray } from './utils'
 import type { FieldInfo, FormApi } from './FormApi'
 import type {
   ValidationCause,
@@ -422,8 +422,7 @@ export class FieldApi<
     // Default Value
 
     if (this.state.value === undefined) {
-      const formDefault =
-        opts.form.options.defaultValues?.[opts.name as keyof TParentData]
+      const formDefault = getBy(opts.form.options.defaultValues, opts.name)
 
       if (opts.defaultValue !== undefined) {
         this.setValue(opts.defaultValue as never)

--- a/packages/react-form/src/tests/useField.test.tsx
+++ b/packages/react-form/src/tests/useField.test.tsx
@@ -874,4 +874,30 @@ describe('useField', () => {
     await user.type(confirmPasswordInput, '1')
     expect(await findByText('Passwords do not match')).toBeInTheDocument()
   })
+
+  it('should handle deeply nested values in StrictMode', async () => {
+    function Comp() {
+      const form = useForm({
+        defaultValues: {
+          name: { first: 'Test', last: 'User' },
+        },
+      })
+
+      return (
+        <form.Field
+          name="name.last"
+          children={(field) => <p>{field.state.value ?? ''}</p>}
+        />
+      )
+    }
+
+    const { queryByText, findByText } = render(
+      <React.StrictMode>
+        <Comp />
+      </React.StrictMode>,
+    )
+
+    expect(queryByText('Test')).not.toBeInTheDocument()
+    expect(await findByText('User')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
This PR fixes #685, which was a result of a bug in `form-core` accessing the `name` field naively