### PR TITLE
style(form-core): remove unused imports

### DIFF
--- a/docs/reference/functions/formoptions.md
+++ b/docs/reference/functions/formoptions.md
@@ -11,7 +11,7 @@ title: formOptions
 function formOptions<T>(defaultOpts): T
 ```
 
-Defined in: [packages/form-core/src/formOptions.ts:7](https://github.com/TanStack/form/blob/main/packages/form-core/src/formOptions.ts#L7)
+Defined in: [packages/form-core/src/formOptions.ts:3](https://github.com/TanStack/form/blob/main/packages/form-core/src/formOptions.ts#L3)
 
 ## Type Parameters
 

--- a/packages/form-core/src/formOptions.ts
+++ b/packages/form-core/src/formOptions.ts
@@ -1,7 +1,5 @@
 import type {
-  FormAsyncValidateOrFn,
   FormOptions,
-  FormValidateOrFn,
 } from './FormApi'
 
 export function formOptions<

--- a/packages/form-core/src/formOptions.ts
+++ b/packages/form-core/src/formOptions.ts
@@ -1,6 +1,4 @@
-import type {
-  FormOptions,
-} from './FormApi'
+import type { FormOptions } from './FormApi'
 
 export function formOptions<
   T extends Partial<


### PR DESCRIPTION
Remove unused `FormAsyncValidateOrFn` and `FormValidateOrFn` imports from `formOptions.ts`. These types were not referenced in the file, and their removal improves code cleanliness without impacting functionality.

No functional changes.