### PR TITLE
fix: maintain the form types when transforming with useTransform hook

### DIFF
--- a/packages/react-form/src/useTransform.ts
+++ b/packages/react-form/src/useTransform.ts
@@ -1,4 +1,4 @@
-import type { FormApi, Validator } from '@tanstack/form-core'
+import type { FormApi, FormTransform, Validator } from '@tanstack/form-core'
 
 export function useTransform<
   TFormData,
@@ -6,7 +6,7 @@ export function useTransform<
 >(
   fn: (formBase: FormApi<any, any>) => FormApi<TFormData, TFormValidator>,
   deps: unknown[],
-) {
+): FormTransform<TFormData, TFormValidator> {
   return {
     fn,
     deps,

--- a/packages/react-form/tests/useTransform.test-d.tsx
+++ b/packages/react-form/tests/useTransform.test-d.tsx
@@ -1,0 +1,30 @@
+import { assertType, it } from 'vitest'
+import { formOptions, mergeForm, useForm, useTransform } from '../src'
+import { type ServerFormState } from '../src/nextjs/types'
+
+it('should maintain the type of the form', () => {
+  const state = {} as ServerFormState<any>
+
+  const formOpts = formOptions({
+    defaultValues: {
+      firstName: '',
+      age: 123,
+    } as const,
+  })
+
+  function Comp() {
+    const form = useForm({
+      ...formOpts,
+      transform: useTransform(
+        (baseForm) => mergeForm(baseForm, state),
+        [state],
+      ),
+    })
+
+    assertType<123>(form.state.values.age)
+    assertType<string>(form.state.values.firstName)
+
+    // @ts-expect-error this should be a number
+    form.state.values.age = 'age'
+  }
+})


### PR DESCRIPTION
Passing the values (`fn` and `deps`) to `transform` works fine, it's just `useTransform` not being able to infer the `TFormData` properly.