### PR TITLE
docs: re-add zod import in schema library example

### DIFF
--- a/docs/framework/angular/guides/basic-concepts.md
+++ b/docs/framework/angular/guides/basic-concepts.md
@@ -114,7 +114,7 @@ export class AppComponent {
 }
 ```
 
-## Validation with Schema Libraries
+## Validation with Standard Schema Libraries
 
 In addition to hand-rolled validation options, we also support the [Standard Schema](https://github.com/standard-schema/standard-schema) specification.
 

--- a/docs/framework/react/guides/basic-concepts.md
+++ b/docs/framework/react/guides/basic-concepts.md
@@ -144,7 +144,7 @@ Example:
 />
 ```
 
-## Validation with Schema Libraries
+## Validation with Standard Schema Libraries
 
 In addition to hand-rolled validation options, we also support the [Standard Schema](https://github.com/standard-schema/standard-schema) specification.
 
@@ -157,6 +157,8 @@ Supported libraries include:
 - [ArkType](https://arktype.io/)
 
 ```tsx
+import { z } from 'zod'
+
 const userSchema = z.object({
   age: z.number().gte(13, 'You must be 13 to make an account'),
 })

--- a/docs/framework/solid/guides/basic-concepts.md
+++ b/docs/framework/solid/guides/basic-concepts.md
@@ -139,7 +139,7 @@ Example:
 />
 ```
 
-## Validation with Schema Libraries
+## Validation with Standard Schema Libraries
 
 In addition to hand-rolled validation options, we also support the [Standard Schema](https://github.com/standard-schema/standard-schema) specification.
 

--- a/docs/framework/vue/guides/basic-concepts.md
+++ b/docs/framework/vue/guides/basic-concepts.md
@@ -146,7 +146,7 @@ Example:
 </template>
 ```
 
-## Validation with Schema Libraries
+## Validation with Standard Schema Libraries
 
 In addition to hand-rolled validation options, we also support the [Standard Schema](https://github.com/standard-schema/standard-schema) specification.
 


### PR DESCRIPTION
was removed by accident in #1064

@Balastrong sorry the "Schema Libraries" vs "Standard Schema Libraries" change slipped in with the one commit - renamed those Headlines as they only talk about the "Schema Libraries" that implement the "Standard Schema"