### PR TITLE
fix(ssr-docs): Corrected "intergration" to "integration" in SSR docs

### DIFF
--- a/docs/framework/react/guides/ssr.md
+++ b/docs/framework/react/guides/ssr.md
@@ -25,7 +25,7 @@ _Remix Support Coming soon_
 
 
 
-# App Router intergration
+# App Router integration
 
 - To use TanStack Form, the component containing the form should be a client component. This requires adding the `"use client"` directive. Wrap this client component within a server component like so:
 


### PR DESCRIPTION
Noticed this typo when going through docs and wanted to send a quick fix