### PR TITLE
fix(core): fix DeepKeys not support partial nested object

### DIFF
--- a/packages/form-core/src/tests/util-types.test-d.ts
+++ b/packages/form-core/src/tests/util-types.test-d.ts
@@ -42,6 +42,18 @@ assertType<
 >(0 as never as NestedSupport)
 
 /**
+ * Properly handles deep partial object nesting like so:
+ */
+type NestedPartialSupport = DeepKeys<{ meta?: { mainUser?: User } }>
+assertType<
+  | 'meta'
+  | 'meta.mainUser'
+  | 'meta.mainUser.name'
+  | 'meta.mainUser.id'
+  | 'meta.mainUser.age'
+>(0 as never as NestedPartialSupport)
+
+/**
  * Properly handles `object` edgecase nesting like so:
  */
 type ObjectNestedEdgecase = DeepKeys<{ meta: { mainUser: object } }>

--- a/packages/form-core/src/util-types.ts
+++ b/packages/form-core/src/util-types.ts
@@ -60,7 +60,7 @@ type PrefixTupleAccessor<
 }[TIndex]
 
 type PrefixObjectAccessor<T extends object, TDepth extends any[]> = {
-  [K in keyof T]: K extends string | number
+  [K in keyof T]-?: K extends string | number
     ?
         | PrefixFromDepth<K, TDepth>
         | `${PrefixFromDepth<K, TDepth>}${DeepKeys<T[K], [TDepth]>}`
@@ -71,19 +71,17 @@ export type DeepKeys<T, TDepth extends any[] = []> = TDepth['length'] extends 5
   ? never
   : unknown extends T
     ? PrefixFromDepth<string, TDepth>
-    : object extends T
-      ? PrefixFromDepth<string, TDepth>
-      : T extends readonly any[] & IsTuple<T>
-        ? PrefixTupleAccessor<T, AllowedIndexes<T>, TDepth>
-        : T extends any[]
-          ? PrefixArrayAccessor<T, [...TDepth, any]>
-          : T extends Date
-            ? never
-            : T extends object
-              ? PrefixObjectAccessor<T, TDepth>
-              : T extends string | number | boolean | bigint
-                ? ''
-                : never
+    : T extends readonly any[] & IsTuple<T>
+      ? PrefixTupleAccessor<T, AllowedIndexes<T>, TDepth>
+      : T extends any[]
+        ? PrefixArrayAccessor<T, [...TDepth, any]>
+        : T extends Date
+          ? never
+          : T extends object
+            ? PrefixObjectAccessor<T, TDepth>
+            : T extends string | number | boolean | bigint
+              ? ''
+              : never
 
 type PrefixFromDepth<
   T extends string | number,


### PR DESCRIPTION
fix https://github.com/TanStack/form/issues/738

## About `object extends T`

Typescript will see `{a?:number}` as `{ a: number | undefined } | {}`, so `object extends T` will return `true`.

Which cause `DeepKeys<{a?:number}>` go to `PrefixFromDepth<string, TDepth>`, returns `string`.

**Danger**: Delete it will cause `DeepKeys` handle other types: like `class`. I don't know if this is expected.

```ts
class SomeClass {
  someAttribute = "hello world";
  someFunction() {
    return this.someAttribute;
  }
}
type A = DeepKeys<{ a: SomeClass; b: string }>; // "a" | "b" | "a.someAttribute" | "a.someFunction"
```


## About `-?:`

In `PrefixObjectAccessor` type, if `K` is partial, `T[K]` will union with `undefined`. So `PrefixObjectAccessor` result will get `undefined`.