### PR TITLE
feat: pass on return value of onSubmit inside handleSubmit

### DIFF
--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -910,7 +910,7 @@ export class FormApi<
   /**
    * Handles the form submission, performs validation, and calls the appropriate onSubmit or onInvalidSubmit callbacks.
    */
-  handleSubmit = async () => {
+  handleSubmit = async (): Promise<any> => {
     this.store.setState((old) => ({
       ...old,
       // Submission attempts mark the form as not submitted
@@ -955,12 +955,16 @@ export class FormApi<
 
     try {
       // Run the submit code
-      await this.options.onSubmit?.({ value: this.state.values, formApi: this })
+      const result = await this.options.onSubmit?.({
+        value: this.state.values,
+        formApi: this,
+      })
 
       this.store.batch(() => {
         this.store.setState((prev) => ({ ...prev, isSubmitted: true }))
         done()
       })
+      return result
     } catch (err) {
       done()
       throw err


### PR DESCRIPTION
To be able to directly use the results returned by onSubmit the handleSubmit function should pass on the returned value after calling onSubmit. Issue here #949 