### PR TITLE
feat: add support for nullable objects.

### DIFF
--- a/packages/form-core/src/tests/FormApi.spec.ts
+++ b/packages/form-core/src/tests/FormApi.spec.ts
@@ -1095,4 +1095,60 @@ describe('form api', () => {
     await form.handleSubmit()
     expect(form.state.errors).toStrictEqual(['first name is required'])
   })
+
+  it('should update a nullable object', async () => {
+    const form = new FormApi({
+      defaultValues: {
+        person: null,
+      } as { person: { firstName: string } | null },
+    })
+
+    const field = new FieldApi({
+      form,
+      name: 'person.firstName',
+    })
+
+    field.mount()
+
+    field.setValue('firstName')
+    expect(form.state.values.person?.firstName).toStrictEqual('firstName')
+  })
+
+  it('should update a deep nullable object', async () => {
+    const form = new FormApi({
+      defaultValues: {
+        person: null,
+      } as { person: { nameInfo: { first: string } | null } | null },
+    })
+
+    const field = new FieldApi({
+      form,
+      name: 'person.nameInfo.first',
+    })
+
+    field.mount()
+
+    field.setValue('firstName')
+    expect(form.state.values.person?.nameInfo?.first).toStrictEqual('firstName')
+  })
+
+  it('should update a nullable array', async () => {
+    const form = new FormApi({
+      defaultValues: {
+        persons: null,
+      } as { persons: Array<{ nameInfo: { first: string } }> | null },
+    })
+
+    const field = new FieldApi({
+      form,
+      name: 'persons',
+    })
+
+    field.mount()
+
+    field.pushValue({ nameInfo: { first: 'firstName' } })
+    expect(form.state.values.persons).toStrictEqual([
+      { nameInfo: { first: 'firstName' } },
+    ])
+  })
 })

--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -46,6 +46,9 @@ export function setBy(obj: any, _path: any, updater: Updater<any>) {
 
     if (typeof key === 'string') {
       if (typeof parent === 'object') {
+        if (parent === null) {
+          parent = {}
+        }
         return {
           ...parent,
           [key]: doSet(parent[key]),


### PR DESCRIPTION
My previous PR added support for nullable objects on type level.

Didn't check if updating a null object works or not.

This PR adds tests and fixes this issue.