### PR TITLE
docs: update react-zod form example defining a zod schema

### DIFF
--- a/docs/framework/react/guides/validation.md
+++ b/docs/framework/react/guides/validation.md
@@ -487,12 +487,14 @@ import { z } from 'zod'
 
 // ...
 
+const formSchema = z.object({
+  age: z.number().gte(13, 'You must be 13 to make an account'),
+})
+
 const form = useForm({
   validatorAdapter: zodValidator(),
   validators: {
-    onChange: z.object({
-      age: z.number().gte(13, 'You must be 13 to make an account'),
-    }),
+    onChange: formSchema
   },
 })
 ```

--- a/examples/react/zod/src/index.tsx
+++ b/examples/react/zod/src/index.tsx
@@ -17,8 +17,10 @@ function FieldInfo({ field }: { field: FieldApi<any, any, any, any> }) {
 }
 
 const userSchema = z.object({
-  firstName: z.string(),
-  lastName: z.string(),
+  firstName: z.string().refine((val) => val !== 'John', {
+    message: '[Form] First name cannot be John',
+  }),
+  lastName: z.string().min(3, '[Form] Last name must be at least 3 characters'),
 })
 
 type User = z.infer<typeof userSchema>
@@ -57,7 +59,7 @@ export default function App() {
             validators={{
               onChange: z
                 .string()
-                .min(3, 'First name must be at least 3 characters'),
+                .min(3, '[Field] First name must be at least 3 characters'),
               onChangeAsyncDebounceMs: 500,
               onChangeAsync: z.string().refine(
                 async (value) => {
@@ -65,7 +67,7 @@ export default function App() {
                   return !value.includes('error')
                 },
                 {
-                  message: "No 'error' allowed in first name",
+                  message: "[Field] No 'error' allowed in first name",
                 },
               ),
             }}

--- a/examples/react/zod/src/index.tsx
+++ b/examples/react/zod/src/index.tsx
@@ -36,8 +36,8 @@ export default function App() {
     // Add a validator to support Zod usage in Form and Field
     validatorAdapter: zodValidator(),
     validators: {
-      onChange: userSchema
-    }
+      onChange: userSchema,
+    },
   })
 
   return (

--- a/examples/react/zod/src/index.tsx
+++ b/examples/react/zod/src/index.tsx
@@ -36,8 +36,8 @@ export default function App() {
     // Add a validator to support Zod usage in Form and Field
     validatorAdapter: zodValidator(),
     validators: {
-      onChange: formSchema
-    }
+      onChange: formSchema,
+    },
   })
 
   return (

--- a/examples/react/zod/src/index.tsx
+++ b/examples/react/zod/src/index.tsx
@@ -16,19 +16,19 @@ function FieldInfo({ field }: { field: FieldApi<any, any, any, any> }) {
   )
 }
 
-const formSchema = z.object({
+const userSchema = z.object({
   firstName: z.string(),
   lastName: z.string(),
 })
 
-type Form = z.infer<typeof formSchema>
+type User = z.infer<typeof userSchema>
 
 export default function App() {
   const form = useForm({
     defaultValues: {
       firstName: '',
       lastName: '',
-    } as Form,
+    } as User,
     onSubmit: async ({ value }) => {
       // Do something with form data
       console.log(value)
@@ -36,8 +36,8 @@ export default function App() {
     // Add a validator to support Zod usage in Form and Field
     validatorAdapter: zodValidator(),
     validators: {
-      onChange: formSchema,
-    },
+      onChange: userSchema
+    }
   })
 
   return (

--- a/examples/react/zod/src/index.tsx
+++ b/examples/react/zod/src/index.tsx
@@ -16,18 +16,28 @@ function FieldInfo({ field }: { field: FieldApi<any, any, any, any> }) {
   )
 }
 
+const formSchema = z.object({
+  firstName: z.string(),
+  lastName: z.string(),
+})
+
+type Form = z.infer<typeof formSchema>
+
 export default function App() {
   const form = useForm({
     defaultValues: {
       firstName: '',
       lastName: '',
-    },
+    } as Form,
     onSubmit: async ({ value }) => {
       // Do something with form data
       console.log(value)
     },
     // Add a validator to support Zod usage in Form and Field
     validatorAdapter: zodValidator(),
+    validators: {
+      onChange: formSchema
+    }
   })
 
   return (


### PR DESCRIPTION
Based on the discussion on https://github.com/TanStack/form/discussions/978 with @Balastrong 

This PR updates the docs example on `react/zod` using the most common case which is defining a `Zod` schema at the top level, and then using it on the `useForm` hook.