### PR TITLE
feat(docs): risks of omitting useStore selector

### DIFF
--- a/docs/framework/react/guides/basic-concepts.md
+++ b/docs/framework/react/guides/basic-concepts.md
@@ -204,6 +204,16 @@ const firstName = useStore(form.store, (state) => state.values.firstName)
 />
 ```
 
+It is important to remember that while the `useStore` hook's `selector` prop is optional, it is strongly recommended to provide one, as omitting it will result in unnecessary re-renders.
+
+```tsx
+// Correct use
+const firstName = useStore(form.store, (state) => state.values.firstName)
+const errors = useStore(form.store,  (state) => state.errorMap)
+// Incorrect use
+const store = useStore(form.store)
+```
+
 Note: The usage of the `useField` hook to achieve reactivity is discouraged since it is designed to be used thoughtfully within the `form.Field` component. You might want to use `useStore(form.store)` instead.
 
 ## Listeners


### PR DESCRIPTION
From issue #1122 and a conversation with @crutchcorn, omitting the selector prop of the useStore hook will result in unnecessary re-renders.

![Screenshot 2025-01-22 at 15 06 57](https://github.com/user-attachments/assets/c59a85b7-32f6-4384-b568-65d0da60c658)

---

The interface of useStore shows it as an optional prop, and while the hook will work without the prop, it is not the recommended approach.

```tsx
export declare function useStore<TState, TSelected = NoInfer<TState>>(store: Store<TState, any>, selector?: (state: NoInfer<TState>) => TSelected): TSelected;
```

---

I've searched the Docs for references to this, and the only documentation relating to this hook was under `Reactivity` of `basic concepts`. However, it does not highlight the risks of omitting selector.

![Screenshot 2025-01-22 at 15 13 36](https://github.com/user-attachments/assets/32103ab6-28d5-443f-9e83-924ede6ed0f8)

The only other references to this hook, I found in the documentation, were examples demonstrating the use of `useStore`. However, none of them highlighted this potential pitfall.

This PR adds clarification of useStore and examples of correct use.

![Screenshot 2025-01-22 at 15 07 07](https://github.com/user-attachments/assets/cbee709e-1400-4e3a-a1e9-2d6f22274412)