### PR TITLE
chore: Update valibot dependency to version >=v0.33.0

### DIFF
--- a/examples/angular/valibot/package.json
+++ b/examples/angular/valibot/package.json
@@ -22,7 +22,7 @@
     "@angular/router": "^17.3.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "valibot": "^0.31.1",
+    "valibot": "^0.35.0",
     "zone.js": "~0.14.2"
   },
   "devDependencies": {

--- a/examples/react/valibot/package.json
+++ b/examples/react/valibot/package.json
@@ -13,7 +13,7 @@
     "@tanstack/valibot-form-adapter": "^0.23.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "valibot": "^0.31.1"
+    "valibot": "^0.35.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/examples/solid/valibot/package.json
+++ b/examples/solid/valibot/package.json
@@ -12,7 +12,7 @@
     "@tanstack/solid-form": "^0.23.3",
     "@tanstack/valibot-form-adapter": "^0.23.3",
     "solid-js": "^1.7.8",
-    "valibot": "^0.31.1"
+    "valibot": "^0.35.0"
   },
   "devDependencies": {
     "typescript": "5.4.2",

--- a/examples/vue/valibot/package.json
+++ b/examples/vue/valibot/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@tanstack/valibot-form-adapter": "^0.23.3",
     "@tanstack/vue-form": "^0.23.3",
-    "valibot": "^0.31.1",
+    "valibot": "^0.35.0",
     "vue": "^3.3.4"
   },
   "devDependencies": {

--- a/packages/valibot-form-adapter/package.json
+++ b/packages/valibot-form-adapter/package.json
@@ -54,9 +54,9 @@
     "@tanstack/form-core": "workspace:*"
   },
   "peerDependencies": {
-    "valibot": ">=0.31.0 <1"
+    "valibot": ">=0.33.0 <1"
   },
   "devDependencies": {
-    "valibot": "^0.31.1"
+    "valibot": "^0.35.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,7 +219,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: ^17.3.0
-        version: 17.3.0(@angular/compiler-cli@17.3.0(@angular/compiler@17.3.0(@angular/core@17.3.0(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.4.2))(@swc/core@1.4.6)(@types/express@4.17.21)(@types/node@20.10.6)(chokidar@3.6.0)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.0(@angular/compiler@17.3.0(@angular/core@17.3.0(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.4.2))(tslib@2.6.2)(typescript@5.4.2))(sugarss@4.0.1)(typescript@5.4.2)
+        version: 17.3.0(@angular/compiler-cli@17.3.0(@angular/compiler@17.3.0(@angular/core@17.3.0(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.4.2))(@swc/core@1.4.6)(@types/express@4.17.21)(@types/node@20.10.6)(chokidar@3.6.0)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.0(@angular/compiler@17.3.0(@angular/core@17.3.0(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.4.2))(tslib@2.6.2)(typescript@5.4.2))(sugarss@4.0.1(postcss@8.4.35))(typescript@5.4.2)
       '@angular/cli':
         specifier: ^17.3.0
         version: 17.3.0(chokidar@3.6.0)
@@ -269,15 +269,15 @@ importers:
         specifier: ^2.3.0
         version: 2.6.2
       valibot:
-        specifier: ^0.31.1
-        version: 0.31.1
+        specifier: ^0.35.0
+        version: 0.35.0
       zone.js:
         specifier: ~0.14.2
         version: 0.14.4
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: ^17.3.0
-        version: 17.3.0(@angular/compiler-cli@17.3.0(@angular/compiler@17.3.0(@angular/core@17.3.0(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.4.2))(@swc/core@1.4.6)(@types/express@4.17.21)(@types/node@20.10.6)(chokidar@3.6.0)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.0(@angular/compiler@17.3.0(@angular/core@17.3.0(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.4.2))(tslib@2.6.2)(typescript@5.4.2))(sugarss@4.0.1)(typescript@5.4.2)
+        version: 17.3.0(@angular/compiler-cli@17.3.0(@angular/compiler@17.3.0(@angular/core@17.3.0(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.4.2))(@swc/core@1.4.6)(@types/express@4.17.21)(@types/node@20.10.6)(chokidar@3.6.0)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.0(@angular/compiler@17.3.0(@angular/core@17.3.0(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.4.2))(tslib@2.6.2)(typescript@5.4.2))(sugarss@4.0.1(postcss@8.4.35))(typescript@5.4.2)
       '@angular/cli':
         specifier: ^17.3.0
         version: 17.3.0(chokidar@3.6.0)
@@ -335,7 +335,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: ^17.3.0
-        version: 17.3.0(@angular/compiler-cli@17.3.0(@angular/compiler@17.3.0(@angular/core@17.3.0(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.4.2))(@swc/core@1.4.6)(@types/express@4.17.21)(@types/node@20.10.6)(chokidar@3.6.0)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.0(@angular/compiler@17.3.0(@angular/core@17.3.0(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.4.2))(tslib@2.6.2)(typescript@5.4.2))(sugarss@4.0.1)(typescript@5.4.2)
+        version: 17.3.0(@angular/compiler-cli@17.3.0(@angular/compiler@17.3.0(@angular/core@17.3.0(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.4.2))(@swc/core@1.4.6)(@types/express@4.17.21)(@types/node@20.10.6)(chokidar@3.6.0)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.0(@angular/compiler@17.3.0(@angular/core@17.3.0(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.4.2))(tslib@2.6.2)(typescript@5.4.2))(sugarss@4.0.1(postcss@8.4.35))(typescript@5.4.2)
       '@angular/cli':
         specifier: ^17.3.0
         version: 17.3.0(chokidar@3.6.0)
@@ -393,7 +393,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: ^17.3.0
-        version: 17.3.0(@angular/compiler-cli@17.3.0(@angular/compiler@17.3.0(@angular/core@17.3.0(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.4.2))(@swc/core@1.4.6)(@types/express@4.17.21)(@types/node@20.10.6)(chokidar@3.6.0)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.0(@angular/compiler@17.3.0(@angular/core@17.3.0(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.4.2))(tslib@2.6.2)(typescript@5.4.2))(sugarss@4.0.1)(typescript@5.4.2)
+        version: 17.3.0(@angular/compiler-cli@17.3.0(@angular/compiler@17.3.0(@angular/core@17.3.0(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.4.2))(@swc/core@1.4.6)(@types/express@4.17.21)(@types/node@20.10.6)(chokidar@3.6.0)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.0(@angular/compiler@17.3.0(@angular/core@17.3.0(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.4.2))(tslib@2.6.2)(typescript@5.4.2))(sugarss@4.0.1(postcss@8.4.35))(typescript@5.4.2)
       '@angular/cli':
         specifier: ^17.3.0
         version: 17.3.0(chokidar@3.6.0)
@@ -465,7 +465,7 @@ importers:
         version: link:../../../packages/react-form
       next:
         specifier: 15.0.0-rc.0
-        version: 15.0.0-rc.0(react-dom@19.0.0-rc-6d3110b4d9-20240531(react@19.0.0-rc-6d3110b4d9-20240531))(react@19.0.0-rc-6d3110b4d9-20240531)(sass@1.72.0)
+        version: 15.0.0-rc.0(@babel/core@7.24.7)(react-dom@19.0.0-rc-6d3110b4d9-20240531(react@19.0.0-rc-6d3110b4d9-20240531))(react@19.0.0-rc-6d3110b4d9-20240531)(sass@1.72.0)
       react:
         specifier: 19.0.0-rc-6d3110b4d9-20240531
         version: 19.0.0-rc-6d3110b4d9-20240531
@@ -627,8 +627,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       valibot:
-        specifier: ^0.31.1
-        version: 0.31.1
+        specifier: ^0.35.0
+        version: 0.35.0
     devDependencies:
       '@types/react':
         specifier: ^18.3.3
@@ -755,8 +755,8 @@ importers:
         specifier: ^1.7.8
         version: 1.7.12
       valibot:
-        specifier: ^0.31.1
-        version: 0.31.1
+        specifier: ^0.35.0
+        version: 0.35.0
     devDependencies:
       typescript:
         specifier: 5.4.2
@@ -871,8 +871,8 @@ importers:
         specifier: ^0.23.3
         version: link:../../../packages/vue-form
       valibot:
-        specifier: ^0.31.1
-        version: 0.31.1
+        specifier: ^0.35.0
+        version: 0.35.0
       vue:
         specifier: ^3.3.4
         version: 3.3.4
@@ -1068,8 +1068,8 @@ importers:
         version: link:../form-core
     devDependencies:
       valibot:
-        specifier: ^0.31.1
-        version: 0.31.1
+        specifier: ^0.35.0
+        version: 0.35.0
 
   packages/vue-form:
     dependencies:
@@ -7752,11 +7752,11 @@ packages:
     resolution: {integrity: sha512-fcRLaS4H/hrZk9hYwbdRM35D0U8IYMfEClhXxCivOojl+yTRAZH3Zy2sSy6qVCiGbV9YAtPssP6jaChqC9vPCg==}
     engines: {node: '>= 10.13.0'}
 
-  valibot@0.31.1:
-    resolution: {integrity: sha512-2YYIhPrnVSz/gfT2/iXVTrSj92HwchCt9Cga/6hX4B26iCz9zkIsGTS0HjDYTZfTi1Un0X6aRvhBi1cfqs/i0Q==}
-
   valibot@0.32.0:
     resolution: {integrity: sha512-FXBnJl4bNOmeg7lQv+jfvo/wADsRBN8e9C3r+O77Re3dEnDma8opp7p4hcIbF7XJJ30h/5SVohdjer17/sHOsQ==}
+
+  valibot@0.35.0:
+    resolution: {integrity: sha512-+i2aCRkReTrd5KBN/dW2BrPOvFnU5LXTV2xjZnjnqUIO8YUx6P2+MgRrkwF2FhkexgyKq/NIZdPdknhHf5A/Ww==}
 
   validate-html-nesting@1.2.2:
     resolution: {integrity: sha512-hGdgQozCsQJMyfK5urgFcWEqsSSrK63Awe0t/IMR0bZ0QMtnuaiHzThW81guu3qx9abLi99NEuiaN6P9gVYsNg==}
@@ -8260,7 +8260,7 @@ snapshots:
       watchpack: 2.4.0
       webpack: 5.90.3(@swc/core@1.4.6)(esbuild@0.20.2)
       webpack-dev-middleware: 6.1.1(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.1))
-      webpack-dev-server: 4.15.1(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.1))
+      webpack-dev-server: 4.15.1(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.2))
       webpack-merge: 5.10.0
       webpack-subresource-integrity: 5.1.0(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.1))
     optionalDependencies:
@@ -8349,7 +8349,7 @@ snapshots:
       watchpack: 2.4.0
       webpack: 5.90.3(@swc/core@1.4.6)(esbuild@0.20.2)
       webpack-dev-middleware: 6.1.1(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.1))
-      webpack-dev-server: 4.15.1(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.1))
+      webpack-dev-server: 4.15.1(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.2))
       webpack-merge: 5.10.0
       webpack-subresource-integrity: 5.1.0(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.1))
     optionalDependencies:
@@ -8379,7 +8379,7 @@ snapshots:
       '@angular-devkit/architect': 0.1703.0(chokidar@3.6.0)
       rxjs: 7.8.1
       webpack: 5.90.3(@swc/core@1.4.6)(esbuild@0.20.2)
-      webpack-dev-server: 4.15.1(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.1))
+      webpack-dev-server: 4.15.1(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.2))
     transitivePeerDependencies:
       - chokidar
 
@@ -13737,7 +13737,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@15.0.0-rc.0(react-dom@19.0.0-rc-6d3110b4d9-20240531(react@19.0.0-rc-6d3110b4d9-20240531))(react@19.0.0-rc-6d3110b4d9-20240531)(sass@1.72.0):
+  next@15.0.0-rc.0(@babel/core@7.24.7)(react-dom@19.0.0-rc-6d3110b4d9-20240531(react@19.0.0-rc-6d3110b4d9-20240531))(react@19.0.0-rc-6d3110b4d9-20240531)(sass@1.72.0):
     dependencies:
       '@next/env': 15.0.0-rc.0
       '@swc/helpers': 0.5.11
@@ -13747,7 +13747,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.0.0-rc-6d3110b4d9-20240531
       react-dom: 19.0.0-rc-6d3110b4d9-20240531(react@19.0.0-rc-6d3110b4d9-20240531)
-      styled-jsx: 5.1.3(react@19.0.0-rc-6d3110b4d9-20240531)
+      styled-jsx: 5.1.3(@babel/core@7.24.7)(react@19.0.0-rc-6d3110b4d9-20240531)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.0.0-rc.0
       '@next/swc-darwin-x64': 15.0.0-rc.0
@@ -15164,10 +15164,12 @@ snapshots:
 
   stubborn-fs@1.2.5: {}
 
-  styled-jsx@5.1.3(react@19.0.0-rc-6d3110b4d9-20240531):
+  styled-jsx@5.1.3(@babel/core@7.24.7)(react@19.0.0-rc-6d3110b4d9-20240531):
     dependencies:
       client-only: 0.0.1
       react: 19.0.0-rc-6d3110b4d9-20240531
+    optionalDependencies:
+      '@babel/core': 7.24.7
 
   stylis@4.2.0: {}
 
@@ -15221,7 +15223,7 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.4.6)(esbuild@0.20.2)(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.1)):
+  terser-webpack-plugin@5.3.10(@swc/core@1.4.6)(esbuild@0.20.2)(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.2)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -15546,9 +15548,9 @@ snapshots:
 
   v8flags@4.0.1: {}
 
-  valibot@0.31.1: {}
-
   valibot@0.32.0: {}
+
+  valibot@0.35.0: {}
 
   validate-html-nesting@1.2.2: {}
 
@@ -15764,7 +15766,7 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  webpack-dev-middleware@5.3.3(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.1)):
+  webpack-dev-middleware@5.3.3(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.2)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -15783,7 +15785,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.90.3(@swc/core@1.4.6)(esbuild@0.20.2)
 
-  webpack-dev-server@4.15.1(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.1)):
+  webpack-dev-server@4.15.1(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.2)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -15813,7 +15815,7 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.3(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.1))
+      webpack-dev-middleware: 5.3.3(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.2))
       ws: 8.16.0
     optionalDependencies:
       webpack: 5.90.3(@swc/core@1.4.6)(esbuild@0.20.2)
@@ -15859,7 +15861,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.4.6)(esbuild@0.20.2)(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.1))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.4.6)(esbuild@0.20.2)(webpack@5.90.3(@swc/core@1.4.6)(esbuild@0.20.2))
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
Unfortunately, I introduced a breaking change in a type of Valibot v0.33.0. So I updated the dependencies.