### PR TITLE
Add 'setErrorMap' api to 'formApi' and 'fieldApi'

### DIFF
--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -963,6 +963,19 @@ export class FieldApi<
     }
     this.validate('blur')
   }
+
+  /**
+   * Updates the field's errorMap  
+   */
+  setErrorMap(errorMap: ValidationErrorMap) {
+    this.setMeta((prev) => ({
+      ...prev,
+      errorMap: {
+        ...prev.errorMap,
+        ...errorMap,
+      },
+    }))
+  }
 }
 
 function normalizeError(rawError?: ValidationError) {

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -965,7 +965,7 @@ export class FieldApi<
   }
 
   /**
-   * Updates the field's errorMap  
+   * Updates the field's errorMap
    */
   setErrorMap(errorMap: ValidationErrorMap) {
     this.setMeta((prev) => ({

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -1096,7 +1096,7 @@ export class FormApi<
     this.validateField(`${field}[${index2}]` as DeepKeys<TFormData>, 'change')
   }
   /**
-   * Updates the form's errorMap  
+   * Updates the form's errorMap
    */
   setErrorMap(errorMap: ValidationErrorMap) {
     this.store.setState((prev) => ({

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -1095,6 +1095,18 @@ export class FormApi<
     this.validateField(`${field}[${index1}]` as DeepKeys<TFormData>, 'change')
     this.validateField(`${field}[${index2}]` as DeepKeys<TFormData>, 'change')
   }
+  /**
+   * Updates the form's errorMap  
+   */
+  setErrorMap(errorMap: ValidationErrorMap) {
+    this.store.setState((prev) => ({
+      ...prev,
+      errorMap: {
+        ...prev.errorMap,
+        ...errorMap,
+      },
+    }))
+  }
 }
 
 function normalizeError(rawError?: ValidationError) {

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -1270,4 +1270,63 @@ describe('field api', () => {
       'Passwords do not match',
     ])
   })
+
+  it('should add  a new value to the fieldApi errorMap', () => {
+    interface Form {
+      name: string
+    }
+    const form = new FormApi<Form>()
+    const nameField = new FieldApi({
+      form,
+      name: 'name',
+    })
+    nameField.mount()
+    nameField.setErrorMap({
+      onChange: "name can't be Josh",
+    })
+    expect(nameField.getMeta().errorMap.onChange).toEqual("name can't be Josh")
+  })
+  it('should preserve other values in the fieldApi errorMap when adding other values', () => {
+    interface Form {
+      name: string
+    }
+    const form = new FormApi<Form>()
+    const nameField = new FieldApi({
+      form,
+      name: 'name',
+    })
+    nameField.mount()
+    nameField.setErrorMap({
+      onChange: "name can't be Josh",
+    })
+    expect(nameField.getMeta().errorMap.onChange).toEqual("name can't be Josh")
+    nameField.setErrorMap({
+      onBlur: 'name must begin with uppercase',
+    })
+    expect(nameField.getMeta().errorMap.onChange).toEqual("name can't be Josh")
+    expect(nameField.getMeta().errorMap.onBlur).toEqual(
+      'name must begin with uppercase',
+    )
+  })
+  it('should replace errorMap value if it exists in the fieldApi object', () => {
+    interface Form {
+      name: string
+    }
+    const form = new FormApi<Form>()
+    const nameField = new FieldApi({
+      form,
+      name: 'name',
+    })
+    nameField.mount()
+    nameField.setErrorMap({
+      onChange: "name can't be Josh",
+    })
+    expect(nameField.getMeta().errorMap.onChange).toEqual("name can't be Josh")
+    nameField.setErrorMap({
+      onChange: 'other validation error',
+    })
+    expect(nameField.getMeta().errorMap.onChange).toEqual(
+      'other validation error',
+    )
+  })
 })

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -1527,4 +1527,43 @@ describe('form api', () => {
       { nameInfo: { first: 'firstName' } },
     ])
   })
+  it('should add  a new value to the formApi errorMap', () => {
+    interface Form {
+      name: string
+    }
+    const form = new FormApi<Form>()
+    form.setErrorMap({
+      onChange: "name can't be Josh",
+    })
+    expect(form.state.errorMap.onChange).toEqual("name can't be Josh")
+  })
+  it('should preserve other values in the formApi errorMap when adding other values', () => {
+    interface Form {
+      name: string
+    }
+    const form = new FormApi<Form>()
+    form.setErrorMap({
+      onChange: "name can't be Josh",
+    })
+    expect(form.state.errorMap.onChange).toEqual("name can't be Josh")
+    form.setErrorMap({
+      onBlur: 'name must begin with uppercase',
+    })
+    expect(form.state.errorMap.onChange).toEqual("name can't be Josh")
+    expect(form.state.errorMap.onBlur).toEqual('name must begin with uppercase')
+  })
+  it('should replace errorMap value if it exists in the FormApi object', () => {
+    interface Form {
+      name: string
+    }
+    const form = new FormApi<Form>()
+    form.setErrorMap({
+      onChange: "name can't be Josh",
+    })
+    expect(form.state.errorMap.onChange).toEqual("name can't be Josh")
+    form.setErrorMap({
+      onChange: 'other validation error',
+    })
+    expect(form.state.errorMap.onChange).toEqual('other validation error')
+  })
 })


### PR DESCRIPTION
This PR adds an ability to set errorMap on a fieldApi on formApi as requested in #786.

work done:
- [x] adding the setErrorMap to both of fieldApi and formApi
- [x] write test for
    - [x] checking if the values are added
    - [x] checking if the other values on the errorMap are not overriden by incomming errorMap
    - [x] checking that only the concerned value is overriden when setting erroMap
- [x] add the necessary documentation on FormApi and FieldApi

Feel free to reach out if any of the implementation made needs to be corrected.
