### PR TITLE
docs: fix doc issues and header consistency

### DIFF
--- a/docs/framework/angular/guides/arrays.md
+++ b/docs/framework/angular/guides/arrays.md
@@ -5,7 +5,7 @@ title: Arrays
 
 TanStack Form supports arrays as values in a form, including sub-object values inside of an array.
 
-# Basic Usage
+## Basic Usage
 
 To use an array, you can use `field.api.state.value` on an array value:
 

--- a/docs/framework/angular/guides/basic-concepts.md
+++ b/docs/framework/angular/guides/basic-concepts.md
@@ -41,7 +41,7 @@ Each field has its own state, which includes its current value, validation statu
 Example:
 
 ```tsx
-const { value, error, touched, isValidating } = field.state
+const { value, meta: { errors, isValidating } } = field.state
 ```
 
 There are three field states can be very useful to see how the user interacts with a field. A field is _"touched"_ when the user clicks/tabs into it, _"pristine"_ until the user changes value in it, and _"dirty"_ after the value has been changed. You can check these states via the `isTouched`, `isPristine` and `isDirty` flags, as seen below.

--- a/docs/framework/react/guides/arrays.md
+++ b/docs/framework/react/guides/arrays.md
@@ -5,7 +5,7 @@ title: Arrays
 
 TanStack Form supports arrays as values in a form, including sub-object values inside of an array.
 
-# Basic Usage
+## Basic Usage
 
 To use an array, you can use `field.state.value` on an array value:
 

--- a/docs/framework/react/guides/basic-concepts.md
+++ b/docs/framework/react/guides/basic-concepts.md
@@ -80,7 +80,7 @@ Each field has its own state, which includes its current value, validation statu
 Example:
 
 ```tsx
-const { value, error, touched, isValidating } = field.state
+const { value, meta: { errors, isValidating } } = field.state
 ```
 
 There are three field states can be very useful to see how the user interacts with a field. A field is _"touched"_ when the user clicks/tabs into it, _"pristine"_ until the user changes value in it, and _"dirty"_ after the value has been changed. You can check these states via the `isTouched`, `isPristine` and `isDirty` flags, as seen below.

--- a/docs/framework/react/guides/linked-fields.md
+++ b/docs/framework/react/guides/linked-fields.md
@@ -1,4 +1,7 @@
-# Link Two Form Fields Together
+---
+id: linked-fields
+title: Link Two Form Fields Together
+---
 
 You may find yourself needing to link two fields together; when one is validated as another field's value has changed.
 One such usage is when you have both a `password` and `confirm_password` field,

--- a/docs/framework/vue/guides/basic-concepts.md
+++ b/docs/framework/vue/guides/basic-concepts.md
@@ -81,7 +81,7 @@ Each field has its own state, which includes its current value, validation statu
 Example:
 
 ```js
-const { value, error, touched, isValidating } = field.state
+const { value, meta: { errors, isValidating } } = field.state
 ```
 
 There are three field states can be very useful to see how the user interacts with a field. A field is _"touched"_ when the user clicks/tabs into it, _"pristine"_ until the user changes value in it, and _"dirty"_ after the value has been changed. You can check these states via the `isTouched`, `isPristine` and `isDirty` flags, as seen below.


### PR DESCRIPTION
This PR addresses several minor issues in the TanStack Form documentation:

1. **Basic Concepts Section**:
   - Updated the snippet to use `meta` for `errors` and `isValidating` since they're not directly in `field.state`.
   - New snippet: 
     ```javascript
     const { value, meta: { errors, isValidating } } = field.state
     ```

2. **Arrays Guide**:
   - Changed "Basic usage" subtopic header from `h1` to `h2` for better consistency.

3. **Linked Fields Guide**:
   - Added an `id` and `title` to the markdown to match other sections.

Links to the issues:
- [Basic Concepts](https://tanstack.com/form/latest/docs/framework/react/guides/basic-concepts#field-state)
- [Arrays Guide](https://tanstack.com/form/latest/docs/framework/react/guides/arrays)
- [Linked Fields](https://tanstack.com/form/latest/docs/framework/react/guides/linked-fields)