### PR TITLE
chore: allow unusedLocals in standard-schema example

### DIFF
--- a/examples/react/standard-schema/src/index.tsx
+++ b/examples/react/standard-schema/src/index.tsx
@@ -17,7 +17,6 @@ function FieldInfo({ field }: { field: FieldApi<any, any, any, any> }) {
   )
 }
 
-// @ts-ignore - Might be unused for demo purposes
 const ZodSchema = z.object({
   firstName: z
     .string()
@@ -26,7 +25,6 @@ const ZodSchema = z.object({
   lastName: z.string().min(3, '[Zod] You must have a length of at least 3'),
 })
 
-// @ts-ignore - Might be unused for demo purposes
 const ValibotSchema = v.object({
   firstName: v.pipe(
     v.string(),
@@ -39,7 +37,6 @@ const ValibotSchema = v.object({
   ),
 })
 
-// @ts-ignore - Might be unused for demo purposes
 const ArkTypeSchema = type({
   firstName: 'string >= 3',
   lastName: 'string >= 3',

--- a/examples/react/standard-schema/tsconfig.json
+++ b/examples/react/standard-schema/tsconfig.json
@@ -15,7 +15,7 @@
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },


### PR DESCRIPTION
there were a bunch ts-ignores, which looks bad on an example

Personally I prefer policing unused locals via a linter, which helps assign more appropriate "seriousness" to tsc errors, and so unused local errors can be more easily suppressed, but that's just me so I didn't make a sweeping change here.