### PR TITLE
fix: Valibot peer dependency to support dist-tags

### DIFF
--- a/packages/valibot-form-adapter/package.json
+++ b/packages/valibot-form-adapter/package.json
@@ -58,6 +58,6 @@
     "valibot": "1.0.0-beta.2"
   },
   "peerDependencies": {
-    "valibot": "^1.0.0"
+    "valibot": "^1.0.0 || ^1.0.0-beta || ^1.0.0-rc"
   }
 }


### PR DESCRIPTION
Looks like the npm install broke with the upgrade to Valibot v1. This PR should fix that.