### PR TITLE
refactor(react-form/nextjs): update `onServerValidate` to enable async behavior

### DIFF
--- a/packages/react-form/src/nextjs/createServerValidate.ts
+++ b/packages/react-form/src/nextjs/createServerValidate.ts
@@ -9,7 +9,7 @@ import type { ServerFormState } from './types'
 
 type OnServerValidateFn<TFormData> = (props: {
   value: TFormData
-}) => ValidationError
+}) => ValidationError | Promise<ValidationError>
 
 interface CreateServerValidateOptions<
   TFormData,
@@ -30,7 +30,7 @@ export const createServerValidate =
   async (formData: FormData, info?: Parameters<typeof decode>[1]) => {
     const { validatorAdapter, onServerValidate } = defaultOpts
 
-    const runValidator = (propsValue: { value: TFormData }) => {
+    const runValidator = async (propsValue: { value: TFormData }) => {
       if (validatorAdapter && typeof onServerValidate !== 'function') {
         return validatorAdapter().validate(propsValue, onServerValidate)
       }
@@ -40,7 +40,7 @@ export const createServerValidate =
 
     const values = decode(formData, info) as never as TFormData
 
-    const onServerError = runValidator({ value: values })
+    const onServerError = await runValidator({ value: values })
 
     if (!onServerError) return
 

--- a/packages/react-form/tests/nextjs/createServerValidate.test.ts
+++ b/packages/react-form/tests/nextjs/createServerValidate.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+import { ServerValidateError, createServerValidate } from '../../src/nextjs'
+
+describe('createServerValidate', () => {
+  const syncOnServerValidate = createServerValidate({
+    defaultValues: {
+      name: '',
+    },
+    onServerValidate: ({ value }) => {
+      const { name } = value
+      if (!name) return 'Name is required'
+      return
+    },
+  })
+
+  const asyncOnServerValidate = createServerValidate({
+    defaultValues: {
+      name: '',
+    },
+    onServerValidate: async ({ value }) => {
+      const errorMessage = await Promise.resolve('Name is required')
+
+      const { name } = value
+      if (!name) return errorMessage
+      return
+    },
+  })
+
+  it('onServerValidate throws ServerValidateError', () => {
+    const formData = new FormData()
+    formData.append('name', '')
+
+    expect(syncOnServerValidate(formData)).rejects.toThrowError(
+      ServerValidateError,
+    )
+
+    expect(asyncOnServerValidate(formData)).rejects.toThrowError(
+      ServerValidateError,
+    )
+  })
+
+  it('onSeverValidate returns formState', async () => {
+    const formData = new FormData()
+    formData.append('name', '')
+
+    try {
+      await syncOnServerValidate(formData)
+    } catch (e) {
+      if (e instanceof ServerValidateError) {
+        expect(e.formState).toHaveProperty('errors')
+        expect(e.formState.errors[0]).toEqual('Name is required')
+      }
+    }
+
+    try {
+      await asyncOnServerValidate(formData)
+    } catch (e) {
+      if (e instanceof ServerValidateError) {
+        expect(e.formState).toHaveProperty('errors')
+        expect(e.formState.errors[0]).toEqual('Name is required')
+      }
+    }
+  })
+})


### PR DESCRIPTION
It's not possible to run async validations in the `onServerValidate` function. This PR enables that.

- Update `OnServerValidateFn` return type
- Add `async`/`await` keywords to `runValidator`
- Add tests

Fixes https://github.com/TanStack/form/issues/737