### PR TITLE
ci: set codecov target to auto

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,5 +2,5 @@ coverage:
   status:
     project:
       default:
-        target: 90%
+        target: auto
         threshold: 1%


### PR DESCRIPTION
We're currently below the previous threshold of 90% and all codecov checks are red.

Setting the target to [auto](https://docs.codecov.com/docs/common-recipe-list#increase-overall-coverage-on-each-pull-request) to ensure coverage does not go down but still make it pass if changes in the PR are tested.