### PR TITLE
feat(docs): reusable fields & reusable field utility type

### DIFF
--- a/docs/framework/react/guides/reusable-fields.md
+++ b/docs/framework/react/guides/reusable-fields.md
@@ -17,8 +17,8 @@ export default function GenericTextField<
   TName extends InferValidFormKeys<TForm, string>,
   TFormValidator extends Validator<TForm, unknown> | undefined,
 >({ name, form }: {
-   name: TName;
-   form: ReturnType<typeof useForm<TForm, TFormValidator>
+  name: TName;
+  form: ReturnType<typeof useForm<TForm, TFormValidator>
 > }): JSX.Element {
   return (
     <form.Field name={name}>
@@ -65,8 +65,8 @@ export default function GenericTextField<
   TName extends InferValidFormKeys<TForm, string>,
   TFormValidator extends Validator<TForm, unknown> | undefined,
 >({ name, form }: {
-   name: TName;
-   form: ReturnType<typeof useForm<TForm, TFormValidator>
+  name: TName;
+  form: ReturnType<typeof useForm<TForm, TFormValidator>
 > }): JSX.Element {
   return (
     <form.Field name={name}>
@@ -83,7 +83,7 @@ export default function GenericTextField<
 
 function App() {
   const form = useForm({
-    defaultValues: { name: '', id: 0 },
+    defaultValues: { name: '', id: 0, interests: {hobbies: 'climbing'} },
     onSubmit: ({ value }) => {
       console.log(value);
     },

--- a/docs/framework/react/guides/reusable-fields.md
+++ b/docs/framework/react/guides/reusable-fields.md
@@ -1,0 +1,94 @@
+---
+id: reusable-fields
+title: Creating reusable fields
+---
+
+As TanStack form is a headless library, we provide you the core building blocks and then give you the freedom to build on top of them. This page introduces the concept of creating reusable field-components for your form, allowing you to create fields that you can reuse throughout your app.
+
+## Basic Usage
+
+To create a reusable fields, you can do the following.
+
+```tsx
+import {  useForm, Validator, InferValidFormKeys } from '@tanstack/react-form';
+
+export default function GenericTextField<
+  TForm,
+  TName extends InferValidFormKeys<TForm, string>,
+  TFormValidator extends Validator<TForm, unknown> | undefined,
+>({ name, form }: {
+   name: TName;
+   form: ReturnType<typeof useForm<TForm, TFormValidator>
+> }): JSX.Element {
+  return (
+    <form.Field name={name}>
+      {({ handleChange, handleBlur, state }) => (
+        <input
+          value={state.value}
+          onChange={(e) => handleChange(e.target.value as any)}
+          onBlur={handleBlur}
+        />
+      )}
+    </form.Field>
+  );
+}
+```
+
+In this setup the GenericTextField will only accept names of fields that have a valid value type, in this case a string, as shown here.
+
+```tsx
+ TName extends InferValidFormKeys<TForm, string>,
+```
+
+Deep values can also be inferred using this method from the parent form.
+
+```tsx
+function App() {
+  const form = useForm({
+    defaultValues: { name: '', id: 0, interests: {hobbies: 'climbing'} },
+    onSubmit: ({ value }) => {
+      console.log(value);
+    },
+  });
+
+  return <GenericTextField form={form} name="interests.hobbies" />;
+}
+```
+
+## Full Example
+
+```tsx
+import {  useForm, Validator, InferValidFormKeys } from '@tanstack/react-form';
+
+export default function GenericTextField<
+  TForm,
+  TName extends InferValidFormKeys<TForm, string>,
+  TFormValidator extends Validator<TForm, unknown> | undefined,
+>({ name, form }: {
+   name: TName;
+   form: ReturnType<typeof useForm<TForm, TFormValidator>
+> }): JSX.Element {
+  return (
+    <form.Field name={name}>
+      {({ handleChange, handleBlur, state }) => (
+        <input
+          value={state.value}
+          onChange={(e) => handleChange(e.target.value as any)}
+          onBlur={handleBlur}
+        />
+      )}
+    </form.Field>
+  );
+}
+
+function App() {
+  const form = useForm({
+    defaultValues: { name: '', id: 0 },
+    onSubmit: ({ value }) => {
+      console.log(value);
+    },
+  });
+
+  return <GenericTextField form={form} name="name" />;
+}
+```

--- a/docs/framework/react/guides/reusable-fields.md
+++ b/docs/framework/react/guides/reusable-fields.md
@@ -10,14 +10,13 @@ As TanStack form is a headless library, we provide you the core building blocks 
 To create a reusable fields, you can do the following.
 
 ```tsx
-import {  InferValidFormKeys } from '@tanstack/react-form';
+import {  InferValidFormKeys, UseFormReturnType } from '@tanstack/react-form';
 
 export default function GenericTextField<
   TForm,
   TFormValidator
-  TName extends InferValidFormKeys<TForm, string>,
 >({ name, form }: {
-  name: TName;
+  name: InferValidFormKeys<TForm, string>;
   form: UseFormReturnType<TForm, TFormValidator>,
 > }): JSX.Element {
   return (
@@ -34,10 +33,10 @@ export default function GenericTextField<
 }
 ```
 
-In this setup the GenericTextField will only accept names of fields that have a valid value type, in this case a string, as shown here.
+With the InferValidFormKeys the GenericTextField component's name prop will only accept the names of fields that have a valid value type, in this case a string, as shown here.
 
 ```tsx
- TName extends InferValidFormKeys<TForm, string>,
+  name: InferValidFormKeys<TForm, string>;
 ```
 
 Deep values can also be inferred using this method from the parent form.
@@ -58,14 +57,13 @@ function App() {
 ## Full Example
 
 ```tsx
-import { InferValidFormKeys } from '@tanstack/react-form';
+import { InferValidFormKeys, UseFormReturnType } from '@tanstack/react-form';
 
 export default function GenericTextField<
   TForm,
   TFormValidator
-  TName extends InferValidFormKeys<TForm, string>,
 >({ name, form }: {
-  name: TName;
+  name: InferValidFormKeys<TForm, string>;
   form: UseFormReturnType<TForm, TFormValidator>
 > }): JSX.Element {
   return (

--- a/docs/framework/react/guides/reusable-fields.md
+++ b/docs/framework/react/guides/reusable-fields.md
@@ -10,15 +10,15 @@ As TanStack form is a headless library, we provide you the core building blocks 
 To create a reusable fields, you can do the following.
 
 ```tsx
-import {  useForm, Validator, InferValidFormKeys } from '@tanstack/react-form';
+import {  InferValidFormKeys } from '@tanstack/react-form';
 
 export default function GenericTextField<
   TForm,
+  TFormValidator
   TName extends InferValidFormKeys<TForm, string>,
-  TFormValidator extends Validator<TForm, unknown> | undefined,
 >({ name, form }: {
   name: TName;
-  form: ReturnType<typeof useForm<TForm, TFormValidator>
+  form: UseFormReturnType<TForm, TFormValidator>,
 > }): JSX.Element {
   return (
     <form.Field name={name}>
@@ -45,7 +45,7 @@ Deep values can also be inferred using this method from the parent form.
 ```tsx
 function App() {
   const form = useForm({
-    defaultValues: { name: '', id: 0, interests: {hobbies: 'climbing'} },
+    defaultValues: { name: '', id: 0, interests: {hobbies: ''} },
     onSubmit: ({ value }) => {
       console.log(value);
     },
@@ -58,15 +58,15 @@ function App() {
 ## Full Example
 
 ```tsx
-import {  useForm, Validator, InferValidFormKeys } from '@tanstack/react-form';
+import { InferValidFormKeys } from '@tanstack/react-form';
 
 export default function GenericTextField<
   TForm,
+  TFormValidator
   TName extends InferValidFormKeys<TForm, string>,
-  TFormValidator extends Validator<TForm, unknown> | undefined,
 >({ name, form }: {
   name: TName;
-  form: ReturnType<typeof useForm<TForm, TFormValidator>
+  form: UseFormReturnType<TForm, TFormValidator>
 > }): JSX.Element {
   return (
     <form.Field name={name}>
@@ -83,7 +83,7 @@ export default function GenericTextField<
 
 function App() {
   const form = useForm({
-    defaultValues: { name: '', id: 0, interests: {hobbies: 'climbing'} },
+    defaultValues: { name: '', id: 0, interests: {hobbies: ''} },
     onSubmit: ({ value }) => {
       console.log(value);
     },

--- a/docs/framework/react/guides/reusable-fields.md
+++ b/docs/framework/react/guides/reusable-fields.md
@@ -10,7 +10,7 @@ As TanStack form is a headless library, we provide you the core building blocks 
 To create a reusable fields, you can do the following.
 
 ```tsx
-import {  InferValidFormKeys, UseFormReturnType } from '@tanstack/react-form';
+import { InferValidFormKeys, UseFormReturnType } from '@tanstack/react-form';
 
 export default function GenericTextField<
   TForm,

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -34,6 +34,7 @@ title: "@tanstack/form-core"
 - [FormState](type-aliases/formstate.md)
 - [FormValidateFn](type-aliases/formvalidatefn.md)
 - [FormValidator](type-aliases/formvalidator.md)
+- [InferValidFormKeys](type-aliases/infervalidformkeys.md)
 - [StandardSchemaV1](type-aliases/standardschemav1.md)
 - [Updater](type-aliases/updater.md)
 - [UpdaterFn](type-aliases/updaterfn.md)

--- a/docs/reference/type-aliases/infervalidformkeys.md
+++ b/docs/reference/type-aliases/infervalidformkeys.md
@@ -1,0 +1,22 @@
+---
+id: InferValidFormKeys
+title: InferValidFormKeys
+---
+
+# Type Alias: InferValidFormKeys\<TForm, TFieldType\>
+
+```ts
+type InferValidFormKeys<TForm, TFieldType>: { [K in DeepKeys<TForm>]: DeepValue<TForm, K> extends TFieldType ? K : never }[DeepKeys<TForm>];
+```
+
+Infers the form keys of valid fields
+
+## Type Parameters
+
+• **TForm**
+
+• **TFieldType**
+
+## Defined in
+
+[packages/form-core/src/util-types.ts:151](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L151)

--- a/packages/form-core/src/util-types.ts
+++ b/packages/form-core/src/util-types.ts
@@ -144,3 +144,15 @@ export type DeepValue<
                 : never
         : // Do not allow `TValue` to be anything else
           never
+
+/**
+ * Infers the form keys of valid fields
+ */
+export type InferValidFormKeys<
+  // Form generic slot
+  TForm,
+  // Desired type of the generic component
+  TFieldType,
+> = {
+  [K in DeepKeys<TForm>]: DeepValue<TForm, K> extends TFieldType ? K : never
+}[DeepKeys<TForm>]

--- a/packages/react-form/src/types.ts
+++ b/packages/react-form/src/types.ts
@@ -4,8 +4,7 @@ import type {
   FieldApiOptions,
   Validator,
 } from '@tanstack/form-core'
-import type { FunctionComponent } from 'react'
-import { useForm } from './useForm'
+import { ReactFormExtendedApi } from './useForm'
 
 /**
  * The field options.
@@ -36,5 +35,5 @@ export type UseFieldOptions<
 export type UseFormReturnType<TForm, TFormValidator> = TFormValidator extends
   | Validator<TForm, unknown>
   | undefined
-  ? ReturnType<typeof useForm<TForm, TFormValidator>>
+  ? ReactFormExtendedApi<TForm, TFormValidator>
   : never

--- a/packages/react-form/src/types.ts
+++ b/packages/react-form/src/types.ts
@@ -5,6 +5,7 @@ import type {
   Validator,
 } from '@tanstack/form-core'
 import type { FunctionComponent } from 'react'
+import { useForm } from './useForm'
 
 /**
  * The field options.
@@ -28,3 +29,12 @@ export type UseFieldOptions<
 > & {
   mode?: 'value' | 'array'
 }
+
+/**
+ * The return type use useForm with pre-populated generics
+ */
+export type UseFormReturnType<TForm, TFormValidator> = TFormValidator extends
+  | Validator<TForm, unknown>
+  | undefined
+  ? ReturnType<typeof useForm<TForm, TFormValidator>>
+  : never


### PR DESCRIPTION
A continue on from #636, this PR introduces docs for reusable components/fields as well as introduces a Ts utility type for inferring valid field names, for the relevant component. 

Much like my last PR this is something I was trying to do for a work project, but not having any docs or examples hindered the process, so I figured I'd give it a go.

---
**Guidance wanted:**

Specifically with this line `onChange={(e) => handleChange(e.target.value as any)}` (line 28 in reusable-fields) I can't stand the casting of any, however I can figure a way for Ts to infer this value. Any suggestions is greatly appreciated!

---
**Sandbox**

I have a code sandbox for playing around with this [here](https://codesandbox.io/p/sandbox/yv7zmh), you'll see theres a folder called solutions that has two files: 
- one.tsx works and is a refined version of all my test components 
- two.tsx is another version that I haven't quite got working but in terms of user Ux I think is an improvement. 

The rest of the files can be ignored but if you want to see how I got here they kind of explain my reasoning.
