### PR TITLE
docs: update discord invite link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/TanStack/form/discussions
     about: Please ask and answer questions here.
   - name: Community Chat
-    url: https://discord.gg/mQd7egN
+    url: https://discord.com/invite/WrRKjPJ
     about: A dedicated discord server hosted by Tanner Linsley


### PR DESCRIPTION
The previous link was pointing to an archived channel, the new one is the link used everywhere else in the docs pointing to #💬-introductions