### PR TITLE
chore: Set root "moduleResolution" to "Node"

### DIFF
--- a/examples/lit/simple/tsconfig.json
+++ b/examples/lit/simple/tsconfig.json
@@ -8,7 +8,7 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/examples/lit/ui-libraries/tsconfig.json
+++ b/examples/lit/ui-libraries/tsconfig.json
@@ -8,7 +8,7 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/examples/react/next-server-actions/tsconfig.json
+++ b/examples/react/next-server-actions/tsconfig.json
@@ -1,14 +1,14 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/examples/react/ui-libraries/tsconfig.json
+++ b/examples/react/ui-libraries/tsconfig.json
@@ -6,7 +6,7 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/examples/solid/array/tsconfig.json
+++ b/examples/solid/array/tsconfig.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/examples/solid/simple/tsconfig.json
+++ b/examples/solid/simple/tsconfig.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/examples/solid/valibot/tsconfig.json
+++ b/examples/solid/valibot/tsconfig.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/examples/solid/yup/tsconfig.json
+++ b/examples/solid/yup/tsconfig.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/examples/solid/zod/tsconfig.json
+++ b/examples/solid/zod/tsconfig.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/examples/vue/array/tsconfig.json
+++ b/examples/vue/array/tsconfig.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/examples/vue/simple/tsconfig.json
+++ b/examples/vue/simple/tsconfig.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/examples/vue/valibot/tsconfig.json
+++ b/examples/vue/valibot/tsconfig.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/examples/vue/yup/tsconfig.json
+++ b/examples/vue/yup/tsconfig.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/examples/vue/zod/tsconfig.json
+++ b/examples/vue/zod/tsconfig.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/packages/angular-form/tsconfig.build.json
+++ b/packages/angular-form/tsconfig.build.json
@@ -1,10 +1,10 @@
 {
   "extends": "./node_modules/ng-packagr/lib/ts/conf/tsconfig.ngc.json",
   "compilerOptions": {
-    "moduleResolution": "bundler",
     "allowJs": true,
+    "module": "ESNext",
     "moduleDetection": "force",
-    "module": "ESNext"
+    "moduleResolution": "Bundler"
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/packages/angular-form/tsconfig.json
+++ b/packages/angular-form/tsconfig.json
@@ -1,16 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
-    "useDefineForClassFields": false,
-    "target": "es2022",
-
-    "strict": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "moduleResolution": "node",
-    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "useDefineForClassFields": false,
     "paths": {
       "@tanstack/form-core": ["../form-core/src"]
     }

--- a/packages/form-core/tsconfig.legacy.json
+++ b/packages/form-core/tsconfig.legacy.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "moduleResolution": "Node"
-  },
   "include": ["src"]
 }

--- a/packages/react-form/tsconfig.legacy.json
+++ b/packages/react-form/tsconfig.legacy.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react",
-    "moduleResolution": "Node",
     "paths": {
       "@tanstack/form-core": ["../form-core/src"]
     }

--- a/packages/solid-form/tsconfig.legacy.json
+++ b/packages/solid-form/tsconfig.legacy.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "moduleResolution": "Node",
     "paths": {
       "@tanstack/form-core": ["../form-core/src"]
     }

--- a/packages/valibot-form-adapter/tsconfig.legacy.json
+++ b/packages/valibot-form-adapter/tsconfig.legacy.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "moduleResolution": "Node",
     "paths": {
       "@tanstack/form-core": ["../form-core/src"]
     }

--- a/packages/vue-form/tsconfig.legacy.json
+++ b/packages/vue-form/tsconfig.legacy.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "jsx": "preserve",
     "jsxImportSource": "vue",
-    "moduleResolution": "Node",
     "types": ["vue/jsx"],
     "paths": {
       "@tanstack/form-core": ["../form-core/src"]

--- a/packages/yup-form-adapter/tsconfig.legacy.json
+++ b/packages/yup-form-adapter/tsconfig.legacy.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "moduleResolution": "Node",
     "paths": {
       "@tanstack/form-core": ["../form-core/src"]
     }

--- a/packages/zod-form-adapter/tsconfig.legacy.json
+++ b/packages/zod-form-adapter/tsconfig.legacy.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "moduleResolution": "Node",
     "paths": {
       "@tanstack/form-core": ["../form-core/src"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "isolatedModules": true,
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "module": "ES2022",
+    "moduleResolution": "Node",
     "noEmit": true,
     "noImplicitReturns": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
Fixes errors resolving imports in top-level type-checked files such as `eslint.config.js`