### PR TITLE
fix: Remove `form-core` type overrides from adapters

### DIFF
--- a/packages/react-form/src/createServerValidate.ts
+++ b/packages/react-form/src/createServerValidate.ts
@@ -17,16 +17,11 @@ type OnServerValidateOrFn<
   ? FFN | OnServerValidateFn<TFormData>
   : OnServerValidateFn<TFormData>
 
-declare module '@tanstack/form-core' {
-  // eslint-disable-next-line no-shadow
-  interface FormOptions<
-    TFormData,
-    TFormValidator extends
-      | Validator<TFormData, unknown>
-      | undefined = undefined,
-  > {
-    onServerValidate?: OnServerValidateOrFn<TFormData, TFormValidator>
-  }
+interface ServerFormOptions<
+  TFormData,
+  TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
+> extends FormOptions<TFormData, TFormValidator> {
+  onServerValidate?: OnServerValidateOrFn<TFormData, TFormValidator>
 }
 
 type ValidateFormData<
@@ -41,13 +36,13 @@ export const createServerValidate = <
   TFormData,
   TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
 >(
-  defaultOpts?: FormOptions<TFormData, TFormValidator>,
+  defaultOpts: ServerFormOptions<TFormData, TFormValidator>,
 ) =>
   (async (
     formData: FormData,
     info?: Parameters<typeof decode>[1],
   ): Promise<Partial<FormApi<TFormData, TFormValidator>['state']>> => {
-    const { validatorAdapter, onServerValidate } = defaultOpts || {}
+    const { validatorAdapter, onServerValidate } = defaultOpts
 
     const runValidator = (propsValue: { value: TFormData }) => {
       if (validatorAdapter && typeof onServerValidate !== 'function') {

--- a/packages/react-form/src/useForm.tsx
+++ b/packages/react-form/src/useForm.tsx
@@ -10,7 +10,7 @@ import type { NodeType } from './types'
 /**
  * Fields that are added onto the `FormAPI` from `@tanstack/form-core` and returned from `useForm`
  */
-export interface ReactFormApi<
+interface ReactFormApi<
   TFormData,
   TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
 > {
@@ -56,9 +56,7 @@ export interface ReactFormApi<
 export function useForm<
   TFormData,
   TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
->(
-  opts?: FormOptions<TFormData, TFormValidator>,
-) {
+>(opts?: FormOptions<TFormData, TFormValidator>) {
   const [formApi] = useState(() => {
     const api = new FormApi<TFormData, TFormValidator>(opts)
 

--- a/packages/react-form/src/useForm.tsx
+++ b/packages/react-form/src/useForm.tsx
@@ -7,31 +7,32 @@ import type { NoInfer } from '@tanstack/react-store'
 import type { FormOptions, FormState, Validator } from '@tanstack/form-core'
 import type { NodeType } from './types'
 
-declare module '@tanstack/form-core' {
+/**
+ * Fields that are added onto the `FormAPI` from `@tanstack/form-core` and returned from `useForm`
+ */
+export interface ReactFormApi<
+  TFormData,
+  TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
+> {
   /**
-   * When using `@tanstack/react-form`, the core form API is extended at type level with additional methods for React-specific functionality:
+   * A React component to render form fields. With this, you can render and manage individual form fields.
    */
-  // eslint-disable-next-line no-shadow
-  interface FormApi<TFormData, TFormValidator> {
+  Field: FieldComponent<TFormData, TFormValidator>
+  /**
+   * A custom React hook that provides functionalities related to individual form fields. It gives you access to field values, errors, and allows you to set or update field values.
+   */
+  useField: UseField<TFormData, TFormValidator>
+  /**
+   * A `useStore` hook that connects to the internal store of the form. It can be used to access the form's current state or any other related state information. You can optionally pass in a selector function to cherry-pick specific parts of the state
+   */
+  useStore: <TSelected = NoInfer<FormState<TFormData>>>(
+    selector?: (state: NoInfer<FormState<TFormData>>) => TSelected,
+  ) => TSelected
+  /**
+   * A `Subscribe` function that allows you to listen and react to changes in the form's state. It's especially useful when you need to execute side effects or render specific components in response to state updates.
+   */
+  Subscribe: <TSelected = NoInfer<FormState<TFormData>>>(props: {
     /**
-     * A React component to render form fields. With this, you can render and manage individual form fields.
-     */
-    Field: FieldComponent<TFormData, TFormValidator>
-    /**
-     * A custom React hook that provides functionalities related to individual form fields. It gives you access to field values, errors, and allows you to set or update field values.
-     */
-    useField: UseField<TFormData, TFormValidator>
-    /**
-     * A `useStore` hook that connects to the internal store of the form. It can be used to access the form's current state or any other related state information. You can optionally pass in a selector function to cherry-pick specific parts of the state
-     */
-    useStore: <TSelected = NoInfer<FormState<TFormData>>>(
-      selector?: (state: NoInfer<FormState<TFormData>>) => TSelected,
-    ) => TSelected
-    /**
-     * A `Subscribe` function that allows you to listen and react to changes in the form's state. It's especially useful when you need to execute side effects or render specific components in response to state updates.
-     */
-    Subscribe: <TSelected = NoInfer<FormState<TFormData>>>(props: {
-      /**
       TypeScript versions <=5.0.4 have a bug that prevents
       the type of the `TSelected` generic from being inferred
       from the return type of this method.
@@ -42,14 +43,13 @@ declare module '@tanstack/form-core' {
       @see {@link https://github.com/TanStack/form/pull/606/files#r1506715714 | This discussion on GitHub for the details}
       @see {@link https://github.com/microsoft/TypeScript/issues/52786 | The bug report in `microsoft/TypeScript`}
       */
-      selector?: (state: NoInfer<FormState<TFormData>>) => TSelected
-      children: ((state: NoInfer<TSelected>) => NodeType) | NodeType
-    }) => NodeType
-  }
+    selector?: (state: NoInfer<FormState<TFormData>>) => TSelected
+    children: ((state: NoInfer<TSelected>) => NodeType) | NodeType
+  }) => NodeType
 }
 
 /**
- * A custom React Hook that returns an instance of the `FormApi` class.
+ * A custom React Hook that returns an extended instance of the `FormApi` class.
  *
  * This API encapsulates all the necessary functionalities related to the form. It allows you to manage form state, handle submissions, and interact with form fields
  */
@@ -58,19 +58,22 @@ export function useForm<
   TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
 >(
   opts?: FormOptions<TFormData, TFormValidator>,
-): FormApi<TFormData, TFormValidator> {
+) {
   const [formApi] = useState(() => {
     const api = new FormApi<TFormData, TFormValidator>(opts)
-    api.Field = function APIField(props) {
+
+    const extendedApi: typeof api & ReactFormApi<TFormData, TFormValidator> =
+      api as never
+    extendedApi.Field = function APIField(props) {
       return (<Field {...props} form={api} />) as never
     }
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    api.useField = (props) => useField({ ...props, form: api })
-    api.useStore = (selector) => {
+    extendedApi.useField = (props) => useField({ ...props, form: api })
+    extendedApi.useStore = (selector) => {
       // eslint-disable-next-line react-hooks/rules-of-hooks
       return useStore(api.store as any, selector as any) as any
     }
-    api.Subscribe = (props) => {
+    extendedApi.Subscribe = (props) => {
       return functionalUpdate(
         props.children,
         // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -78,7 +81,7 @@ export function useForm<
       ) as any
     }
 
-    return api
+    return extendedApi
   })
 
   useIsomorphicLayoutEffect(formApi.mount, [])
@@ -93,5 +96,5 @@ export function useForm<
     formApi.update(opts)
   })
 
-  return formApi as any
+  return formApi
 }

--- a/packages/solid-form/src/createForm.tsx
+++ b/packages/solid-form/src/createForm.tsx
@@ -11,19 +11,19 @@ import type { FormOptions, FormState, Validator } from '@tanstack/form-core'
 
 type NoInfer<T> = [T][T extends any ? 0 : never]
 
-declare module '@tanstack/form-core' {
-  // eslint-disable-next-line no-shadow
-  interface FormApi<TFormData, TFormValidator> {
-    Field: FieldComponent<TFormData, TFormValidator>
-    createField: CreateField<TFormData, TFormValidator>
-    useStore: <TSelected = NoInfer<FormState<TFormData>>>(
-      selector?: (state: NoInfer<FormState<TFormData>>) => TSelected,
-    ) => () => TSelected
-    Subscribe: <TSelected = NoInfer<FormState<TFormData>>>(props: {
-      selector?: (state: NoInfer<FormState<TFormData>>) => TSelected
-      children: ((state: () => NoInfer<TSelected>) => JSXElement) | JSXElement
-    }) => JSXElement
-  }
+interface SolidFormApi<
+  TFormData,
+  TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
+> {
+  Field: FieldComponent<TFormData, TFormValidator>
+  createField: CreateField<TFormData, TFormValidator>
+  useStore: <TSelected = NoInfer<FormState<TFormData>>>(
+    selector?: (state: NoInfer<FormState<TFormData>>) => TSelected,
+  ) => () => TSelected
+  Subscribe: <TSelected = NoInfer<FormState<TFormData>>>(props: {
+    selector?: (state: NoInfer<FormState<TFormData>>) => TSelected
+    children: ((state: () => NoInfer<TSelected>) => JSXElement) | JSXElement
+  }) => JSXElement
 }
 
 export function createForm<
@@ -31,28 +31,28 @@ export function createForm<
   TFormValidator extends
     | Validator<TParentData, unknown>
     | undefined = undefined,
->(
-  opts?: () => FormOptions<TParentData, TFormValidator>,
-): FormApi<TParentData, TFormValidator> {
+>(opts?: () => FormOptions<TParentData, TFormValidator>) {
   const options = opts?.()
-  const formApi = new FormApi<TParentData, TFormValidator>(options)
+  const api = new FormApi<TParentData, TFormValidator>(options)
+  const extendedApi: typeof api & SolidFormApi<TParentData, TFormValidator> =
+    api as never
 
-  formApi.Field = (props) => <Field {...props} form={formApi} />
-  formApi.createField = (props) =>
+  extendedApi.Field = (props) => <Field {...props} form={api} />
+  extendedApi.createField = (props) =>
     createField(() => {
-      return { ...props(), form: formApi }
+      return { ...props(), form: api }
     })
-  formApi.useStore = (selector) => useStore(formApi.store, selector)
-  formApi.Subscribe = (props) =>
-    functionalUpdate(props.children, useStore(formApi.store, props.selector))
+  extendedApi.useStore = (selector) => useStore(api.store, selector)
+  extendedApi.Subscribe = (props) =>
+    functionalUpdate(props.children, useStore(api.store, props.selector))
 
-  onMount(formApi.mount)
+  onMount(api.mount)
 
   /**
    * formApi.update should not have any side effects. Think of it like a `useRef`
    * that we need to keep updated every render with the most up-to-date information.
    */
-  createComputed(() => formApi.update(opts?.()))
+  createComputed(() => api.update(opts?.()))
 
-  return formApi
+  return extendedApi
 }

--- a/packages/vue-form/src/useField.tsx
+++ b/packages/vue-form/src/useField.tsx
@@ -1,30 +1,17 @@
 import { FieldApi } from '@tanstack/form-core'
 import { useStore } from '@tanstack/vue-store'
 import { defineComponent, onMounted, onUnmounted, watch } from 'vue'
-import type {
-  DeepKeys,
-  DeepValue,
-  Narrow,
-  Validator,
-} from '@tanstack/form-core'
+import type { DeepKeys, DeepValue, Validator } from '@tanstack/form-core'
 import type { Ref, SetupContext, SlotsType } from 'vue'
 import type { UseFieldOptions } from './types'
 
-declare module '@tanstack/form-core' {
-  // eslint-disable-next-line no-shadow
-  interface FieldApi<
-    TParentData,
-    TName extends DeepKeys<TParentData>,
-    TFieldValidator extends
-      | Validator<DeepValue<TParentData, TName>, unknown>
-      | undefined = undefined,
-    TFormValidator extends
-      | Validator<TParentData, unknown>
-      | undefined = undefined,
-    TData = DeepValue<TParentData, TName>,
-  > {
-    Field: FieldComponent<TParentData, TFormValidator>
-  }
+interface VueFieldApi<
+  TParentData,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
+> {
+  Field: FieldComponent<TParentData, TFormValidator>
 }
 
 export type UseField<
@@ -44,7 +31,8 @@ export type UseField<
     'form'
   >,
 ) => {
-  api: FieldApi<TParentData, TName, TFieldValidator, TFormValidator, TData>
+  api: FieldApi<TParentData, TName, TFieldValidator, TFormValidator, TData> &
+    VueFieldApi<TParentData, TFormValidator>
   state: Readonly<
     Ref<
       FieldApi<
@@ -76,30 +64,20 @@ export function useField<
     TFormValidator,
     TData
   >,
-): {
-  api: FieldApi<TParentData, TName, TFieldValidator, TFormValidator, TData>
-  state: Readonly<
-    Ref<
-      FieldApi<
-        TParentData,
-        TName,
-        TFieldValidator,
-        TFormValidator,
-        TData
-      >['state']
-    >
-  >
-} {
+) {
   const fieldApi = (() => {
     const api = new FieldApi({
       ...opts,
       form: opts.form,
       name: opts.name,
-    } as never)
+    })
 
-    api.Field = Field as never
+    const extendedApi: typeof api & VueFieldApi<TParentData, TFormValidator> =
+      api as never
 
-    return api
+    extendedApi.Field = Field as never
+
+    return extendedApi
   })()
 
   const fieldState = useStore(fieldApi.store, (state) => state)
@@ -121,7 +99,7 @@ export function useField<
     },
   )
 
-  return { api: fieldApi, state: fieldState } as never
+  return { api: fieldApi, state: fieldState } as const
 }
 
 type FieldComponentProps<
@@ -202,7 +180,7 @@ export const Field = defineComponent(
     >,
     context: SetupContext,
   ) => {
-    const fieldApi = useField({ ...fieldOptions, ...context.attrs } as any)
+    const fieldApi = useField({ ...fieldOptions, ...context.attrs })
 
     return () =>
       context.slots.default!({

--- a/packages/vue-form/src/useForm.tsx
+++ b/packages/vue-form/src/useForm.tsx
@@ -7,36 +7,36 @@ import type { NoInfer } from '@tanstack/vue-store'
 import type { EmitsOptions, Ref, SetupContext, SlotsType } from 'vue'
 import type { FieldComponent, UseField } from './useField'
 
-declare module '@tanstack/form-core' {
-  // eslint-disable-next-line no-shadow
-  interface FormApi<TFormData, TFormValidator> {
-    Field: FieldComponent<TFormData, TFormValidator>
-    useField: UseField<TFormData, TFormValidator>
-    useStore: <TSelected = NoInfer<FormState<TFormData>>>(
-      selector?: (state: NoInfer<FormState<TFormData>>) => TSelected,
-    ) => Readonly<Ref<TSelected>>
-    Subscribe: <TSelected = NoInfer<FormState<TFormData>>>(
-      props: {
-        selector?: (state: NoInfer<FormState<TFormData>>) => TSelected
-      },
-      context: SetupContext<
-        EmitsOptions,
-        SlotsType<{ default: NoInfer<FormState<TFormData>> }>
-      >,
-    ) => any
-  }
+interface VueFormApi<
+  TFormData,
+  TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
+> {
+  Field: FieldComponent<TFormData, TFormValidator>
+  useField: UseField<TFormData, TFormValidator>
+  useStore: <TSelected = NoInfer<FormState<TFormData>>>(
+    selector?: (state: NoInfer<FormState<TFormData>>) => TSelected,
+  ) => Readonly<Ref<TSelected>>
+  Subscribe: <TSelected = NoInfer<FormState<TFormData>>>(
+    props: {
+      selector?: (state: NoInfer<FormState<TFormData>>) => TSelected
+    },
+    context: SetupContext<
+      EmitsOptions,
+      SlotsType<{ default: NoInfer<FormState<TFormData>> }>
+    >,
+  ) => any
 }
 
 export function useForm<
   TFormData,
   TFormValidator extends Validator<TFormData, unknown> | undefined = undefined,
->(
-  opts?: FormOptions<TFormData, TFormValidator>,
-): FormApi<TFormData, TFormValidator> {
+>(opts?: FormOptions<TFormData, TFormValidator>) {
   const formApi = (() => {
     const api = new FormApi<TFormData, TFormValidator>(opts)
 
-    api.Field = defineComponent(
+    const extendedApi: typeof api & VueFormApi<TFormData, TFormValidator> =
+      api as never
+    extendedApi.Field = defineComponent(
       (props, context) => {
         return () =>
           h(
@@ -50,11 +50,14 @@ export function useForm<
         inheritAttrs: false,
       },
     )
-    api.useField = (props) => useField({ ...props, form: api })
-    api.useStore = (selector) => {
+    extendedApi.useField = (props) => {
+      const field = useField({ ...props, form: api })
+      return field
+    }
+    extendedApi.useStore = (selector) => {
       return useStore(api.store as never, selector as never) as never
     }
-    api.Subscribe = defineComponent(
+    extendedApi.Subscribe = defineComponent(
       (props, context) => {
         const allProps = { ...props, ...context.attrs }
         const selector = allProps.selector ?? ((state) => state)
@@ -67,7 +70,7 @@ export function useForm<
       },
     )
 
-    return api
+    return extendedApi
   })()
 
   onMounted(formApi.mount)
@@ -75,5 +78,5 @@ export function useForm<
   // formApi.useStore((state) => state.isSubmitting)
   formApi.update(opts)
 
-  return formApi as never
+  return formApi
 }


### PR DESCRIPTION
Previously, we were patching the types of `form-core` in our framework adapters, which meant that any imports to `@tanstack/form-core` would _technically_ not be correct. This PR fixes this by localizing these imports and making them more accurate.