### PR TITLE
test: Standard Validator should handle multiple errors on a field

### DIFF
--- a/packages/form-core/tests/standardSchemaValidator.spec.ts
+++ b/packages/form-core/tests/standardSchemaValidator.spec.ts
@@ -395,3 +395,43 @@ describe('standard schema validator', () => {
     ])
   })
 })
+
+it('should handle multiple errors on a field', () => {
+  const form = new FormApi({
+    defaultValues: {
+      name: '',
+    },
+  })
+  const field = new FieldApi({
+    form,
+    name: 'name',
+    validators: {
+      onChange: z
+        .string()
+        .min(3, 'You must have a length of at least 3')
+        .regex(/^[a-z]+$/i, 'You must have only letters'),
+    },
+  })
+
+  field.mount()
+
+  // valid by default
+  expect(field.getMeta().errors).toEqual([])
+
+  // too short
+  field.setValue('a')
+  expect(field.getMeta().errors).toEqual([
+    'You must have a length of at least 3',
+  ])
+
+  // too short and invalid character
+  field.setValue('a#')
+  expect(field.getMeta().errors).toEqual([
+    'You must have a length of at least 3',
+    'You must have only letters',
+  ])
+
+  // valid
+  field.setValue('asdf')
+  expect(field.getMeta().errors).toEqual([])
+})


### PR DESCRIPTION
As the ZodAdapter is getting deprecated I refactored the failing test to go against the Standard Validator.

see: #943