### PR TITLE
test: fix async validation tests with adapters

### DIFF
--- a/packages/valibot-form-adapter/tests/FieldApi.spec.ts
+++ b/packages/valibot-form-adapter/tests/FieldApi.spec.ts
@@ -74,7 +74,10 @@ describe('valibot field api', () => {
       validators: {
         onChangeAsync: v.pipeAsync(
           v.string(),
-          v.checkAsync(async (val) => val.length > 3, 'Testing 123'),
+          v.checkAsync(async (val) => {
+            await sleep(1)
+            return val.length > 3
+          }, 'Testing 123'),
         ),
         onChangeAsyncDebounceMs: 0,
       },
@@ -103,8 +106,10 @@ describe('valibot field api', () => {
       validatorAdapter: valibotValidator(),
       name: 'name',
       validators: {
-        onChangeAsync: async ({ value }) =>
-          value === 'a' ? 'Test' : undefined,
+        onChangeAsync: async ({ value }) => {
+          await sleep(1)
+          return value === 'a' ? 'Test' : undefined
+        },
         onChangeAsyncDebounceMs: 0,
       },
     })

--- a/packages/yup-form-adapter/tests/FieldApi.spec.ts
+++ b/packages/yup-form-adapter/tests/FieldApi.spec.ts
@@ -71,9 +71,10 @@ describe('yup field api', () => {
       validators: {
         onChangeAsync: yup
           .string()
-          .test('Testing 123', 'Testing 123', async (val) =>
-            typeof val === 'string' ? val.length > 3 : false,
-          ),
+          .test('Testing 123', 'Testing 123', async (val) => {
+            await sleep(1)
+            return typeof val === 'string' ? val.length > 3 : false
+          }),
         onChangeAsyncDebounceMs: 0,
       },
     })
@@ -101,8 +102,10 @@ describe('yup field api', () => {
       validatorAdapter: yupValidator(),
       name: 'name',
       validators: {
-        onChangeAsync: async ({ value }) =>
-          value === 'a' ? 'Test' : undefined,
+        onChangeAsync: async ({ value }) => {
+          await sleep(1)
+          return value === 'a' ? 'Test' : undefined
+        },
         onChangeAsyncDebounceMs: 0,
       },
     })

--- a/packages/zod-form-adapter/tests/FieldApi.spec.ts
+++ b/packages/zod-form-adapter/tests/FieldApi.spec.ts
@@ -70,9 +70,15 @@ describe('zod field api', () => {
       validatorAdapter: zodValidator(),
       name: 'name',
       validators: {
-        onChangeAsync: z.string().refine(async (val) => val.length > 3, {
-          message: 'Testing 123',
-        }),
+        onChangeAsync: z.string().refine(
+          async (val) => {
+            await sleep(1)
+            return val.length > 3
+          },
+          {
+            message: 'Testing 123',
+          },
+        ),
         onChangeAsyncDebounceMs: 0,
       },
     })
@@ -100,8 +106,10 @@ describe('zod field api', () => {
       validatorAdapter: zodValidator(),
       name: 'name',
       validators: {
-        onChangeAsync: async ({ value }) =>
-          value === 'a' ? 'Test' : undefined,
+        onChangeAsync: async ({ value }) => {
+          await sleep(1)
+          return value === 'a' ? 'Test' : undefined
+        },
         onChangeAsyncDebounceMs: 0,
       },
     })


### PR DESCRIPTION
I'm not sure why [this test failed](https://github.com/TanStack/form/actions/runs/9738060935/job/26871065053#step:5:554) on the CI but not locally.

Giving it a try with an actual async operation to be awaited.