### PR TITLE
Option for automatically resetting validators

### DIFF
--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -796,8 +796,6 @@ export class FieldApi<
       }))
     }
 
-    console.log(this.getMeta().errorMap) // TODO
-
     return { hasErrored }
   }
 

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -467,10 +467,13 @@ export class FieldApi<
         onUpdate: () => {
           const state = this.store.state
 
-          state.meta.errors = [...new Set(Object.values(state.meta.errorMap).filter(
-            (val: unknown) => val !== undefined,
-          ))];
-
+          state.meta.errors = [
+            ...new Set(
+              Object.values(state.meta.errorMap).filter(
+                (val: unknown) => val !== undefined,
+              ),
+            ),
+          ]
 
           state.meta.isPristine = !state.meta.isDirty
 
@@ -793,7 +796,7 @@ export class FieldApi<
       }))
     }
 
-    console.log(this.getMeta().errorMap); // TODO
+    console.log(this.getMeta().errorMap) // TODO
 
     return { hasErrored }
   }

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -467,13 +467,9 @@ export class FieldApi<
         onUpdate: () => {
           const state = this.store.state
 
-          state.meta.errors = [
-            ...new Set(
-              Object.values(state.meta.errorMap).filter(
-                (val: unknown) => val !== undefined,
-              ),
-            ),
-          ]
+          state.meta.errors = Object.values(state.meta.errorMap).filter(
+            (val: unknown) => val !== undefined,
+          )
 
           state.meta.isPristine = !state.meta.isDirty
 

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -467,9 +467,10 @@ export class FieldApi<
         onUpdate: () => {
           const state = this.store.state
 
-          state.meta.errors = Object.values(state.meta.errorMap).filter(
+          state.meta.errors = [...new Set(Object.values(state.meta.errorMap).filter(
             (val: unknown) => val !== undefined,
-          )
+          ))];
+
 
           state.meta.isPristine = !state.meta.isDirty
 
@@ -791,6 +792,8 @@ export class FieldApi<
         },
       }))
     }
+
+    console.log(this.getMeta().errorMap); // TODO
 
     return { hasErrored }
   }

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -719,6 +719,12 @@ export class FieldApi<
    * @private
    */
   validateSync = (cause: ValidationCause) => {
+    if (this.form.options.automaticallyResetValidators === true)
+      this.setMeta((prev) => ({
+        ...prev,
+        errorMap: {},
+      }));
+
     const validates = getSyncValidatorArray(cause, this.options)
 
     const linkedFields = this.getLinkedFields(cause)

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -723,7 +723,7 @@ export class FieldApi<
       this.setMeta((prev) => ({
         ...prev,
         errorMap: {},
-      }));
+      }))
 
     const validates = getSyncValidatorArray(cause, this.options)
 

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -719,12 +719,6 @@ export class FieldApi<
    * @private
    */
   validateSync = (cause: ValidationCause) => {
-    if (this.form.options.automaticallyResetValidators === true)
-      this.setMeta((prev) => ({
-        ...prev,
-        errorMap: {},
-      }))
-
     const validates = getSyncValidatorArray(cause, this.options)
 
     const linkedFields = this.getLinkedFields(cause)
@@ -937,6 +931,13 @@ export class FieldApi<
     try {
       this.form.validate(cause)
     } catch (_) {}
+
+    // Clear previous validation errors
+    if (this.form.options.automaticallyResetValidators === true)
+      this.setMeta((prev) => ({
+        ...prev,
+        errorMap: {},
+      }))
 
     // Attempt to sync validate first
     const { hasErrored } = this.validateSync(cause)

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -172,7 +172,7 @@ export interface FormOptions<
    *
    * @default false
    */
-  automaticallyResetValidators?: boolean;
+  automaticallyResetValidators?: boolean
 }
 
 /**

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -169,6 +169,7 @@ export interface FormOptions<
    * While `false`:
    *  - An `onMount` error will never be cleared.
    *  - An `onBlur` error will only be cleared on the next `onBlur` event.
+   *  - An `onChange` error will only be cleared on the next `onChange` event.
    *
    * @default false
    */

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -160,6 +160,19 @@ export interface FormOptions<
     formApi: FormApi<TFormData, TFormValidator>
   }) => void
   transform?: FormTransform<TFormData, TFormValidator>
+  /**
+   * When true, all previous validation errors will be cleared when running validation.
+   *
+   * While `true`:
+   *  - `onMount` and `onBlur` errors will be cleared when `onChange` triggers validation.
+   *
+   * While `false`:
+   *  - An `onMount` error will never be cleared.
+   *  - An `onBlur` error will only be cleared on the next `onBlur` event.
+   *
+   * @default false
+   */
+  automaticallyResetValidators?: boolean;
 }
 
 /**


### PR DESCRIPTION
A potential solution for #903.

I think this is a more general solution than #726 but they both cover the same issue.

My assumption coming into Tanstack Form was that all previous validation errors would be cleared out when running the next validation but that doesn't seem to be the case.

So `onMount` returning an error means the error will *always exist* and `onBlur` returning an error is only cleared on the next blur event.

## New behavior

When `form.options.automaticallyResetValidators === true`  previous validation errors are cleared when running the validator,
else retain the previous behaviour.

## Known problems

Calling `.validateSync` or `.validateAsync` will not cause the fields to be reset. These fields are however marked as `@private` so I think this is fine.

I think fixing this would also add a lot more complexity because the `.validate` method calls `.validateSync` and then `.validateAsync`, so we would need to know *not* to clear the errors that were just added by `.validateSync` in `.validateAsync`.

## Questions

- [ ] One major question I have is what should the default be? Personally I think it should be `true` but this would be a breaking change.
