### PR TITLE
For valibot validator, Add a way to display only one error for a field

### DIFF
--- a/packages/valibot-form-adapter/src/validator.ts
+++ b/packages/valibot-form-adapter/src/validator.ts
@@ -8,12 +8,12 @@ export const valibotValidator = (() => {
       if (fn.async) return
       const result = safeParse(fn, value)
       if (result.success) return
-      return result.issues.map((i) => i.message).join(', ')
+      return result.issues[0].message
     },
     async validateAsync({ value }, fn) {
       const result = await safeParseAsync(fn, value)
       if (result.success) return
-      return result.issues.map((i) => i.message).join(', ')
+      return result.issues[0].message
     },
   }
 }) as Validator<unknown, BaseSchema | BaseSchemaAsync>


### PR DESCRIPTION
**Related issue :** #667

Referring to the [comments](https://github.com/TanStack/form/issues/667#issuecomment-2043786027) of @crutchcorn I solved it by changing the code as below.

```js
return {
    validate({ value }, fn) {
      if (fn.async) return
      const result = safeParse(fn, value)
      if (result.success) return
      return result.issues[0].message // here
    },
    async validateAsync({ value }, fn) {
      const result = await safeParseAsync(fn, value)
      if (result.success) return
      return result.issues[0].message // here
    },
```
<!--
### Additional Question
Now the error shown on the UI became only the first error,
however, at the same time valibot validator's `field.getMeta().errors` and `field.state.meta.touchedErrors` are returning Array containing only the first error.

I have not changed the code anymore because I thought the current test code has no problem validating `valibot validator` logic. Also, `touchedErrors` is used by various validators.

I was wondering if there would be any additional test modifications or code modifications needed for this. --!>