### PR TITLE
docs(form-core): Update philosophy heading tag levels h1 to h2.md

### DIFF
--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -7,13 +7,13 @@ Every well-established project should have a philosophy that guides its developm
 
 This document outlines the core principles that drive the development and feature-set of TanStack Form.
 
-# Upgrading unified APIs
+## Upgrading unified APIs
 
 APIs come with tradeoffs. As a result, it can be tempting to make each set of tradeoffs available to the user through different APIs. However, this can lead to a fragmented API that is harder to learn and use.
 
 While this may mean a higher learning curve, it means that you don't have to question which API to use internally or have higher cognitive overhead when switching between APIs.
 
-# Forms need flexibility
+## Forms need flexibility
 
 TanStack Form is designed to be flexible and customizable. While many forms may conform to similar patterns, there are always exceptions; especially when forms are a core component of your application.
 
@@ -25,7 +25,7 @@ As a result, TanStack Form supports multiple methods for validation:
 - **Custom error messages**: You can customize the error messages for each field by returning any object from a validator.
 - **Async validation**: You can validate fields asynchronously and have common utils like debouncing and cancellation handled for you.
 
-# Controlled is Cool
+## Controlled is Cool
 
 In a world where controlled vs uncontrolled inputs are a hot topic, TanStack Form is firmly in the controlled camp.
 
@@ -37,7 +37,7 @@ This comes with a number of advantages:
 - **Enhanced conditional logic**: You can easily conditionally show/hide fields based on the form state.
 - **Debugging**: You can easily log the form state to the console to debug issues.
 
-# Generics are grim
+## Generics are grim
 
 You should never need to pass a generic or use an internal type when leveraging TanStack Form. This is because we've designed the library to inference everything from runtime defaults.
 
@@ -60,7 +60,7 @@ useForm({
 });
 ```
 
-# Libraries are liberating
+## Libraries are liberating
 
 One of the main objectives of TanStack Form is that you should be wrapping it into your own component system or design system.
 


### PR DESCRIPTION
Unless there was a reason for h1s, I just converted headings to h2 to be consistent with the rest of the tanstack docs