### PR TITLE
Fix/array field validation

### DIFF
--- a/docs/reference/formApi.md
+++ b/docs/reference/formApi.md
@@ -137,6 +137,10 @@ A class representing the Form API. It handles the logic and interactions with th
   validateAllFields(cause: ValidationCause): Promise<ValidationError[]>
   ```
   - Validates all fields in the form using the correct handlers for a given validation type.
+- ```tsx
+  validateField<TField extends DeepKeys<TFormData>>(field: TField, cause: ValidationCause): ValidationError[] | Promise<ValidationError[]>
+  ```
+  - Validates a specified field in the form using the correct handlers for a given validation type.
 
 - ```tsx
     handleSubmit()

--- a/docs/reference/formApi.md
+++ b/docs/reference/formApi.md
@@ -138,6 +138,10 @@ A class representing the Form API. It handles the logic and interactions with th
   ```
   - Validates all fields in the form using the correct handlers for a given validation type.
 - ```tsx
+  validateArrayFieldsStartingFrom<TField extends DeepKeys<TFormData>>(field: TField, index: number, cause: ValidationCause): ValidationError[] | Promise<ValidationError[]>
+  ```
+  - Validates the children of a specified array in the form starting from a given index until the end using the correct handlers for a given validation type.
+- ```tsx
   validateField<TField extends DeepKeys<TFormData>>(field: TField, cause: ValidationCause): ValidationError[] | Promise<ValidationError[]>
   ```
   - Validates a specified field in the form using the correct handlers for a given validation type.

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -477,9 +477,8 @@ export class FieldApi<
     value: TData extends any[] ? TData[number] : never,
   ) => this.form.insertFieldValue(this.name, index, value as any)
 
-  removeValue = async (index: number, opts?: { touch: boolean }) => {
-    await this.form.removeFieldValue(this.name, index, opts)
-  }
+  removeValue = (index: number, opts?: { touch: boolean }) =>
+    this.form.removeFieldValue(this.name, index, opts)
 
   swapValues = (aIndex: number, bIndex: number) =>
     this.form.swapFieldValues(this.name, aIndex, bIndex)

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -768,7 +768,8 @@ export class FormApi<
     }
 
     this.validate('change')
-    this.validateField(field, 'change')
+    // Here all fields have to be validated, since the indexes in the meta map have changed
+    await this.validateAllFields('change')
   }
 
   swapFieldValues = <TField extends DeepKeys<TFormData>>(

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -689,11 +689,12 @@ export class FormApi<
       : never,
     opts?: { touch?: boolean },
   ) => {
-    return this.setFieldValue(
+    this.setFieldValue(
       field,
       (prev) => [...(Array.isArray(prev) ? prev : []), value] as any,
       opts,
     )
+    this.validate('change')
   }
 
   insertFieldValue = <TField extends DeepKeys<TFormData>>(
@@ -713,6 +714,7 @@ export class FormApi<
       },
       opts,
     )
+    this.validate('change')
   }
 
   removeFieldValue = <TField extends DeepKeys<TFormData>>(
@@ -729,6 +731,7 @@ export class FormApi<
       },
       opts,
     )
+    this.validate('change')
   }
 
   swapFieldValues = <TField extends DeepKeys<TFormData>>(
@@ -741,6 +744,7 @@ export class FormApi<
       const prev2 = prev[index2]!
       return setBy(setBy(prev, `${index1}`, prev2), `${index2}`, prev1)
     })
+    this.validate('change')
   }
 
   moveFieldValues = <TField extends DeepKeys<TFormData>>(
@@ -752,6 +756,7 @@ export class FormApi<
       prev.splice(index2, 0, prev.splice(index1, 1)[0])
       return prev
     })
+    this.validate('change')
   }
 }
 

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -378,12 +378,6 @@ export class FormApi<
     const fieldInstance = this.fieldInfo[field]?.instance
     if (!fieldInstance) return []
 
-    // If the field is not touched (same logic as in validateAllFields)
-    if (!fieldInstance.state.meta.isTouched) {
-      // Mark it as touched
-      fieldInstance.setMeta((prev) => ({ ...prev, isTouched: true }))
-    }
-
     return fieldInstance.validate(cause)
   }
 

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -370,6 +370,23 @@ export class FormApi<
     return fieldErrorMapMap.flat()
   }
 
+  validateField = <TField extends DeepKeys<TFormData>>(
+    field: TField,
+    cause: ValidationCause,
+  ) => {
+    // eslint-disable-next-line  @typescript-eslint/no-unnecessary-condition
+    const fieldInstance = this.fieldInfo[field]?.instance
+    if (!fieldInstance) return []
+
+    // If the field is not touched (same logic as in validateAllFields)
+    if (!fieldInstance.state.meta.isTouched) {
+      // Mark it as touched
+      fieldInstance.setMeta((prev) => ({ ...prev, isTouched: true }))
+    }
+
+    return fieldInstance.validate(cause)
+  }
+
   // TODO: This code is copied from FieldApi, we should refactor to share
   validateSync = (cause: ValidationCause) => {
     const validates = getSyncValidatorArray(cause, this.options)
@@ -695,6 +712,7 @@ export class FormApi<
       opts,
     )
     this.validate('change')
+    this.validateField(field, 'change')
   }
 
   insertFieldValue = <TField extends DeepKeys<TFormData>>(
@@ -715,6 +733,7 @@ export class FormApi<
       opts,
     )
     this.validate('change')
+    this.validateField(field, 'change')
   }
 
   removeFieldValue = <TField extends DeepKeys<TFormData>>(
@@ -732,6 +751,7 @@ export class FormApi<
       opts,
     )
     this.validate('change')
+    this.validateField(field, 'change')
   }
 
   swapFieldValues = <TField extends DeepKeys<TFormData>>(
@@ -745,6 +765,7 @@ export class FormApi<
       return setBy(setBy(prev, `${index1}`, prev2), `${index2}`, prev1)
     })
     this.validate('change')
+    this.validateField(field, 'change')
   }
 
   moveFieldValues = <TField extends DeepKeys<TFormData>>(
@@ -757,6 +778,7 @@ export class FormApi<
       return prev
     })
     this.validate('change')
+    this.validateField(field, 'change')
   }
 }
 

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -378,6 +378,12 @@ export class FormApi<
     const fieldInstance = this.fieldInfo[field]?.instance
     if (!fieldInstance) return []
 
+    // If the field is not touched (same logic as in validateAllFields)
+    if (!fieldInstance.state.meta.isTouched) {
+      // Mark it as touched
+      fieldInstance.setMeta((prev) => ({ ...prev, isTouched: true }))
+    }
+
     return fieldInstance.validate(cause)
   }
 

--- a/packages/form-core/src/tests/FieldApi.spec.ts
+++ b/packages/form-core/src/tests/FieldApi.spec.ts
@@ -107,7 +107,7 @@ describe('field api', () => {
     expect(field.getValue()).toStrictEqual(['one', 'other'])
   })
 
-  it.only('should run onChange validation when pushing an array fields value', async () => {
+  it('should run onChange validation when pushing an array fields value', async () => {
     const form = new FormApi({
       defaultValues: {
         names: ['test'],
@@ -120,7 +120,6 @@ describe('field api', () => {
       name: 'names',
       validators: {
         onChange: ({ value }) => {
-          console.log('value', value)
           if (value.length < 3) {
             return 'At least 3 names are required'
           }

--- a/packages/form-core/src/tests/FieldApi.spec.ts
+++ b/packages/form-core/src/tests/FieldApi.spec.ts
@@ -135,8 +135,6 @@ describe('field api', () => {
 
     field.pushValue('other')
 
-    await new Promise(r => setTimeout(r, 0))
-
     expect(field.getMeta().errors).toStrictEqual([
       'At least 3 names are required',
     ])

--- a/packages/form-core/src/tests/FieldApi.spec.ts
+++ b/packages/form-core/src/tests/FieldApi.spec.ts
@@ -188,6 +188,33 @@ describe('field api', () => {
     ])
   })
 
+  it("should not run onChange validation when inserting an array fields value if the field isn't touched", () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ['test'],
+      },
+    })
+    form.mount()
+
+    const field = new FieldApi({
+      form,
+      name: 'names',
+      validators: {
+        onChange: ({ value }) => {
+          if (value.length < 3) {
+            return 'At least 3 names are required'
+          }
+          return
+        },
+      },
+    })
+    field.mount()
+
+    field.insertValue(1, 'other')
+
+    expect(field.getMeta().errors).toStrictEqual([])
+  })
+
   it('should remove a value from an array value correctly', () => {
     const form = new FormApi({
       defaultValues: {

--- a/packages/form-core/src/tests/FieldApi.spec.ts
+++ b/packages/form-core/src/tests/FieldApi.spec.ts
@@ -107,6 +107,41 @@ describe('field api', () => {
     expect(field.getValue()).toStrictEqual(['one', 'other'])
   })
 
+  it.only('should run onChange validation when pushing an array fields value', async () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ['test'],
+      },
+    })
+    form.mount()
+
+    const field = new FieldApi({
+      form,
+      name: 'names',
+      validators: {
+        onChange: ({ value }) => {
+          console.log('value', value)
+          if (value.length < 3) {
+            return 'At least 3 names are required'
+          }
+          return
+        },
+      },
+      defaultMeta: {
+        isTouched: true,
+      },
+    })
+    field.mount()
+
+    field.pushValue('other')
+
+    await new Promise(r => setTimeout(r, 0))
+
+    expect(field.getMeta().errors).toStrictEqual([
+      'At least 3 names are required',
+    ])
+  })
+
   it('should insert a value into an array value correctly', () => {
     const form = new FormApi({
       defaultValues: {
@@ -122,6 +157,38 @@ describe('field api', () => {
     field.insertValue(1, 'other')
 
     expect(field.getValue()).toStrictEqual(['one', 'other'])
+  })
+
+  it('should run onChange validation when inserting an array fields value', () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ['test'],
+      },
+    })
+    form.mount()
+
+    const field = new FieldApi({
+      form,
+      name: 'names',
+      validators: {
+        onChange: ({ value }) => {
+          if (value.length < 3) {
+            return 'At least 3 names are required'
+          }
+          return
+        },
+      },
+      defaultMeta: {
+        isTouched: true,
+      },
+    })
+    field.mount()
+
+    field.insertValue(1, 'other')
+
+    expect(field.getMeta().errors).toStrictEqual([
+      'At least 3 names are required',
+    ])
   })
 
   it('should remove a value from an array value correctly', () => {
@@ -141,6 +208,38 @@ describe('field api', () => {
     expect(field.getValue()).toStrictEqual(['one'])
   })
 
+  it('should run onChange validation when removing an array fields value', () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ['test'],
+      },
+    })
+    form.mount()
+
+    const field = new FieldApi({
+      form,
+      name: 'names',
+      validators: {
+        onChange: ({ value }) => {
+          if (value.length < 3) {
+            return 'At least 3 names are required'
+          }
+          return
+        },
+      },
+      defaultMeta: {
+        isTouched: true,
+      },
+    })
+    field.mount()
+
+    field.removeValue(0)
+
+    expect(field.getMeta().errors).toStrictEqual([
+      'At least 3 names are required',
+    ])
+  })
+
   it('should swap a value from an array value correctly', () => {
     const form = new FormApi({
       defaultValues: {
@@ -158,6 +257,38 @@ describe('field api', () => {
     expect(field.getValue()).toStrictEqual(['two', 'one'])
   })
 
+  it('should run onChange validation when swapping an array fields value', () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ['test', 'test2'],
+      },
+    })
+    form.mount()
+
+    const field = new FieldApi({
+      form,
+      name: 'names',
+      validators: {
+        onChange: ({ value }) => {
+          if (value.length < 3) {
+            return 'At least 3 names are required'
+          }
+          return
+        },
+      },
+      defaultMeta: {
+        isTouched: true,
+      },
+    })
+    field.mount()
+
+    field.swapValues(0, 1)
+
+    expect(field.getMeta().errors).toStrictEqual([
+      'At least 3 names are required',
+    ])
+  })
+
   it('should move a value from an array value correctly', () => {
     const form = new FormApi({
       defaultValues: {
@@ -173,6 +304,38 @@ describe('field api', () => {
     field.moveValue(2, 0)
 
     expect(field.getValue()).toStrictEqual(['three', 'one', 'two', 'four'])
+  })
+
+  it('should run onChange validation when moving an array fields value', () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ['test', 'test2'],
+      },
+    })
+    form.mount()
+
+    const field = new FieldApi({
+      form,
+      name: 'names',
+      validators: {
+        onChange: ({ value }) => {
+          if (value.length < 3) {
+            return 'At least 3 names are required'
+          }
+          return
+        },
+      },
+      defaultMeta: {
+        isTouched: true,
+      },
+    })
+    field.mount()
+
+    field.moveValue(0, 1)
+
+    expect(field.getMeta().errors).toStrictEqual([
+      'At least 3 names are required',
+    ])
   })
 
   it('should not throw errors when no meta info is stored on a field and a form re-renders', async () => {

--- a/packages/form-core/src/tests/FieldApi.spec.ts
+++ b/packages/form-core/src/tests/FieldApi.spec.ts
@@ -205,7 +205,7 @@ describe('field api', () => {
     expect(field.getValue()).toStrictEqual(['one'])
   })
 
-  it('should run onChange validation when removing an array fields value', () => {
+  it('should run onChange validation when removing an array fields value', async () => {
     const form = new FormApi({
       defaultValues: {
         names: ['test'],
@@ -230,7 +230,7 @@ describe('field api', () => {
     })
     field.mount()
 
-    field.removeValue(0)
+    await field.removeValue(0)
 
     expect(field.getMeta().errors).toStrictEqual([
       'At least 3 names are required',

--- a/packages/form-core/src/tests/FieldApi.spec.ts
+++ b/packages/form-core/src/tests/FieldApi.spec.ts
@@ -126,9 +126,6 @@ describe('field api', () => {
           return
         },
       },
-      defaultMeta: {
-        isTouched: true,
-      },
     })
     field.mount()
 
@@ -186,33 +183,6 @@ describe('field api', () => {
     expect(field.getMeta().errors).toStrictEqual([
       'At least 3 names are required',
     ])
-  })
-
-  it("should not run onChange validation when inserting an array fields value if the field isn't touched", () => {
-    const form = new FormApi({
-      defaultValues: {
-        names: ['test'],
-      },
-    })
-    form.mount()
-
-    const field = new FieldApi({
-      form,
-      name: 'names',
-      validators: {
-        onChange: ({ value }) => {
-          if (value.length < 3) {
-            return 'At least 3 names are required'
-          }
-          return
-        },
-      },
-    })
-    field.mount()
-
-    field.insertValue(1, 'other')
-
-    expect(field.getMeta().errors).toStrictEqual([])
   })
 
   it('should remove a value from an array value correctly', () => {

--- a/packages/form-core/src/tests/FormApi.spec.ts
+++ b/packages/form-core/src/tests/FormApi.spec.ts
@@ -324,6 +324,22 @@ describe('form api', () => {
     expect(form.getFieldValue('names')).toStrictEqual(['test', 'other'])
   })
 
+  it("should run onChange validation when pushing an array field's value", () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ['test'],
+      },
+      validators: {
+        onChange: ({ value }) =>
+          value.names.length > 3 ? undefined : 'At least 3 names are required',
+      },
+    })
+    form.mount()
+    form.pushFieldValue('names', 'other')
+
+    expect(form.state.errors).toStrictEqual(["At least 3 names are required"])
+  })
+
   it("should insert an array field's value", () => {
     const form = new FormApi({
       defaultValues: {
@@ -334,6 +350,22 @@ describe('form api', () => {
     form.insertFieldValue('names', 1, 'other')
 
     expect(form.getFieldValue('names')).toStrictEqual(['one', 'other', 'three'])
+  })
+
+  it("should run onChange validation when inserting an array field's value", () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ["test"],
+      },
+      validators: {
+        onChange: ({ value }) =>
+          value.names.length > 3 ? undefined : 'At least 3 names are required',
+      },
+    })
+    form.mount()
+    form.insertFieldValue('names', 1, 'other')
+
+    expect(form.state.errors).toStrictEqual(["At least 3 names are required"])
   })
 
   it("should remove an array field's value", () => {
@@ -348,6 +380,22 @@ describe('form api', () => {
     expect(form.getFieldValue('names')).toStrictEqual(['one', 'three'])
   })
 
+  it("should run onChange validation when removing an array field's value", () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ["test"],
+      },
+      validators: {
+        onChange: ({ value }) =>
+          value.names.length > 1 ? undefined : 'At least 1 name is required',
+      },
+    })
+    form.mount()
+    form.removeFieldValue('names', 0)
+
+    expect(form.state.errors).toStrictEqual(["At least 1 name is required"])
+  })
+
   it("should swap an array field's value", () => {
     const form = new FormApi({
       defaultValues: {
@@ -358,6 +406,52 @@ describe('form api', () => {
     form.swapFieldValues('names', 1, 2)
 
     expect(form.getFieldValue('names')).toStrictEqual(['one', 'three', 'two'])
+  })
+
+  it("should run onChange validation when swapping an array field's value", () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ["test", "test2"],
+      },
+      validators: {
+        onChange: ({ value }) =>
+          value.names.length > 3 ? undefined : 'At least 3 names are required',
+      },
+    })
+    form.mount()
+    expect(form.state.errors).toStrictEqual([])
+    form.swapFieldValues('names', 1, 2)
+
+    expect(form.state.errors).toStrictEqual(["At least 3 names are required"])
+  })
+
+  it("should move an array field's value", () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ['one', 'two', 'three'],
+      },
+    })
+    form.mount()
+    form.moveFieldValues('names', 1, 2)
+
+    expect(form.getFieldValue('names')).toStrictEqual(['one', 'three', 'two'])
+  })
+
+  it("should run onChange validation when moving an array field's value", () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ["test", "test2"],
+      },
+      validators: {
+        onChange: ({ value }) =>
+          value.names.length > 3 ? undefined : 'At least 3 names are required',
+      },
+    })
+    form.mount()
+    expect(form.state.errors).toStrictEqual([])
+    form.moveFieldValues('names', 0, 1)
+
+    expect(form.state.errors).toStrictEqual(["At least 3 names are required"])
   })
 
   it('should handle fields inside an array', async () => {

--- a/packages/form-core/src/tests/FormApi.spec.ts
+++ b/packages/form-core/src/tests/FormApi.spec.ts
@@ -335,6 +335,9 @@ describe('form api', () => {
       },
     })
     form.mount()
+    // Since validation runs through the field, a field must be mounted for that array
+    new FieldApi({ form, name: 'names' }).mount()
+
     form.pushFieldValue('names', 'other')
 
     expect(form.state.errors).toStrictEqual(['At least 3 names are required'])
@@ -363,9 +366,43 @@ describe('form api', () => {
       },
     })
     form.mount()
+    // Since validation runs through the field, a field must be mounted for that array
+    new FieldApi({ form, name: 'names' }).mount()
+
     form.insertFieldValue('names', 1, 'other')
 
     expect(form.state.errors).toStrictEqual(['At least 3 names are required'])
+  })
+
+  it("should validate all shifted fields when inserting an array field's value", async () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: [{ first: 'test' }, { first: 'test2' }],
+      },
+      validators: {
+        onChange: ({ value }) =>
+          value.names.length > 3 ? undefined : 'At least 3 names are required',
+      },
+    })
+    form.mount()
+    // Since validation runs through the field, a field must be mounted for that array
+    new FieldApi({ form, name: 'names' }).mount()
+
+    const field1 = new FieldApi({
+      form,
+      name: 'names[0].first',
+      defaultValue: 'test',
+      validators: {
+        onChange: ({ value }) => value !== 'test' && 'Invalid value',
+      },
+    })
+    field1.mount()
+
+    expect(field1.state.meta.errors).toStrictEqual([])
+
+    await form.insertFieldValue('names', 0, { first: 'other' })
+
+    expect(field1.state.meta.errors).toStrictEqual(['Invalid value'])
   })
 
   it("should remove an array field's value", () => {
@@ -380,7 +417,7 @@ describe('form api', () => {
     expect(form.getFieldValue('names')).toStrictEqual(['one', 'three'])
   })
 
-  it("should run onChange validation when removing an array field's value", async () => {
+  it("should run onChange validation when removing an array field's value", () => {
     const form = new FormApi({
       defaultValues: {
         names: ['test'],
@@ -391,9 +428,66 @@ describe('form api', () => {
       },
     })
     form.mount()
-    await form.removeFieldValue('names', 0)
+    // Since validation runs through the field, a field must be mounted for that array
+    new FieldApi({ form, name: 'names' }).mount()
+
+    form.removeFieldValue('names', 0)
 
     expect(form.state.errors).toStrictEqual(['At least 1 name is required'])
+  })
+
+  it("should validate following fields when removing an array field's value", async () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ['test', 'test2', 'test3'],
+      },
+      validators: {
+        onChange: ({ value }) =>
+          value.names.length > 1 ? undefined : 'At least 1 name is required',
+      },
+    })
+    form.mount()
+    // Since validation runs through the field, a field must be mounted for that array
+    new FieldApi({ form, name: 'names' }).mount()
+
+    const field1 = new FieldApi({
+      form,
+      name: 'names[0]',
+      defaultValue: 'test',
+      validators: {
+        onChange: ({ value }) => value !== 'test' && 'Invalid value',
+      },
+    })
+    field1.mount()
+    const field2 = new FieldApi({
+      form,
+      name: 'names[1]',
+      defaultValue: 'test2',
+      validators: {
+        onChange: ({ value }) => value !== 'test2' && 'Invalid value',
+      },
+    })
+    field2.mount()
+    const field3 = new FieldApi({
+      form,
+      name: 'names[2]',
+      defaultValue: 'test3',
+      validators: {
+        onChange: ({ value }) => value !== 'test3' && 'Invalid value',
+      },
+    })
+    field3.mount()
+
+    expect(field1.state.meta.errors).toStrictEqual([])
+    expect(field2.state.meta.errors).toStrictEqual([])
+    expect(field3.state.meta.errors).toStrictEqual([])
+
+    await form.removeFieldValue('names', 1)
+
+    expect(field1.state.meta.errors).toStrictEqual([])
+    expect(field2.state.meta.errors).toStrictEqual(['Invalid value'])
+    // This field does not exist anymore. Therefore, its validation should also not run
+    expect(field3.state.meta.errors).toStrictEqual([])
   })
 
   it("should swap an array field's value", () => {
@@ -403,6 +497,9 @@ describe('form api', () => {
       },
     })
     form.mount()
+    // Since validation runs through the field, a field must be mounted for that array
+    new FieldApi({ form, name: 'names' }).mount()
+
     form.swapFieldValues('names', 1, 2)
 
     expect(form.getFieldValue('names')).toStrictEqual(['one', 'three', 'two'])
@@ -419,10 +516,53 @@ describe('form api', () => {
       },
     })
     form.mount()
+    // Since validation runs through the field, a field must be mounted for that array
+    new FieldApi({ form, name: 'names' }).mount()
     expect(form.state.errors).toStrictEqual([])
+
     form.swapFieldValues('names', 1, 2)
 
     expect(form.state.errors).toStrictEqual(['At least 3 names are required'])
+  })
+
+  it('should run validation on swapped fields', () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ['test', 'test2'],
+      },
+      validators: {
+        onChange: ({ value }) =>
+          value.names.length > 3 ? undefined : 'At least 3 names are required',
+      },
+    })
+    form.mount()
+    // Since validation runs through the field, a field must be mounted for that array
+    new FieldApi({ form, name: 'names' }).mount()
+
+    const field1 = new FieldApi({
+      form,
+      name: 'names[0]',
+      defaultValue: 'test',
+      validators: {
+        onChange: ({ value }) => value !== 'test' && 'Invalid value',
+      },
+    })
+    field1.mount()
+
+    const field2 = new FieldApi({
+      form,
+      name: 'names[1]',
+      defaultValue: 'test2',
+    })
+    field2.mount()
+
+    expect(field1.state.meta.errors).toStrictEqual([])
+    expect(field2.state.meta.errors).toStrictEqual([])
+
+    form.swapFieldValues('names', 0, 1)
+
+    expect(field1.state.meta.errors).toStrictEqual(['Invalid value'])
+    expect(field2.state.meta.errors).toStrictEqual([])
   })
 
   it("should move an array field's value", () => {
@@ -448,10 +588,53 @@ describe('form api', () => {
       },
     })
     form.mount()
+    // Since validation runs through the field, a field must be mounted for that array
+    new FieldApi({ form, name: 'names' }).mount()
+
     expect(form.state.errors).toStrictEqual([])
     form.moveFieldValues('names', 0, 1)
 
     expect(form.state.errors).toStrictEqual(['At least 3 names are required'])
+  })
+
+  it('should run validation on moved fields', () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ['test', 'test2'],
+      },
+      validators: {
+        onChange: ({ value }) =>
+          value.names.length > 3 ? undefined : 'At least 3 names are required',
+      },
+    })
+    form.mount()
+    // Since validation runs through the field, a field must be mounted for that array
+    new FieldApi({ form, name: 'names' }).mount()
+
+    const field1 = new FieldApi({
+      form,
+      name: 'names[0]',
+      defaultValue: 'test',
+      validators: {
+        onChange: ({ value }) => value !== 'test' && 'Invalid value',
+      },
+    })
+    field1.mount()
+
+    const field2 = new FieldApi({
+      form,
+      name: 'names[1]',
+      defaultValue: 'test2',
+    })
+    field2.mount()
+
+    expect(field1.state.meta.errors).toStrictEqual([])
+    expect(field2.state.meta.errors).toStrictEqual([])
+
+    form.swapFieldValues('names', 0, 1)
+
+    expect(field1.state.meta.errors).toStrictEqual(['Invalid value'])
+    expect(field2.state.meta.errors).toStrictEqual([])
   })
 
   it('should handle fields inside an array', async () => {
@@ -1163,7 +1346,7 @@ describe('form api', () => {
       },
       defaultMeta: {
         isTouched: true,
-      }
+      },
     })
 
     field.mount()

--- a/packages/form-core/src/tests/FormApi.spec.ts
+++ b/packages/form-core/src/tests/FormApi.spec.ts
@@ -337,7 +337,7 @@ describe('form api', () => {
     form.mount()
     form.pushFieldValue('names', 'other')
 
-    expect(form.state.errors).toStrictEqual(["At least 3 names are required"])
+    expect(form.state.errors).toStrictEqual(['At least 3 names are required'])
   })
 
   it("should insert an array field's value", () => {
@@ -355,7 +355,7 @@ describe('form api', () => {
   it("should run onChange validation when inserting an array field's value", () => {
     const form = new FormApi({
       defaultValues: {
-        names: ["test"],
+        names: ['test'],
       },
       validators: {
         onChange: ({ value }) =>
@@ -365,7 +365,7 @@ describe('form api', () => {
     form.mount()
     form.insertFieldValue('names', 1, 'other')
 
-    expect(form.state.errors).toStrictEqual(["At least 3 names are required"])
+    expect(form.state.errors).toStrictEqual(['At least 3 names are required'])
   })
 
   it("should remove an array field's value", () => {
@@ -383,7 +383,7 @@ describe('form api', () => {
   it("should run onChange validation when removing an array field's value", () => {
     const form = new FormApi({
       defaultValues: {
-        names: ["test"],
+        names: ['test'],
       },
       validators: {
         onChange: ({ value }) =>
@@ -393,7 +393,7 @@ describe('form api', () => {
     form.mount()
     form.removeFieldValue('names', 0)
 
-    expect(form.state.errors).toStrictEqual(["At least 1 name is required"])
+    expect(form.state.errors).toStrictEqual(['At least 1 name is required'])
   })
 
   it("should swap an array field's value", () => {
@@ -411,7 +411,7 @@ describe('form api', () => {
   it("should run onChange validation when swapping an array field's value", () => {
     const form = new FormApi({
       defaultValues: {
-        names: ["test", "test2"],
+        names: ['test', 'test2'],
       },
       validators: {
         onChange: ({ value }) =>
@@ -422,7 +422,7 @@ describe('form api', () => {
     expect(form.state.errors).toStrictEqual([])
     form.swapFieldValues('names', 1, 2)
 
-    expect(form.state.errors).toStrictEqual(["At least 3 names are required"])
+    expect(form.state.errors).toStrictEqual(['At least 3 names are required'])
   })
 
   it("should move an array field's value", () => {
@@ -440,7 +440,7 @@ describe('form api', () => {
   it("should run onChange validation when moving an array field's value", () => {
     const form = new FormApi({
       defaultValues: {
-        names: ["test", "test2"],
+        names: ['test', 'test2'],
       },
       validators: {
         onChange: ({ value }) =>
@@ -451,7 +451,7 @@ describe('form api', () => {
     expect(form.state.errors).toStrictEqual([])
     form.moveFieldValues('names', 0, 1)
 
-    expect(form.state.errors).toStrictEqual(["At least 3 names are required"])
+    expect(form.state.errors).toStrictEqual(['At least 3 names are required'])
   })
 
   it('should handle fields inside an array', async () => {

--- a/packages/form-core/src/tests/FormApi.spec.ts
+++ b/packages/form-core/src/tests/FormApi.spec.ts
@@ -1146,7 +1146,7 @@ describe('form api', () => {
     expect(field.getMeta().errorMap.onChange).toEqual('first name is required')
   })
 
-  it('should validate a single field consistently', async () => {
+  it('should validate a single field consistently if touched', async () => {
     const form = new FormApi({
       defaultValues: {
         firstName: '',
@@ -1161,6 +1161,9 @@ describe('form api', () => {
         onChange: ({ value }) =>
           value.length > 0 ? undefined : 'first name is required',
       },
+      defaultMeta: {
+        isTouched: true,
+      }
     })
 
     field.mount()

--- a/packages/form-core/src/tests/FormApi.spec.ts
+++ b/packages/form-core/src/tests/FormApi.spec.ts
@@ -1107,6 +1107,32 @@ describe('form api', () => {
     expect(field.getMeta().errorMap.onChange).toEqual('first name is required')
   })
 
+  it("should validate a single field consistently", async () => {
+    const form = new FormApi({
+      defaultValues: {
+        firstName: '',
+        lastName: '',
+      },
+    })
+
+    const field = new FieldApi({
+      form,
+      name: 'firstName',
+      validators: {
+        onChange: ({ value }) =>
+          value.length > 0 ? undefined : 'first name is required',
+      },
+    })
+
+    field.mount()
+    form.mount()
+
+    await form.validateField("firstName", 'change')
+    expect(field.getMeta().errorMap.onChange).toEqual('first name is required')
+    await form.validateField("firstName", 'change')
+    expect(field.getMeta().errorMap.onChange).toEqual('first name is required')
+  })
+
   it('should show onSubmit errors', async () => {
     const form = new FormApi({
       defaultValues: {

--- a/packages/form-core/src/tests/FormApi.spec.ts
+++ b/packages/form-core/src/tests/FormApi.spec.ts
@@ -380,7 +380,7 @@ describe('form api', () => {
     expect(form.getFieldValue('names')).toStrictEqual(['one', 'three'])
   })
 
-  it("should run onChange validation when removing an array field's value", () => {
+  it("should run onChange validation when removing an array field's value", async () => {
     const form = new FormApi({
       defaultValues: {
         names: ['test'],
@@ -391,7 +391,7 @@ describe('form api', () => {
       },
     })
     form.mount()
-    form.removeFieldValue('names', 0)
+    await form.removeFieldValue('names', 0)
 
     expect(form.state.errors).toStrictEqual(['At least 1 name is required'])
   })

--- a/packages/form-core/src/tests/FormApi.spec.ts
+++ b/packages/form-core/src/tests/FormApi.spec.ts
@@ -1107,7 +1107,7 @@ describe('form api', () => {
     expect(field.getMeta().errorMap.onChange).toEqual('first name is required')
   })
 
-  it("should validate a single field consistently", async () => {
+  it('should validate a single field consistently', async () => {
     const form = new FormApi({
       defaultValues: {
         firstName: '',
@@ -1127,9 +1127,9 @@ describe('form api', () => {
     field.mount()
     form.mount()
 
-    await form.validateField("firstName", 'change')
+    await form.validateField('firstName', 'change')
     expect(field.getMeta().errorMap.onChange).toEqual('first name is required')
-    await form.validateField("firstName", 'change')
+    await form.validateField('firstName', 'change')
     expect(field.getMeta().errorMap.onChange).toEqual('first name is required')
   })
 


### PR DESCRIPTION
This PR closes #662

Any Array Field helper method now also runs the onChange validation of the Form and the field.
Furthermore, there is now a new method to validate a single field on a form.