### PR TITLE
feat(core): add field listeners

### DIFF
--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -129,6 +129,24 @@ export type FieldAsyncValidateOrFn<
         TData
       >
 
+/**
+ * @private
+ */
+export type FieldListenerFn<
+  TParentData,
+  TName extends DeepKeys<TParentData>,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
+  TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
+> = (props: {
+  value: TData
+  fieldApi: FieldApi<TParentData, TName, TFieldValidator, TFormValidator, TData>
+}) => void
+
 export interface FieldValidators<
   TParentData,
   TName extends DeepKeys<TParentData>,
@@ -251,6 +269,40 @@ export interface FieldValidators<
   >
 }
 
+export interface FieldListeners<
+  TParentData,
+  TName extends DeepKeys<TParentData>,
+  TFieldValidator extends
+    | Validator<DeepValue<TParentData, TName>, unknown>
+    | undefined = undefined,
+  TFormValidator extends
+    | Validator<TParentData, unknown>
+    | undefined = undefined,
+  TData extends DeepValue<TParentData, TName> = DeepValue<TParentData, TName>,
+> {
+  onChange?: FieldListenerFn<
+    TParentData,
+    TName,
+    TFieldValidator,
+    TFormValidator,
+    TData
+  >
+  onHandleChange?: FieldListenerFn<
+    TParentData,
+    TName,
+    TFieldValidator,
+    TFormValidator,
+    TData
+  >
+  onBlur?: FieldListenerFn<
+    TParentData,
+    TName,
+    TFieldValidator,
+    TFormValidator,
+    TData
+  >
+}
+
 /**
  * An object type representing the options for a field in a form.
  */
@@ -299,6 +351,16 @@ export interface FieldOptions<
    * An optional object with default metadata for the field.
    */
   defaultMeta?: Partial<FieldMeta>
+  /**
+   * A list of listeners which attach to the corresponding events
+   */
+  listeners?: FieldListeners<
+    TParentData,
+    TName,
+    TFieldValidator,
+    TFormValidator,
+    TData
+  >
 }
 
 /**
@@ -479,6 +541,11 @@ export class FieldApi<
 
           this.prevState = state
           this.state = state
+
+          this.options.listeners?.onChange?.({
+            value: state.value,
+            fieldApi: this,
+          })
         },
       },
     )
@@ -949,6 +1016,11 @@ export class FieldApi<
    */
   handleChange = (updater: Updater<TData>) => {
     this.setValue(updater, { touch: true })
+
+    this.options.listeners?.onHandleChange?.({
+      value: this.state.value,
+      fieldApi: this,
+    })
   }
 
   /**
@@ -961,6 +1033,11 @@ export class FieldApi<
       this.validate('change')
     }
     this.validate('blur')
+
+    this.options.listeners?.onBlur?.({
+      value: this.state.value,
+      fieldApi: this,
+    })
   }
 }
 

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -802,6 +802,78 @@ describe('field api', () => {
     })
   })
 
+  it('should run listener on handleChange', () => {
+    const form = new FormApi({
+      defaultValues: {
+        name: 'test',
+      },
+    })
+
+    let triggered!: string
+    const field = new FieldApi({
+      form,
+      name: 'name',
+      listeners: {
+        onHandleChange: ({ value }) => {
+          triggered = value
+        },
+      },
+    })
+
+    field.mount()
+
+    field.handleChange('other')
+    expect(triggered).toStrictEqual('other')
+  })
+
+  it('should run listener onChange', () => {
+    const form = new FormApi({
+      defaultValues: {
+        name: 'test',
+      },
+    })
+
+    let triggered!: string
+    const field = new FieldApi({
+      form,
+      name: 'name',
+      listeners: {
+        onChange: ({ value }) => {
+          triggered = value
+        },
+      },
+    })
+
+    field.mount()
+
+    field.setValue('other', { touch: true })
+    expect(triggered).toStrictEqual('other')
+  })
+
+  it('should run listener onBlur', () => {
+    const form = new FormApi({
+      defaultValues: {
+        name: 'test',
+      },
+    })
+
+    let triggered!: string
+    const field = new FieldApi({
+      form,
+      name: 'name',
+      listeners: {
+        onBlur: ({ value }) => {
+          triggered = value
+        },
+      },
+    })
+
+    field.mount()
+
+    field.handleBlur()
+    expect(triggered).toStrictEqual('test')
+  })
+
   it('should contain multiple errors when running validation onBlur and onChange', () => {
     const form = new FormApi({
       defaultValues: {


### PR DESCRIPTION
from discussion #709 

### Background

Sometimes we may want to attach our own side effects to the field when some event happends. For example, resetting another field if some field value has changed.

Attaching these 'listeners' inside the validator does not work as intended because validator does not guarantee if it was triggered by the exact event. (eg. all validators run when form submits)

It's of course possible to implement but it's not very clean and the concerns become scattered.

### Proposal

This PR adds `listeners` api to the field for easy handling of forementioned use cases.

`onChange` and `onHandleChange` are differentiated because `onHandleChange` captures the 'manual' changes to the field. (eg. user input) while `onChange` also captures programmatic changes. (eg. `setValue`)

### Thoughts

I'm not certain about the whole idea or implementation, open to suggestions.