### PR TITLE
fix(solid-form): use { equals: false }

### DIFF
--- a/docs/framework/solid/reference/functions/createfield.md
+++ b/docs/framework/solid/reference/functions/createfield.md
@@ -11,7 +11,7 @@ title: createField
 function createField<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta>(opts): () => FieldApi<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta> & SolidFieldApi<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta>
 ```
 
-Defined in: [packages/solid-form/src/createField.tsx:237](https://github.com/TanStack/form/blob/main/packages/solid-form/src/createField.tsx#L237)
+Defined in: [packages/solid-form/src/createField.tsx:236](https://github.com/TanStack/form/blob/main/packages/solid-form/src/createField.tsx#L236)
 
 ## Type Parameters
 

--- a/docs/framework/solid/reference/functions/field.md
+++ b/docs/framework/solid/reference/functions/field.md
@@ -11,7 +11,7 @@ title: Field
 function Field<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta>(props): Element
 ```
 
-Defined in: [packages/solid-form/src/createField.tsx:481](https://github.com/TanStack/form/blob/main/packages/solid-form/src/createField.tsx#L481)
+Defined in: [packages/solid-form/src/createField.tsx:480](https://github.com/TanStack/form/blob/main/packages/solid-form/src/createField.tsx#L480)
 
 ## Type Parameters
 

--- a/docs/framework/solid/reference/type-aliases/fieldcomponent.md
+++ b/docs/framework/solid/reference/type-aliases/fieldcomponent.md
@@ -14,7 +14,7 @@ type FieldComponent<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync
 }) => JSXElement;
 ```
 
-Defined in: [packages/solid-form/src/createField.tsx:426](https://github.com/TanStack/form/blob/main/packages/solid-form/src/createField.tsx#L426)
+Defined in: [packages/solid-form/src/createField.tsx:425](https://github.com/TanStack/form/blob/main/packages/solid-form/src/createField.tsx#L425)
 
 ## Type Parameters
 

--- a/packages/solid-form/src/createField.tsx
+++ b/packages/solid-form/src/createField.tsx
@@ -1,579 +1,579 @@
-import { FieldApi } from "@tanstack/form-core";
+import { FieldApi } from '@tanstack/form-core'
 import {
-	createComponent,
-	createComputed,
-	createMemo,
-	createSignal,
-	onCleanup,
-	onMount,
-} from "solid-js";
+  createComponent,
+  createComputed,
+  createMemo,
+  createSignal,
+  onCleanup,
+  onMount,
+} from 'solid-js'
 import type {
-	DeepKeys,
-	DeepValue,
-	FieldAsyncValidateOrFn,
-	FieldValidateOrFn,
-	FormAsyncValidateOrFn,
-	FormValidateOrFn,
-	Narrow,
-} from "@tanstack/form-core";
+  DeepKeys,
+  DeepValue,
+  FieldAsyncValidateOrFn,
+  FieldValidateOrFn,
+  FormAsyncValidateOrFn,
+  FormValidateOrFn,
+  Narrow,
+} from '@tanstack/form-core'
 
-import type { JSXElement } from "solid-js";
-import type { CreateFieldOptions } from "./types";
+import type { JSXElement } from 'solid-js'
+import type { CreateFieldOptions } from './types'
 
 interface SolidFieldApi<
-	TParentData,
-	TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TParentSubmitMeta,
+  TParentData,
+  TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TParentSubmitMeta,
 > {
-	Field: FieldComponent<
-		TParentData,
-		TFormOnMount,
-		TFormOnChange,
-		TFormOnChangeAsync,
-		TFormOnBlur,
-		TFormOnBlurAsync,
-		TFormOnSubmit,
-		TFormOnSubmitAsync,
-		TFormOnServer,
-		TParentSubmitMeta
-	>;
+  Field: FieldComponent<
+    TParentData,
+    TFormOnMount,
+    TFormOnChange,
+    TFormOnChangeAsync,
+    TFormOnBlur,
+    TFormOnBlurAsync,
+    TFormOnSubmit,
+    TFormOnSubmitAsync,
+    TFormOnServer,
+    TParentSubmitMeta
+  >
 }
 
 export type CreateField<
-	TParentData,
-	TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TParentSubmitMeta,
+  TParentData,
+  TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TParentSubmitMeta,
 > = <
-	TName extends DeepKeys<TParentData>,
-	TData extends DeepValue<TParentData, TName>,
-	TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnChangeAsync extends
-		| undefined
-		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
-	TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnBlurAsync extends
-		| undefined
-		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
-	TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnSubmitAsync extends
-		| undefined
-		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
-	TSubmitMeta,
+  TName extends DeepKeys<TParentData>,
+  TData extends DeepValue<TParentData, TName>,
+  TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnChangeAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
+  TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnBlurAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
+  TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnSubmitAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
+  TSubmitMeta,
 >(
-	opts: () => { name: Narrow<TName> } & Omit<
-		CreateFieldOptions<
-			TParentData,
-			TName,
-			TData,
-			TOnMount,
-			TOnChange,
-			TOnChangeAsync,
-			TOnBlur,
-			TOnBlurAsync,
-			TOnSubmit,
-			TOnSubmitAsync,
-			TFormOnMount,
-			TFormOnChange,
-			TFormOnChangeAsync,
-			TFormOnBlur,
-			TFormOnBlurAsync,
-			TFormOnSubmit,
-			TFormOnSubmitAsync,
-			TFormOnServer,
-			TSubmitMeta
-		>,
-		"form"
-	>,
+  opts: () => { name: Narrow<TName> } & Omit<
+    CreateFieldOptions<
+      TParentData,
+      TName,
+      TData,
+      TOnMount,
+      TOnChange,
+      TOnChangeAsync,
+      TOnBlur,
+      TOnBlurAsync,
+      TOnSubmit,
+      TOnSubmitAsync,
+      TFormOnMount,
+      TFormOnChange,
+      TFormOnChangeAsync,
+      TFormOnBlur,
+      TFormOnBlurAsync,
+      TFormOnSubmit,
+      TFormOnSubmitAsync,
+      TFormOnServer,
+      TSubmitMeta
+    >,
+    'form'
+  >,
 ) => () => FieldApi<
-	TParentData,
-	TName,
-	TData,
-	TOnMount,
-	TOnChange,
-	TOnChangeAsync,
-	TOnBlur,
-	TOnBlurAsync,
-	TOnSubmit,
-	TOnSubmitAsync,
-	TFormOnMount,
-	TFormOnChange,
-	TFormOnChangeAsync,
-	TFormOnBlur,
-	TFormOnBlurAsync,
-	TFormOnSubmit,
-	TFormOnSubmitAsync,
-	TFormOnServer,
-	TParentSubmitMeta
+  TParentData,
+  TName,
+  TData,
+  TOnMount,
+  TOnChange,
+  TOnChangeAsync,
+  TOnBlur,
+  TOnBlurAsync,
+  TOnSubmit,
+  TOnSubmitAsync,
+  TFormOnMount,
+  TFormOnChange,
+  TFormOnChangeAsync,
+  TFormOnBlur,
+  TFormOnBlurAsync,
+  TFormOnSubmit,
+  TFormOnSubmitAsync,
+  TFormOnServer,
+  TParentSubmitMeta
 > &
-	SolidFieldApi<
-		TParentData,
-		TFormOnMount,
-		TFormOnChange,
-		TFormOnChangeAsync,
-		TFormOnBlur,
-		TFormOnBlurAsync,
-		TFormOnSubmit,
-		TFormOnSubmitAsync,
-		TFormOnServer,
-		TParentSubmitMeta
-	>;
+  SolidFieldApi<
+    TParentData,
+    TFormOnMount,
+    TFormOnChange,
+    TFormOnChangeAsync,
+    TFormOnBlur,
+    TFormOnBlurAsync,
+    TFormOnSubmit,
+    TFormOnSubmitAsync,
+    TFormOnServer,
+    TParentSubmitMeta
+  >
 
 // ugly way to trick solid into triggering updates for changes on the fieldApi
 function makeFieldReactive<
-	TParentData,
-	TName extends DeepKeys<TParentData>,
-	TData extends DeepValue<TParentData, TName>,
-	TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnChangeAsync extends
-		| undefined
-		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
-	TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnBlurAsync extends
-		| undefined
-		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
-	TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnSubmitAsync extends
-		| undefined
-		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
-	TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TParentSubmitMeta,
+  TParentData,
+  TName extends DeepKeys<TParentData>,
+  TData extends DeepValue<TParentData, TName>,
+  TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnChangeAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
+  TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnBlurAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
+  TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnSubmitAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
+  TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TParentSubmitMeta,
 >(
-	fieldApi: FieldApi<
-		TParentData,
-		TName,
-		TData,
-		TOnMount,
-		TOnChange,
-		TOnChangeAsync,
-		TOnBlur,
-		TOnBlurAsync,
-		TOnSubmit,
-		TOnSubmitAsync,
-		TFormOnMount,
-		TFormOnChange,
-		TFormOnChangeAsync,
-		TFormOnBlur,
-		TFormOnBlurAsync,
-		TFormOnSubmit,
-		TFormOnSubmitAsync,
-		TFormOnServer,
-		TParentSubmitMeta
-	> &
-		SolidFieldApi<
-			TParentData,
-			TFormOnMount,
-			TFormOnChange,
-			TFormOnChangeAsync,
-			TFormOnBlur,
-			TFormOnBlurAsync,
-			TFormOnSubmit,
-			TFormOnSubmitAsync,
-			TFormOnServer,
-			TParentSubmitMeta
-		>,
+  fieldApi: FieldApi<
+    TParentData,
+    TName,
+    TData,
+    TOnMount,
+    TOnChange,
+    TOnChangeAsync,
+    TOnBlur,
+    TOnBlurAsync,
+    TOnSubmit,
+    TOnSubmitAsync,
+    TFormOnMount,
+    TFormOnChange,
+    TFormOnChangeAsync,
+    TFormOnBlur,
+    TFormOnBlurAsync,
+    TFormOnSubmit,
+    TFormOnSubmitAsync,
+    TFormOnServer,
+    TParentSubmitMeta
+  > &
+    SolidFieldApi<
+      TParentData,
+      TFormOnMount,
+      TFormOnChange,
+      TFormOnChangeAsync,
+      TFormOnBlur,
+      TFormOnBlurAsync,
+      TFormOnSubmit,
+      TFormOnSubmitAsync,
+      TFormOnServer,
+      TParentSubmitMeta
+    >,
 ): () => FieldApi<
-	TParentData,
-	TName,
-	TData,
-	TOnMount,
-	TOnChange,
-	TOnChangeAsync,
-	TOnBlur,
-	TOnBlurAsync,
-	TOnSubmit,
-	TOnSubmitAsync,
-	TFormOnMount,
-	TFormOnChange,
-	TFormOnChangeAsync,
-	TFormOnBlur,
-	TFormOnBlurAsync,
-	TFormOnSubmit,
-	TFormOnSubmitAsync,
-	TFormOnServer,
-	TParentSubmitMeta
+  TParentData,
+  TName,
+  TData,
+  TOnMount,
+  TOnChange,
+  TOnChangeAsync,
+  TOnBlur,
+  TOnBlurAsync,
+  TOnSubmit,
+  TOnSubmitAsync,
+  TFormOnMount,
+  TFormOnChange,
+  TFormOnChangeAsync,
+  TFormOnBlur,
+  TFormOnBlurAsync,
+  TFormOnSubmit,
+  TFormOnSubmitAsync,
+  TFormOnServer,
+  TParentSubmitMeta
 > &
-	SolidFieldApi<
-		TParentData,
-		TFormOnMount,
-		TFormOnChange,
-		TFormOnChangeAsync,
-		TFormOnBlur,
-		TFormOnBlurAsync,
-		TFormOnSubmit,
-		TFormOnSubmitAsync,
-		TFormOnServer,
-		TParentSubmitMeta
-	> {
-	const [field, setField] = createSignal(fieldApi, { equals: false });
-	const unsubscribeStore = fieldApi.store.subscribe(() => setField(fieldApi));
-	onCleanup(unsubscribeStore);
-	return field;
+  SolidFieldApi<
+    TParentData,
+    TFormOnMount,
+    TFormOnChange,
+    TFormOnChangeAsync,
+    TFormOnBlur,
+    TFormOnBlurAsync,
+    TFormOnSubmit,
+    TFormOnSubmitAsync,
+    TFormOnServer,
+    TParentSubmitMeta
+  > {
+  const [field, setField] = createSignal(fieldApi, { equals: false })
+  const unsubscribeStore = fieldApi.store.subscribe(() => setField(fieldApi))
+  onCleanup(unsubscribeStore)
+  return field
 }
 
 export function createField<
-	TParentData,
-	TName extends DeepKeys<TParentData>,
-	TData extends DeepValue<TParentData, TName>,
-	TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnChangeAsync extends
-		| undefined
-		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
-	TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnBlurAsync extends
-		| undefined
-		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
-	TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnSubmitAsync extends
-		| undefined
-		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
-	TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TParentSubmitMeta,
+  TParentData,
+  TName extends DeepKeys<TParentData>,
+  TData extends DeepValue<TParentData, TName>,
+  TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnChangeAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
+  TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnBlurAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
+  TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnSubmitAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
+  TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TParentSubmitMeta,
 >(
-	opts: () => CreateFieldOptions<
-		TParentData,
-		TName,
-		TData,
-		TOnMount,
-		TOnChange,
-		TOnChangeAsync,
-		TOnBlur,
-		TOnBlurAsync,
-		TOnSubmit,
-		TOnSubmitAsync,
-		TFormOnMount,
-		TFormOnChange,
-		TFormOnChangeAsync,
-		TFormOnBlur,
-		TFormOnBlurAsync,
-		TFormOnSubmit,
-		TFormOnSubmitAsync,
-		TFormOnServer,
-		TParentSubmitMeta
-	>,
+  opts: () => CreateFieldOptions<
+    TParentData,
+    TName,
+    TData,
+    TOnMount,
+    TOnChange,
+    TOnChangeAsync,
+    TOnBlur,
+    TOnBlurAsync,
+    TOnSubmit,
+    TOnSubmitAsync,
+    TFormOnMount,
+    TFormOnChange,
+    TFormOnChangeAsync,
+    TFormOnBlur,
+    TFormOnBlurAsync,
+    TFormOnSubmit,
+    TFormOnSubmitAsync,
+    TFormOnServer,
+    TParentSubmitMeta
+  >,
 ) {
-	const options = opts();
+  const options = opts()
 
-	const api = new FieldApi(options);
+  const api = new FieldApi(options)
 
-	const extendedApi: typeof api &
-		SolidFieldApi<
-			TParentData,
-			TFormOnMount,
-			TFormOnChange,
-			TFormOnChangeAsync,
-			TFormOnBlur,
-			TFormOnBlurAsync,
-			TFormOnSubmit,
-			TFormOnSubmitAsync,
-			TFormOnServer,
-			TParentSubmitMeta
-		> = api as never;
+  const extendedApi: typeof api &
+    SolidFieldApi<
+      TParentData,
+      TFormOnMount,
+      TFormOnChange,
+      TFormOnChangeAsync,
+      TFormOnBlur,
+      TFormOnBlurAsync,
+      TFormOnSubmit,
+      TFormOnSubmitAsync,
+      TFormOnServer,
+      TParentSubmitMeta
+    > = api as never
 
-	extendedApi.Field = Field as never;
+  extendedApi.Field = Field as never
 
-	let mounted = false;
-	// Instantiates field meta and removes it when unrendered
-	onMount(() => {
-		const cleanupFn = api.mount();
-		mounted = true;
-		onCleanup(() => {
-			cleanupFn();
-			mounted = false;
-		});
-	});
+  let mounted = false
+  // Instantiates field meta and removes it when unrendered
+  onMount(() => {
+    const cleanupFn = api.mount()
+    mounted = true
+    onCleanup(() => {
+      cleanupFn()
+      mounted = false
+    })
+  })
 
-	/**
-	 * fieldApi.update should not have any side effects. Think of it like a `useRef`
-	 * that we need to keep updated every render with the most up-to-date information.
-	 *
-	 * createComputed to make sure this effect runs before render effects
-	 */
-	createComputed(() => {
-		if (!mounted) return;
-		api.update(opts());
-	});
+  /**
+   * fieldApi.update should not have any side effects. Think of it like a `useRef`
+   * that we need to keep updated every render with the most up-to-date information.
+   *
+   * createComputed to make sure this effect runs before render effects
+   */
+  createComputed(() => {
+    if (!mounted) return
+    api.update(opts())
+  })
 
-	return makeFieldReactive<
-		TParentData,
-		TName,
-		TData,
-		TOnMount,
-		TOnChange,
-		TOnChangeAsync,
-		TOnBlur,
-		TOnBlurAsync,
-		TOnSubmit,
-		TOnSubmitAsync,
-		TFormOnMount,
-		TFormOnChange,
-		TFormOnChangeAsync,
-		TFormOnBlur,
-		TFormOnBlurAsync,
-		TFormOnSubmit,
-		TFormOnSubmitAsync,
-		TFormOnServer,
-		TParentSubmitMeta
-	>(extendedApi as never);
+  return makeFieldReactive<
+    TParentData,
+    TName,
+    TData,
+    TOnMount,
+    TOnChange,
+    TOnChangeAsync,
+    TOnBlur,
+    TOnBlurAsync,
+    TOnSubmit,
+    TOnSubmitAsync,
+    TFormOnMount,
+    TFormOnChange,
+    TFormOnChangeAsync,
+    TFormOnBlur,
+    TFormOnBlurAsync,
+    TFormOnSubmit,
+    TFormOnSubmitAsync,
+    TFormOnServer,
+    TParentSubmitMeta
+  >(extendedApi as never)
 }
 
 type FieldComponentProps<
-	TParentData,
-	TName extends DeepKeys<TParentData>,
-	TData extends DeepValue<TParentData, TName>,
-	TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnChangeAsync extends
-		| undefined
-		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
-	TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnBlurAsync extends
-		| undefined
-		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
-	TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnSubmitAsync extends
-		| undefined
-		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
-	TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TParentSubmitMeta,
+  TParentData,
+  TName extends DeepKeys<TParentData>,
+  TData extends DeepValue<TParentData, TName>,
+  TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnChangeAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
+  TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnBlurAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
+  TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnSubmitAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
+  TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TParentSubmitMeta,
 > = {
-	children: (
-		fieldApi: () => FieldApi<
-			TParentData,
-			TName,
-			TData,
-			TOnMount,
-			TOnChange,
-			TOnChangeAsync,
-			TOnBlur,
-			TOnBlurAsync,
-			TOnSubmit,
-			TOnSubmitAsync,
-			TFormOnMount,
-			TFormOnChange,
-			TFormOnChangeAsync,
-			TFormOnBlur,
-			TFormOnBlurAsync,
-			TFormOnSubmit,
-			TFormOnSubmitAsync,
-			TFormOnServer,
-			TParentSubmitMeta
-		>,
-	) => JSXElement;
+  children: (
+    fieldApi: () => FieldApi<
+      TParentData,
+      TName,
+      TData,
+      TOnMount,
+      TOnChange,
+      TOnChangeAsync,
+      TOnBlur,
+      TOnBlurAsync,
+      TOnSubmit,
+      TOnSubmitAsync,
+      TFormOnMount,
+      TFormOnChange,
+      TFormOnChangeAsync,
+      TFormOnBlur,
+      TFormOnBlurAsync,
+      TFormOnSubmit,
+      TFormOnSubmitAsync,
+      TFormOnServer,
+      TParentSubmitMeta
+    >,
+  ) => JSXElement
 } & Omit<
-	CreateFieldOptions<
-		TParentData,
-		TName,
-		TData,
-		TOnMount,
-		TOnChange,
-		TOnChangeAsync,
-		TOnBlur,
-		TOnBlurAsync,
-		TOnSubmit,
-		TOnSubmitAsync,
-		TFormOnMount,
-		TFormOnChange,
-		TFormOnChangeAsync,
-		TFormOnBlur,
-		TFormOnBlurAsync,
-		TFormOnSubmit,
-		TFormOnSubmitAsync,
-		TFormOnServer,
-		TParentSubmitMeta
-	>,
-	"form"
->;
+  CreateFieldOptions<
+    TParentData,
+    TName,
+    TData,
+    TOnMount,
+    TOnChange,
+    TOnChangeAsync,
+    TOnBlur,
+    TOnBlurAsync,
+    TOnSubmit,
+    TOnSubmitAsync,
+    TFormOnMount,
+    TFormOnChange,
+    TFormOnChangeAsync,
+    TFormOnBlur,
+    TFormOnBlurAsync,
+    TFormOnSubmit,
+    TFormOnSubmitAsync,
+    TFormOnServer,
+    TParentSubmitMeta
+  >,
+  'form'
+>
 
 export type FieldComponent<
-	TParentData,
-	TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TParentSubmitMeta,
+  TParentData,
+  TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TParentSubmitMeta,
 > = <
-	TName extends DeepKeys<TParentData>,
-	TData extends DeepValue<TParentData, TName>,
-	TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnChangeAsync extends
-		| undefined
-		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
-	TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnBlurAsync extends
-		| undefined
-		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
-	TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnSubmitAsync extends
-		| undefined
-		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
+  TName extends DeepKeys<TParentData>,
+  TData extends DeepValue<TParentData, TName>,
+  TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnChangeAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
+  TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnBlurAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
+  TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnSubmitAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
 >({
-	children,
-	...fieldOptions
+  children,
+  ...fieldOptions
 }: Omit<
-	FieldComponentProps<
-		TParentData,
-		TName,
-		TData,
-		TOnMount,
-		TOnChange,
-		TOnChangeAsync,
-		TOnBlur,
-		TOnBlurAsync,
-		TOnSubmit,
-		TOnSubmitAsync,
-		TFormOnMount,
-		TFormOnChange,
-		TFormOnChangeAsync,
-		TFormOnBlur,
-		TFormOnBlurAsync,
-		TFormOnSubmit,
-		TFormOnSubmitAsync,
-		TFormOnServer,
-		TParentSubmitMeta
-	>,
-	"form"
->) => JSXElement;
+  FieldComponentProps<
+    TParentData,
+    TName,
+    TData,
+    TOnMount,
+    TOnChange,
+    TOnChangeAsync,
+    TOnBlur,
+    TOnBlurAsync,
+    TOnSubmit,
+    TOnSubmitAsync,
+    TFormOnMount,
+    TFormOnChange,
+    TFormOnChangeAsync,
+    TFormOnBlur,
+    TFormOnBlurAsync,
+    TFormOnSubmit,
+    TFormOnSubmitAsync,
+    TFormOnServer,
+    TParentSubmitMeta
+  >,
+  'form'
+>) => JSXElement
 
 export function Field<
-	TParentData,
-	TName extends DeepKeys<TParentData>,
-	TData extends DeepValue<TParentData, TName>,
-	TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnChangeAsync extends
-		| undefined
-		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
-	TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnBlurAsync extends
-		| undefined
-		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
-	TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-	TOnSubmitAsync extends
-		| undefined
-		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
-	TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
-	TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
-	TParentSubmitMeta,
+  TParentData,
+  TName extends DeepKeys<TParentData>,
+  TData extends DeepValue<TParentData, TName>,
+  TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnChangeAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
+  TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnBlurAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
+  TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+  TOnSubmitAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
+  TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
+  TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
+  TParentSubmitMeta,
 >(
-	props: {
-		children: (
-			fieldApi: () => FieldApi<
-				TParentData,
-				TName,
-				TData,
-				TOnMount,
-				TOnChange,
-				TOnChangeAsync,
-				TOnBlur,
-				TOnBlurAsync,
-				TOnSubmit,
-				TOnSubmitAsync,
-				TFormOnMount,
-				TFormOnChange,
-				TFormOnChangeAsync,
-				TFormOnBlur,
-				TFormOnBlurAsync,
-				TFormOnSubmit,
-				TFormOnSubmitAsync,
-				TFormOnServer,
-				TParentSubmitMeta
-			>,
-		) => JSXElement;
-	} & CreateFieldOptions<
-		TParentData,
-		TName,
-		TData,
-		TOnMount,
-		TOnChange,
-		TOnChangeAsync,
-		TOnBlur,
-		TOnBlurAsync,
-		TOnSubmit,
-		TOnSubmitAsync,
-		TFormOnMount,
-		TFormOnChange,
-		TFormOnChangeAsync,
-		TFormOnBlur,
-		TFormOnBlurAsync,
-		TFormOnSubmit,
-		TFormOnSubmitAsync,
-		TFormOnServer,
-		TParentSubmitMeta
-	>,
+  props: {
+    children: (
+      fieldApi: () => FieldApi<
+        TParentData,
+        TName,
+        TData,
+        TOnMount,
+        TOnChange,
+        TOnChangeAsync,
+        TOnBlur,
+        TOnBlurAsync,
+        TOnSubmit,
+        TOnSubmitAsync,
+        TFormOnMount,
+        TFormOnChange,
+        TFormOnChangeAsync,
+        TFormOnBlur,
+        TFormOnBlurAsync,
+        TFormOnSubmit,
+        TFormOnSubmitAsync,
+        TFormOnServer,
+        TParentSubmitMeta
+      >,
+    ) => JSXElement
+  } & CreateFieldOptions<
+    TParentData,
+    TName,
+    TData,
+    TOnMount,
+    TOnChange,
+    TOnChangeAsync,
+    TOnBlur,
+    TOnBlurAsync,
+    TOnSubmit,
+    TOnSubmitAsync,
+    TFormOnMount,
+    TFormOnChange,
+    TFormOnChangeAsync,
+    TFormOnBlur,
+    TFormOnBlurAsync,
+    TFormOnSubmit,
+    TFormOnSubmitAsync,
+    TFormOnServer,
+    TParentSubmitMeta
+  >,
 ) {
-	const fieldApi = createField<
-		TParentData,
-		TName,
-		TData,
-		TOnMount,
-		TOnChange,
-		TOnChangeAsync,
-		TOnBlur,
-		TOnBlurAsync,
-		TOnSubmit,
-		TOnSubmitAsync,
-		TFormOnMount,
-		TFormOnChange,
-		TFormOnChangeAsync,
-		TFormOnBlur,
-		TFormOnBlurAsync,
-		TFormOnSubmit,
-		TFormOnSubmitAsync,
-		TFormOnServer,
-		TParentSubmitMeta
-	>(() => {
-		const { children, ...fieldOptions } = props;
-		return fieldOptions;
-	});
+  const fieldApi = createField<
+    TParentData,
+    TName,
+    TData,
+    TOnMount,
+    TOnChange,
+    TOnChangeAsync,
+    TOnBlur,
+    TOnBlurAsync,
+    TOnSubmit,
+    TOnSubmitAsync,
+    TFormOnMount,
+    TFormOnChange,
+    TFormOnChangeAsync,
+    TFormOnBlur,
+    TFormOnBlurAsync,
+    TFormOnSubmit,
+    TFormOnSubmitAsync,
+    TFormOnServer,
+    TParentSubmitMeta
+  >(() => {
+    const { children, ...fieldOptions } = props
+    return fieldOptions
+  })
 
-	return <>{createComponent(() => props.children(fieldApi), {})}</>;
+  return <>{createComponent(() => props.children(fieldApi), {})}</>
 }

--- a/packages/solid-form/src/createField.tsx
+++ b/packages/solid-form/src/createField.tsx
@@ -1,580 +1,579 @@
-import { FieldApi } from '@tanstack/form-core'
+import { FieldApi } from "@tanstack/form-core";
 import {
-  createComponent,
-  createComputed,
-  createMemo,
-  createSignal,
-  onCleanup,
-  onMount,
-} from 'solid-js'
+	createComponent,
+	createComputed,
+	createMemo,
+	createSignal,
+	onCleanup,
+	onMount,
+} from "solid-js";
 import type {
-  DeepKeys,
-  DeepValue,
-  FieldAsyncValidateOrFn,
-  FieldValidateOrFn,
-  FormAsyncValidateOrFn,
-  FormValidateOrFn,
-  Narrow,
-} from '@tanstack/form-core'
+	DeepKeys,
+	DeepValue,
+	FieldAsyncValidateOrFn,
+	FieldValidateOrFn,
+	FormAsyncValidateOrFn,
+	FormValidateOrFn,
+	Narrow,
+} from "@tanstack/form-core";
 
-import type { JSXElement } from 'solid-js'
-import type { CreateFieldOptions } from './types'
+import type { JSXElement } from "solid-js";
+import type { CreateFieldOptions } from "./types";
 
 interface SolidFieldApi<
-  TParentData,
-  TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TParentSubmitMeta,
+	TParentData,
+	TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TParentSubmitMeta,
 > {
-  Field: FieldComponent<
-    TParentData,
-    TFormOnMount,
-    TFormOnChange,
-    TFormOnChangeAsync,
-    TFormOnBlur,
-    TFormOnBlurAsync,
-    TFormOnSubmit,
-    TFormOnSubmitAsync,
-    TFormOnServer,
-    TParentSubmitMeta
-  >
+	Field: FieldComponent<
+		TParentData,
+		TFormOnMount,
+		TFormOnChange,
+		TFormOnChangeAsync,
+		TFormOnBlur,
+		TFormOnBlurAsync,
+		TFormOnSubmit,
+		TFormOnSubmitAsync,
+		TFormOnServer,
+		TParentSubmitMeta
+	>;
 }
 
 export type CreateField<
-  TParentData,
-  TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TParentSubmitMeta,
+	TParentData,
+	TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TParentSubmitMeta,
 > = <
-  TName extends DeepKeys<TParentData>,
-  TData extends DeepValue<TParentData, TName>,
-  TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnChangeAsync extends
-    | undefined
-    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
-  TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnBlurAsync extends
-    | undefined
-    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
-  TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnSubmitAsync extends
-    | undefined
-    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
-  TSubmitMeta,
+	TName extends DeepKeys<TParentData>,
+	TData extends DeepValue<TParentData, TName>,
+	TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnChangeAsync extends
+		| undefined
+		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
+	TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnBlurAsync extends
+		| undefined
+		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
+	TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnSubmitAsync extends
+		| undefined
+		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
+	TSubmitMeta,
 >(
-  opts: () => { name: Narrow<TName> } & Omit<
-    CreateFieldOptions<
-      TParentData,
-      TName,
-      TData,
-      TOnMount,
-      TOnChange,
-      TOnChangeAsync,
-      TOnBlur,
-      TOnBlurAsync,
-      TOnSubmit,
-      TOnSubmitAsync,
-      TFormOnMount,
-      TFormOnChange,
-      TFormOnChangeAsync,
-      TFormOnBlur,
-      TFormOnBlurAsync,
-      TFormOnSubmit,
-      TFormOnSubmitAsync,
-      TFormOnServer,
-      TSubmitMeta
-    >,
-    'form'
-  >,
+	opts: () => { name: Narrow<TName> } & Omit<
+		CreateFieldOptions<
+			TParentData,
+			TName,
+			TData,
+			TOnMount,
+			TOnChange,
+			TOnChangeAsync,
+			TOnBlur,
+			TOnBlurAsync,
+			TOnSubmit,
+			TOnSubmitAsync,
+			TFormOnMount,
+			TFormOnChange,
+			TFormOnChangeAsync,
+			TFormOnBlur,
+			TFormOnBlurAsync,
+			TFormOnSubmit,
+			TFormOnSubmitAsync,
+			TFormOnServer,
+			TSubmitMeta
+		>,
+		"form"
+	>,
 ) => () => FieldApi<
-  TParentData,
-  TName,
-  TData,
-  TOnMount,
-  TOnChange,
-  TOnChangeAsync,
-  TOnBlur,
-  TOnBlurAsync,
-  TOnSubmit,
-  TOnSubmitAsync,
-  TFormOnMount,
-  TFormOnChange,
-  TFormOnChangeAsync,
-  TFormOnBlur,
-  TFormOnBlurAsync,
-  TFormOnSubmit,
-  TFormOnSubmitAsync,
-  TFormOnServer,
-  TParentSubmitMeta
+	TParentData,
+	TName,
+	TData,
+	TOnMount,
+	TOnChange,
+	TOnChangeAsync,
+	TOnBlur,
+	TOnBlurAsync,
+	TOnSubmit,
+	TOnSubmitAsync,
+	TFormOnMount,
+	TFormOnChange,
+	TFormOnChangeAsync,
+	TFormOnBlur,
+	TFormOnBlurAsync,
+	TFormOnSubmit,
+	TFormOnSubmitAsync,
+	TFormOnServer,
+	TParentSubmitMeta
 > &
-  SolidFieldApi<
-    TParentData,
-    TFormOnMount,
-    TFormOnChange,
-    TFormOnChangeAsync,
-    TFormOnBlur,
-    TFormOnBlurAsync,
-    TFormOnSubmit,
-    TFormOnSubmitAsync,
-    TFormOnServer,
-    TParentSubmitMeta
-  >
+	SolidFieldApi<
+		TParentData,
+		TFormOnMount,
+		TFormOnChange,
+		TFormOnChangeAsync,
+		TFormOnBlur,
+		TFormOnBlurAsync,
+		TFormOnSubmit,
+		TFormOnSubmitAsync,
+		TFormOnServer,
+		TParentSubmitMeta
+	>;
 
 // ugly way to trick solid into triggering updates for changes on the fieldApi
 function makeFieldReactive<
-  TParentData,
-  TName extends DeepKeys<TParentData>,
-  TData extends DeepValue<TParentData, TName>,
-  TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnChangeAsync extends
-    | undefined
-    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
-  TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnBlurAsync extends
-    | undefined
-    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
-  TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnSubmitAsync extends
-    | undefined
-    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
-  TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TParentSubmitMeta,
+	TParentData,
+	TName extends DeepKeys<TParentData>,
+	TData extends DeepValue<TParentData, TName>,
+	TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnChangeAsync extends
+		| undefined
+		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
+	TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnBlurAsync extends
+		| undefined
+		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
+	TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnSubmitAsync extends
+		| undefined
+		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
+	TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TParentSubmitMeta,
 >(
-  fieldApi: FieldApi<
-    TParentData,
-    TName,
-    TData,
-    TOnMount,
-    TOnChange,
-    TOnChangeAsync,
-    TOnBlur,
-    TOnBlurAsync,
-    TOnSubmit,
-    TOnSubmitAsync,
-    TFormOnMount,
-    TFormOnChange,
-    TFormOnChangeAsync,
-    TFormOnBlur,
-    TFormOnBlurAsync,
-    TFormOnSubmit,
-    TFormOnSubmitAsync,
-    TFormOnServer,
-    TParentSubmitMeta
-  > &
-    SolidFieldApi<
-      TParentData,
-      TFormOnMount,
-      TFormOnChange,
-      TFormOnChangeAsync,
-      TFormOnBlur,
-      TFormOnBlurAsync,
-      TFormOnSubmit,
-      TFormOnSubmitAsync,
-      TFormOnServer,
-      TParentSubmitMeta
-    >,
+	fieldApi: FieldApi<
+		TParentData,
+		TName,
+		TData,
+		TOnMount,
+		TOnChange,
+		TOnChangeAsync,
+		TOnBlur,
+		TOnBlurAsync,
+		TOnSubmit,
+		TOnSubmitAsync,
+		TFormOnMount,
+		TFormOnChange,
+		TFormOnChangeAsync,
+		TFormOnBlur,
+		TFormOnBlurAsync,
+		TFormOnSubmit,
+		TFormOnSubmitAsync,
+		TFormOnServer,
+		TParentSubmitMeta
+	> &
+		SolidFieldApi<
+			TParentData,
+			TFormOnMount,
+			TFormOnChange,
+			TFormOnChangeAsync,
+			TFormOnBlur,
+			TFormOnBlurAsync,
+			TFormOnSubmit,
+			TFormOnSubmitAsync,
+			TFormOnServer,
+			TParentSubmitMeta
+		>,
 ): () => FieldApi<
-  TParentData,
-  TName,
-  TData,
-  TOnMount,
-  TOnChange,
-  TOnChangeAsync,
-  TOnBlur,
-  TOnBlurAsync,
-  TOnSubmit,
-  TOnSubmitAsync,
-  TFormOnMount,
-  TFormOnChange,
-  TFormOnChangeAsync,
-  TFormOnBlur,
-  TFormOnBlurAsync,
-  TFormOnSubmit,
-  TFormOnSubmitAsync,
-  TFormOnServer,
-  TParentSubmitMeta
+	TParentData,
+	TName,
+	TData,
+	TOnMount,
+	TOnChange,
+	TOnChangeAsync,
+	TOnBlur,
+	TOnBlurAsync,
+	TOnSubmit,
+	TOnSubmitAsync,
+	TFormOnMount,
+	TFormOnChange,
+	TFormOnChangeAsync,
+	TFormOnBlur,
+	TFormOnBlurAsync,
+	TFormOnSubmit,
+	TFormOnSubmitAsync,
+	TFormOnServer,
+	TParentSubmitMeta
 > &
-  SolidFieldApi<
-    TParentData,
-    TFormOnMount,
-    TFormOnChange,
-    TFormOnChangeAsync,
-    TFormOnBlur,
-    TFormOnBlurAsync,
-    TFormOnSubmit,
-    TFormOnSubmitAsync,
-    TFormOnServer,
-    TParentSubmitMeta
-  > {
-  const [flag, setFlag] = createSignal(false)
-  const fieldApiMemo = createMemo(() => [flag(), fieldApi] as const)
-  const unsubscribeStore = fieldApi.store.subscribe(() => setFlag((f) => !f))
-  onCleanup(unsubscribeStore)
-  return () => fieldApiMemo()[1]
+	SolidFieldApi<
+		TParentData,
+		TFormOnMount,
+		TFormOnChange,
+		TFormOnChangeAsync,
+		TFormOnBlur,
+		TFormOnBlurAsync,
+		TFormOnSubmit,
+		TFormOnSubmitAsync,
+		TFormOnServer,
+		TParentSubmitMeta
+	> {
+	const [field, setField] = createSignal(fieldApi, { equals: false });
+	const unsubscribeStore = fieldApi.store.subscribe(() => setField(fieldApi));
+	onCleanup(unsubscribeStore);
+	return field;
 }
 
 export function createField<
-  TParentData,
-  TName extends DeepKeys<TParentData>,
-  TData extends DeepValue<TParentData, TName>,
-  TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnChangeAsync extends
-    | undefined
-    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
-  TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnBlurAsync extends
-    | undefined
-    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
-  TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnSubmitAsync extends
-    | undefined
-    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
-  TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TParentSubmitMeta,
+	TParentData,
+	TName extends DeepKeys<TParentData>,
+	TData extends DeepValue<TParentData, TName>,
+	TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnChangeAsync extends
+		| undefined
+		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
+	TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnBlurAsync extends
+		| undefined
+		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
+	TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnSubmitAsync extends
+		| undefined
+		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
+	TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TParentSubmitMeta,
 >(
-  opts: () => CreateFieldOptions<
-    TParentData,
-    TName,
-    TData,
-    TOnMount,
-    TOnChange,
-    TOnChangeAsync,
-    TOnBlur,
-    TOnBlurAsync,
-    TOnSubmit,
-    TOnSubmitAsync,
-    TFormOnMount,
-    TFormOnChange,
-    TFormOnChangeAsync,
-    TFormOnBlur,
-    TFormOnBlurAsync,
-    TFormOnSubmit,
-    TFormOnSubmitAsync,
-    TFormOnServer,
-    TParentSubmitMeta
-  >,
+	opts: () => CreateFieldOptions<
+		TParentData,
+		TName,
+		TData,
+		TOnMount,
+		TOnChange,
+		TOnChangeAsync,
+		TOnBlur,
+		TOnBlurAsync,
+		TOnSubmit,
+		TOnSubmitAsync,
+		TFormOnMount,
+		TFormOnChange,
+		TFormOnChangeAsync,
+		TFormOnBlur,
+		TFormOnBlurAsync,
+		TFormOnSubmit,
+		TFormOnSubmitAsync,
+		TFormOnServer,
+		TParentSubmitMeta
+	>,
 ) {
-  const options = opts()
+	const options = opts();
 
-  const api = new FieldApi(options)
+	const api = new FieldApi(options);
 
-  const extendedApi: typeof api &
-    SolidFieldApi<
-      TParentData,
-      TFormOnMount,
-      TFormOnChange,
-      TFormOnChangeAsync,
-      TFormOnBlur,
-      TFormOnBlurAsync,
-      TFormOnSubmit,
-      TFormOnSubmitAsync,
-      TFormOnServer,
-      TParentSubmitMeta
-    > = api as never
+	const extendedApi: typeof api &
+		SolidFieldApi<
+			TParentData,
+			TFormOnMount,
+			TFormOnChange,
+			TFormOnChangeAsync,
+			TFormOnBlur,
+			TFormOnBlurAsync,
+			TFormOnSubmit,
+			TFormOnSubmitAsync,
+			TFormOnServer,
+			TParentSubmitMeta
+		> = api as never;
 
-  extendedApi.Field = Field as never
+	extendedApi.Field = Field as never;
 
-  let mounted = false
-  // Instantiates field meta and removes it when unrendered
-  onMount(() => {
-    const cleanupFn = api.mount()
-    mounted = true
-    onCleanup(() => {
-      cleanupFn()
-      mounted = false
-    })
-  })
+	let mounted = false;
+	// Instantiates field meta and removes it when unrendered
+	onMount(() => {
+		const cleanupFn = api.mount();
+		mounted = true;
+		onCleanup(() => {
+			cleanupFn();
+			mounted = false;
+		});
+	});
 
-  /**
-   * fieldApi.update should not have any side effects. Think of it like a `useRef`
-   * that we need to keep updated every render with the most up-to-date information.
-   *
-   * createComputed to make sure this effect runs before render effects
-   */
-  createComputed(() => {
-    if (!mounted) return
-    api.update(opts())
-  })
+	/**
+	 * fieldApi.update should not have any side effects. Think of it like a `useRef`
+	 * that we need to keep updated every render with the most up-to-date information.
+	 *
+	 * createComputed to make sure this effect runs before render effects
+	 */
+	createComputed(() => {
+		if (!mounted) return;
+		api.update(opts());
+	});
 
-  return makeFieldReactive<
-    TParentData,
-    TName,
-    TData,
-    TOnMount,
-    TOnChange,
-    TOnChangeAsync,
-    TOnBlur,
-    TOnBlurAsync,
-    TOnSubmit,
-    TOnSubmitAsync,
-    TFormOnMount,
-    TFormOnChange,
-    TFormOnChangeAsync,
-    TFormOnBlur,
-    TFormOnBlurAsync,
-    TFormOnSubmit,
-    TFormOnSubmitAsync,
-    TFormOnServer,
-    TParentSubmitMeta
-  >(extendedApi as never)
+	return makeFieldReactive<
+		TParentData,
+		TName,
+		TData,
+		TOnMount,
+		TOnChange,
+		TOnChangeAsync,
+		TOnBlur,
+		TOnBlurAsync,
+		TOnSubmit,
+		TOnSubmitAsync,
+		TFormOnMount,
+		TFormOnChange,
+		TFormOnChangeAsync,
+		TFormOnBlur,
+		TFormOnBlurAsync,
+		TFormOnSubmit,
+		TFormOnSubmitAsync,
+		TFormOnServer,
+		TParentSubmitMeta
+	>(extendedApi as never);
 }
 
 type FieldComponentProps<
-  TParentData,
-  TName extends DeepKeys<TParentData>,
-  TData extends DeepValue<TParentData, TName>,
-  TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnChangeAsync extends
-    | undefined
-    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
-  TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnBlurAsync extends
-    | undefined
-    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
-  TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnSubmitAsync extends
-    | undefined
-    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
-  TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TParentSubmitMeta,
+	TParentData,
+	TName extends DeepKeys<TParentData>,
+	TData extends DeepValue<TParentData, TName>,
+	TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnChangeAsync extends
+		| undefined
+		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
+	TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnBlurAsync extends
+		| undefined
+		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
+	TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnSubmitAsync extends
+		| undefined
+		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
+	TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TParentSubmitMeta,
 > = {
-  children: (
-    fieldApi: () => FieldApi<
-      TParentData,
-      TName,
-      TData,
-      TOnMount,
-      TOnChange,
-      TOnChangeAsync,
-      TOnBlur,
-      TOnBlurAsync,
-      TOnSubmit,
-      TOnSubmitAsync,
-      TFormOnMount,
-      TFormOnChange,
-      TFormOnChangeAsync,
-      TFormOnBlur,
-      TFormOnBlurAsync,
-      TFormOnSubmit,
-      TFormOnSubmitAsync,
-      TFormOnServer,
-      TParentSubmitMeta
-    >,
-  ) => JSXElement
+	children: (
+		fieldApi: () => FieldApi<
+			TParentData,
+			TName,
+			TData,
+			TOnMount,
+			TOnChange,
+			TOnChangeAsync,
+			TOnBlur,
+			TOnBlurAsync,
+			TOnSubmit,
+			TOnSubmitAsync,
+			TFormOnMount,
+			TFormOnChange,
+			TFormOnChangeAsync,
+			TFormOnBlur,
+			TFormOnBlurAsync,
+			TFormOnSubmit,
+			TFormOnSubmitAsync,
+			TFormOnServer,
+			TParentSubmitMeta
+		>,
+	) => JSXElement;
 } & Omit<
-  CreateFieldOptions<
-    TParentData,
-    TName,
-    TData,
-    TOnMount,
-    TOnChange,
-    TOnChangeAsync,
-    TOnBlur,
-    TOnBlurAsync,
-    TOnSubmit,
-    TOnSubmitAsync,
-    TFormOnMount,
-    TFormOnChange,
-    TFormOnChangeAsync,
-    TFormOnBlur,
-    TFormOnBlurAsync,
-    TFormOnSubmit,
-    TFormOnSubmitAsync,
-    TFormOnServer,
-    TParentSubmitMeta
-  >,
-  'form'
->
+	CreateFieldOptions<
+		TParentData,
+		TName,
+		TData,
+		TOnMount,
+		TOnChange,
+		TOnChangeAsync,
+		TOnBlur,
+		TOnBlurAsync,
+		TOnSubmit,
+		TOnSubmitAsync,
+		TFormOnMount,
+		TFormOnChange,
+		TFormOnChangeAsync,
+		TFormOnBlur,
+		TFormOnBlurAsync,
+		TFormOnSubmit,
+		TFormOnSubmitAsync,
+		TFormOnServer,
+		TParentSubmitMeta
+	>,
+	"form"
+>;
 
 export type FieldComponent<
-  TParentData,
-  TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TParentSubmitMeta,
+	TParentData,
+	TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TParentSubmitMeta,
 > = <
-  TName extends DeepKeys<TParentData>,
-  TData extends DeepValue<TParentData, TName>,
-  TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnChangeAsync extends
-    | undefined
-    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
-  TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnBlurAsync extends
-    | undefined
-    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
-  TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnSubmitAsync extends
-    | undefined
-    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
+	TName extends DeepKeys<TParentData>,
+	TData extends DeepValue<TParentData, TName>,
+	TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnChangeAsync extends
+		| undefined
+		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
+	TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnBlurAsync extends
+		| undefined
+		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
+	TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnSubmitAsync extends
+		| undefined
+		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
 >({
-  children,
-  ...fieldOptions
+	children,
+	...fieldOptions
 }: Omit<
-  FieldComponentProps<
-    TParentData,
-    TName,
-    TData,
-    TOnMount,
-    TOnChange,
-    TOnChangeAsync,
-    TOnBlur,
-    TOnBlurAsync,
-    TOnSubmit,
-    TOnSubmitAsync,
-    TFormOnMount,
-    TFormOnChange,
-    TFormOnChangeAsync,
-    TFormOnBlur,
-    TFormOnBlurAsync,
-    TFormOnSubmit,
-    TFormOnSubmitAsync,
-    TFormOnServer,
-    TParentSubmitMeta
-  >,
-  'form'
->) => JSXElement
+	FieldComponentProps<
+		TParentData,
+		TName,
+		TData,
+		TOnMount,
+		TOnChange,
+		TOnChangeAsync,
+		TOnBlur,
+		TOnBlurAsync,
+		TOnSubmit,
+		TOnSubmitAsync,
+		TFormOnMount,
+		TFormOnChange,
+		TFormOnChangeAsync,
+		TFormOnBlur,
+		TFormOnBlurAsync,
+		TFormOnSubmit,
+		TFormOnSubmitAsync,
+		TFormOnServer,
+		TParentSubmitMeta
+	>,
+	"form"
+>) => JSXElement;
 
 export function Field<
-  TParentData,
-  TName extends DeepKeys<TParentData>,
-  TData extends DeepValue<TParentData, TName>,
-  TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnChangeAsync extends
-    | undefined
-    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
-  TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnBlurAsync extends
-    | undefined
-    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
-  TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
-  TOnSubmitAsync extends
-    | undefined
-    | FieldAsyncValidateOrFn<TParentData, TName, TData>,
-  TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
-  TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
-  TParentSubmitMeta,
+	TParentData,
+	TName extends DeepKeys<TParentData>,
+	TData extends DeepValue<TParentData, TName>,
+	TOnMount extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnChange extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnChangeAsync extends
+		| undefined
+		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
+	TOnBlur extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnBlurAsync extends
+		| undefined
+		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
+	TOnSubmit extends undefined | FieldValidateOrFn<TParentData, TName, TData>,
+	TOnSubmitAsync extends
+		| undefined
+		| FieldAsyncValidateOrFn<TParentData, TName, TData>,
+	TFormOnMount extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnChange extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnChangeAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnBlur extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnBlurAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnSubmit extends undefined | FormValidateOrFn<TParentData>,
+	TFormOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TFormOnServer extends undefined | FormAsyncValidateOrFn<TParentData>,
+	TParentSubmitMeta,
 >(
-  props: {
-    children: (
-      fieldApi: () => FieldApi<
-        TParentData,
-        TName,
-        TData,
-        TOnMount,
-        TOnChange,
-        TOnChangeAsync,
-        TOnBlur,
-        TOnBlurAsync,
-        TOnSubmit,
-        TOnSubmitAsync,
-        TFormOnMount,
-        TFormOnChange,
-        TFormOnChangeAsync,
-        TFormOnBlur,
-        TFormOnBlurAsync,
-        TFormOnSubmit,
-        TFormOnSubmitAsync,
-        TFormOnServer,
-        TParentSubmitMeta
-      >,
-    ) => JSXElement
-  } & CreateFieldOptions<
-    TParentData,
-    TName,
-    TData,
-    TOnMount,
-    TOnChange,
-    TOnChangeAsync,
-    TOnBlur,
-    TOnBlurAsync,
-    TOnSubmit,
-    TOnSubmitAsync,
-    TFormOnMount,
-    TFormOnChange,
-    TFormOnChangeAsync,
-    TFormOnBlur,
-    TFormOnBlurAsync,
-    TFormOnSubmit,
-    TFormOnSubmitAsync,
-    TFormOnServer,
-    TParentSubmitMeta
-  >,
+	props: {
+		children: (
+			fieldApi: () => FieldApi<
+				TParentData,
+				TName,
+				TData,
+				TOnMount,
+				TOnChange,
+				TOnChangeAsync,
+				TOnBlur,
+				TOnBlurAsync,
+				TOnSubmit,
+				TOnSubmitAsync,
+				TFormOnMount,
+				TFormOnChange,
+				TFormOnChangeAsync,
+				TFormOnBlur,
+				TFormOnBlurAsync,
+				TFormOnSubmit,
+				TFormOnSubmitAsync,
+				TFormOnServer,
+				TParentSubmitMeta
+			>,
+		) => JSXElement;
+	} & CreateFieldOptions<
+		TParentData,
+		TName,
+		TData,
+		TOnMount,
+		TOnChange,
+		TOnChangeAsync,
+		TOnBlur,
+		TOnBlurAsync,
+		TOnSubmit,
+		TOnSubmitAsync,
+		TFormOnMount,
+		TFormOnChange,
+		TFormOnChangeAsync,
+		TFormOnBlur,
+		TFormOnBlurAsync,
+		TFormOnSubmit,
+		TFormOnSubmitAsync,
+		TFormOnServer,
+		TParentSubmitMeta
+	>,
 ) {
-  const fieldApi = createField<
-    TParentData,
-    TName,
-    TData,
-    TOnMount,
-    TOnChange,
-    TOnChangeAsync,
-    TOnBlur,
-    TOnBlurAsync,
-    TOnSubmit,
-    TOnSubmitAsync,
-    TFormOnMount,
-    TFormOnChange,
-    TFormOnChangeAsync,
-    TFormOnBlur,
-    TFormOnBlurAsync,
-    TFormOnSubmit,
-    TFormOnSubmitAsync,
-    TFormOnServer,
-    TParentSubmitMeta
-  >(() => {
-    const { children, ...fieldOptions } = props
-    return fieldOptions
-  })
+	const fieldApi = createField<
+		TParentData,
+		TName,
+		TData,
+		TOnMount,
+		TOnChange,
+		TOnChangeAsync,
+		TOnBlur,
+		TOnBlurAsync,
+		TOnSubmit,
+		TOnSubmitAsync,
+		TFormOnMount,
+		TFormOnChange,
+		TFormOnChangeAsync,
+		TFormOnBlur,
+		TFormOnBlurAsync,
+		TFormOnSubmit,
+		TFormOnSubmitAsync,
+		TFormOnServer,
+		TParentSubmitMeta
+	>(() => {
+		const { children, ...fieldOptions } = props;
+		return fieldOptions;
+	});
 
-  return <>{createComponent(() => props.children(fieldApi), {})}</>
+	return <>{createComponent(() => props.children(fieldApi), {})}</>;
 }


### PR DESCRIPTION
it was using a weird createMemo hack. Solid has a { equals: false } now that will track regardless of any changes so we can avoid an unnecesary memo and array creation (yay)