### PR TITLE
fix: dont merge arrays in `mergeForm`

### DIFF
--- a/docs/reference/functions/mergeform.md
+++ b/docs/reference/functions/mergeform.md
@@ -27,4 +27,4 @@ function mergeForm<TFormData, TFormValidator>(baseForm, state): FormApi<NoInfer<
 
 ## Defined in
 
-[packages/form-core/src/mergeForm.ts:37](https://github.com/TanStack/form/blob/main/packages/form-core/src/mergeForm.ts#L37)
+[packages/form-core/src/mergeForm.ts:35](https://github.com/TanStack/form/blob/main/packages/form-core/src/mergeForm.ts#L35)

--- a/docs/reference/functions/mergeform.md
+++ b/docs/reference/functions/mergeform.md
@@ -27,4 +27,4 @@ function mergeForm<TFormData, TFormValidator>(baseForm, state): FormApi<NoInfer<
 
 ## Defined in
 
-[packages/form-core/src/mergeForm.ts:35](https://github.com/TanStack/form/blob/main/packages/form-core/src/mergeForm.ts#L35)
+[packages/form-core/src/mergeForm.ts:36](https://github.com/TanStack/form/blob/main/packages/form-core/src/mergeForm.ts#L36)

--- a/packages/form-core/src/mergeForm.ts
+++ b/packages/form-core/src/mergeForm.ts
@@ -12,9 +12,10 @@ export function mutateMergeDeep(target: object, source: object): object {
   for (const key of keySet) {
     const targetKey = key as never as keyof typeof target
     const sourceKey = key as never as keyof typeof source
+
     if (Array.isArray(target[targetKey]) && Array.isArray(source[sourceKey])) {
-      target[targetKey] = ((source[sourceKey] as [] | undefined) ??
-        (target[targetKey] as [] | undefined)) as never
+      // always use the source array to prevent array fields from multiplying
+      target[targetKey] = source[sourceKey] as [] as never
     } else if (
       typeof target[targetKey] === 'object' &&
       typeof source[sourceKey] === 'object'

--- a/packages/form-core/src/mergeForm.ts
+++ b/packages/form-core/src/mergeForm.ts
@@ -13,10 +13,8 @@ export function mutateMergeDeep(target: object, source: object): object {
     const targetKey = key as never as keyof typeof target
     const sourceKey = key as never as keyof typeof source
     if (Array.isArray(target[targetKey]) && Array.isArray(source[sourceKey])) {
-      target[targetKey] = [
-        ...(target[targetKey] as []),
-        ...(source[sourceKey] as []),
-      ] as never
+      target[targetKey] = ((source[sourceKey] as [] | undefined) ??
+        (target[targetKey] as [] | undefined)) as never
     } else if (
       typeof target[targetKey] === 'object' &&
       typeof source[sourceKey] === 'object'

--- a/packages/form-core/tests/mutateMergeDeep.spec.ts
+++ b/packages/form-core/tests/mutateMergeDeep.spec.ts
@@ -16,11 +16,11 @@ describe('mutateMergeDeep', () => {
     expect(a).toStrictEqual({ a: undefined })
   })
 
-  test('Should merge two object by merging arrays', () => {
-    const a = { a: [1] }
-    const b = { a: [2] }
-    mutateMergeDeep(a, b)
-    expect(a).toStrictEqual({ a: [1, 2] })
+  test('Should merge two object by overriding arrays', () => {
+    const target = { a: [1] }
+    const source = { a: [2] }
+    mutateMergeDeep(target, source)
+    expect(target).toStrictEqual({ a: [2] })
   })
 
   test('Should merge two deeply nested objects', () => {

--- a/packages/form-core/tests/mutateMergeDeep.spec.ts
+++ b/packages/form-core/tests/mutateMergeDeep.spec.ts
@@ -23,6 +23,27 @@ describe('mutateMergeDeep', () => {
     expect(target).toStrictEqual({ a: [2] })
   })
 
+  test('Should merge add array element when it does not exist in target', () => {
+    const target = { a: [] }
+    const source = { a: [2] }
+    mutateMergeDeep(target, source)
+    expect(target).toStrictEqual({ a: [2] })
+  })
+
+  test('Should override the target array if source is undefined', () => {
+    const target = { a: [2] }
+    const source = { a: undefined }
+    mutateMergeDeep(target, source)
+    expect(target).toStrictEqual({ a: undefined })
+  })
+
+  test('Should merge update array element when it does not exist in source', () => {
+    const target = { a: [2] }
+    const source = { a: [] }
+    mutateMergeDeep(target, source)
+    expect(target).toStrictEqual({ a: [] })
+  })
+
   test('Should merge two deeply nested objects', () => {
     const a = { a: { a: 1 } }
     const b = { a: { b: 2 } }


### PR DESCRIPTION
- this causes form submissions to be duplicated when having an array field in your form

Example of the problem: https://stackblitz.com/edit/tanstack-form-vdj4yh?file=src%2Fapp%2Fshared-code.ts

Just try to submit the form and watch the todos to be duplicated