### PR TITLE
fix(core): add union to PrefixArrayAccessor to allow indexing e…

### DIFF
--- a/docs/reference/type-aliases/deepkeys.md
+++ b/docs/reference/type-aliases/deepkeys.md
@@ -11,7 +11,7 @@ title: DeepKeys
 type DeepKeys<T, TDepth> = TDepth["length"] extends 5 ? never : unknown extends T ? PrefixFromDepth<string, TDepth> : T extends readonly any[] & IsTuple<T> ? PrefixTupleAccessor<T, AllowedIndexes<T>, TDepth> : T extends any[] ? PrefixArrayAccessor<T, [...TDepth, any]> : T extends Date ? never : T extends object ? PrefixObjectAccessor<T, TDepth> : T extends string | number | boolean | bigint ? "" : never;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:70](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L70)
+Defined in: [packages/form-core/src/util-types.ts:72](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L72)
 
 The keys of an object or array, deeply nested.
 

--- a/docs/reference/type-aliases/deepvalue.md
+++ b/docs/reference/type-aliases/deepvalue.md
@@ -13,7 +13,7 @@ type DeepValue<TValue, TAccessor, TDepth> = unknown extends TValue ? TValue : TD
   | ApplyNull<...> | ApplyUndefined<...> : never;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:104](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L104)
+Defined in: [packages/form-core/src/util-types.ts:106](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L106)
 
 Infer the type of a deeply nested property within an object or an array.
 

--- a/packages/form-core/src/util-types.ts
+++ b/packages/form-core/src/util-types.ts
@@ -44,9 +44,11 @@ type AllowedIndexes<
     ? AllowedIndexes<Tail, Keys | Tail['length']>
     : Keys
 
-type PrefixArrayAccessor<T extends any[], TDepth extends any[]> = {
-  [K in keyof T]: `[${number}]${DeepKeys<T[K], TDepth>}`
-}[number]
+type PrefixArrayAccessor<T extends any[], TDepth extends any[]> =
+  | {
+      [K in keyof T]: `[${number}]${DeepKeys<T[K], TDepth>}`
+    }[number]
+  | `[${number}]`
 
 type PrefixTupleAccessor<
   T extends any[],

--- a/packages/form-core/tests/util-types.test-d.ts
+++ b/packages/form-core/tests/util-types.test-d.ts
@@ -24,6 +24,7 @@ assertType<
 type ArraySupport = DeepKeys<{ users: User[] }>
 assertType<
   | 'users'
+  | `users[${number}]`
   | `users[${number}].name`
   | `users[${number}].id`
   | `users[${number}].age`


### PR DESCRIPTION
…ntire array element

Related to #1227 

Changed PrefixArrayAccessor from:
```ts
type PrefixArrayAccessor<T extends any[], TDepth extends any[]> = {
  [K in keyof T]: `[${number}]${DeepKeys<T[K], TDepth>}`
}[number]
```
to
```ts
type PrefixArrayAccessor<T extends any[], TDepth extends any[]> =
  | {
      [K in keyof T]: `[${number}]${DeepKeys<T[K], TDepth>}`
    }[number]
  | `[${number}]`
```

This now allows accessing regular array elements with DeepKeys type.