### PR TITLE
Deduplicate field and form `errors` property

### DIFF
--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -467,9 +467,13 @@ export class FieldApi<
         onUpdate: () => {
           const state = this.store.state
 
-          state.meta.errors = Object.values(state.meta.errorMap).filter(
-            (val: unknown) => val !== undefined,
-          )
+          state.meta.errors = [
+            ...new Set(
+              Object.values(state.meta.errorMap).filter(
+                (val: unknown) => val !== undefined,
+              ),
+            ),
+          ]
 
           state.meta.isPristine = !state.meta.isDirty
 

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -376,9 +376,13 @@ export class FormApi<
           const isPristine = !isDirty
 
           const isValidating = isFieldsValidating || state.isFormValidating
-          state.errors = Object.values(state.errorMap).filter(
-            (val: unknown) => val !== undefined,
-          )
+          state.errors = [
+            ...new Set(
+              Object.values(state.errorMap).filter(
+                (val: unknown) => val !== undefined,
+              ),
+            ),
+          ]
           const isFormValid = state.errors.length === 0
           const isValid = isFieldsValid && isFormValid
           const canSubmit =

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -953,7 +953,6 @@ describe('field api', () => {
     field.validate('blur')
     expect(field.getMeta().errors).toStrictEqual([
       'Please enter a different value',
-      'Please enter a different value',
     ])
     expect(field.getMeta().errorMap).toEqual({
       onBlur: 'Please enter a different value',

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -1160,10 +1160,7 @@ describe('form api', () => {
 
     field.setValue('other')
     field.validate('blur')
-    expect(form.state.errors).toStrictEqual([
-      'Please enter a different value',
-      'Please enter a different value',
-    ])
+    expect(form.state.errors).toStrictEqual(['Please enter a different value'])
     expect(form.state.errorMap).toEqual({
       onBlur: 'Please enter a different value',
       onChange: 'Please enter a different value',


### PR DESCRIPTION
The current behavior of `form.state.errors` and `field.getMeta().errors` is to collect up all errors within the `errorMap`. The implementation *does not* take care of removing duplicates and Form's unit tests assert this behaviour as expected.

I think this behaviour should potentially be reconsidered.

Personally I think it's very common as an application developer to apply the same validator to multiple events (Eg, `onMount` & `onChange`) and if that is done the `.errors` array will likely end up with duplicates.

If the application developer is to render a list of all errors for the current field/form using `.errors`, they will end up showing the user duplicates. I don't think a user should ever be shown duplicates because it is only one error for them to fix. Right now the application developer would be responsible for implementing deduplication logic and I feel like `.errors` should just do this by default.

If a developer really want the previous behavior they can easily do `Object.values(.errorMap)` but I feel like keeping duplicates is something you should need to opt-in to, as opposed to opt-out like it is right now.

Happy to close this PR if the discussion around changing this behavior decides it's not a great idea.