### PR TITLE
fix(solid-form): Build ESM, CJS, and source

### DIFF
--- a/packages/solid-form/package.json
+++ b/packages/solid-form/package.json
@@ -27,21 +27,25 @@
     "test:lib": "vitest",
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",
-    "build": "tsc -p tsconfig.build.json"
+    "build": "vite build && tsc -p tsconfig.build.json"
   },
   "type": "module",
-  "types": "dist/index.d.ts",
-  "main": "dist/index.jsx",
-  "module": "dist/index.jsx",
+  "types": "dist/esm/index.d.ts",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "solid": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.jsx"
+        "types": "./dist/source/index.d.ts",
+        "default": "./dist/source/index.jsx"
       },
       "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.jsx"
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
       }
     },
     "./package.json": "./package.json"

--- a/packages/solid-form/tsconfig.build.json
+++ b/packages/solid-form/tsconfig.build.json
@@ -5,7 +5,7 @@
     "jsxImportSource": "solid-js",
     "moduleResolution": "Bundler",
     "rootDir": "src",
-    "outDir": "dist",
+    "outDir": "dist/source",
     "noEmit": false,
     "declaration": true,
     "sourceMap": true,

--- a/packages/solid-form/vite.config.ts
+++ b/packages/solid-form/vite.config.ts
@@ -1,8 +1,9 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig, mergeConfig } from 'vitest/config'
+import { tanstackViteConfig } from '@tanstack/config/vite'
 import solid from 'vite-plugin-solid'
 import packageJson from './package.json'
 
-export default defineConfig({
+const config = defineConfig({
   plugins: [solid()],
   test: {
     name: packageJson.name,
@@ -14,3 +15,11 @@ export default defineConfig({
     typecheck: { enabled: true },
   },
 })
+
+export default mergeConfig(
+  config,
+  tanstackViteConfig({
+    entry: ['./src/index.tsx'],
+    srcDir: './src',
+  }),
+)


### PR DESCRIPTION
This implements the changes discussed on Corbin's stream with Ryan.
- `esm` and `cjs` builds are now generated again for use in no-build environments
- The JSX-preserving build is now generated in `source`, keeping with Solid ecosystem conventions
- The `source` entrypoint is still `.jsx` to make sure that all JSX gets compiled properly