### PR TITLE
feat(types): make types on functions extend off the base classes generics

### DIFF
--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -193,40 +193,43 @@ export interface FormValidators<
  */
 export interface FormTransform<
   TFormData,
-  TOnMount extends undefined | FormValidateOrFn<TFormData>,
-  TOnChange extends undefined | FormValidateOrFn<TFormData>,
-  TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
-  TOnBlur extends undefined | FormValidateOrFn<TFormData>,
-  TOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
-  TOnSubmit extends undefined | FormValidateOrFn<TFormData>,
-  TOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
-  TOnServer extends undefined | FormAsyncValidateOrFn<TFormData>,
   TSubmitMeta = never,
 > {
-  fn: (
+  fn: <
+    TFFormData extends TFormData,
+    TFOnMount extends undefined | FormValidateOrFn<TFFormData>,
+    TFOnChange extends undefined | FormValidateOrFn<TFFormData>,
+    TFOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFFormData>,
+    TFOnBlur extends undefined | FormValidateOrFn<TFFormData>,
+    TFOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFFormData>,
+    TFOnSubmit extends undefined | FormValidateOrFn<TFFormData>,
+    TFOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFFormData>,
+    TFOnServer extends undefined | FormValidateOrFn<TFFormData>,
+    TFSubmitMeta extends TSubmitMeta
+  >(
     formBase: FormApi<
-      TFormData,
-      TOnMount,
-      TOnChange,
-      TOnChangeAsync,
-      TOnBlur,
-      TOnBlurAsync,
-      TOnSubmit,
-      TOnSubmitAsync,
-      TOnServer,
-      TSubmitMeta
+      TFFormData,
+      TFOnMount,
+      TFOnChange,
+      TFOnChangeAsync,
+      TFOnBlur,
+      TFOnBlurAsync,
+      TFOnSubmit,
+      TFOnSubmitAsync,
+      TFOnServer,
+      TFSubmitMeta
     >,
   ) => FormApi<
-    TFormData,
-    TOnMount,
-    TOnChange,
-    TOnChangeAsync,
-    TOnBlur,
-    TOnBlurAsync,
-    TOnSubmit,
-    TOnSubmitAsync,
-    TOnServer,
-    TSubmitMeta
+    TFFormData,
+    TFOnMount,
+    TFOnChange,
+    TFOnChangeAsync,
+    TFOnBlur,
+    TFOnBlurAsync,
+    TFOnSubmit,
+    TFOnSubmitAsync,
+    TFOnServer,
+    TFSubmitMeta
   >
   deps: unknown[]
 }
@@ -296,52 +299,63 @@ export interface FormOptions<
   /**
    * A function to be called when the form is submitted, what should happen once the user submits a valid form returns `any` or a promise `Promise<any>`
    */
-  onSubmit?: (props: {
-    value: TFormData
+  onSubmit?: <
+    TFFormData extends TFormData,
+    TFOnMount extends undefined | FormValidateOrFn<TFFormData>,
+    TFOnChange extends undefined | FormValidateOrFn<TFFormData>,
+    TFOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFFormData>,
+    TFOnBlur extends undefined | FormValidateOrFn<TFFormData>,
+    TFOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFFormData>,
+    TFOnSubmit extends undefined | FormValidateOrFn<TFFormData>,
+    TFOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFFormData>,
+    TFOnServer extends undefined | FormValidateOrFn<TFFormData>,
+    TFSubmitMeta extends TSubmitMeta
+  >(props: {
+    value: TFFormData
     formApi: FormApi<
-      TFormData,
-      TOnMount,
-      TOnChange,
-      TOnChangeAsync,
-      TOnBlur,
-      TOnBlurAsync,
-      TOnSubmit,
-      TOnSubmitAsync,
-      TOnServer,
-      TSubmitMeta
+      TFFormData,
+      TFOnMount,
+      TFOnChange,
+      TFOnChangeAsync,
+      TFOnBlur,
+      TFOnBlurAsync,
+      TFOnSubmit,
+      TFOnSubmitAsync,
+      TFOnServer,
+      TFSubmitMeta
     >
     meta: TSubmitMeta
   }) => any | Promise<any>
   /**
    * Specify an action for scenarios where the user tries to submit an invalid form.
    */
-  onSubmitInvalid?: (props: {
-    value: TFormData
+  onSubmitInvalid?: <
+    TFFormData extends TFormData,
+    TFOnMount extends undefined | FormValidateOrFn<TFFormData>,
+    TFOnChange extends undefined | FormValidateOrFn<TFFormData>,
+    TFOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFFormData>,
+    TFOnBlur extends undefined | FormValidateOrFn<TFFormData>,
+    TFOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFFormData>,
+    TFOnSubmit extends undefined | FormValidateOrFn<TFFormData>,
+    TFOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFFormData>,
+    TFOnServer extends undefined | FormValidateOrFn<TFFormData>,
+    TFSubmitMeta extends TSubmitMeta
+  >(props: {
+    value: TFFormData
     formApi: FormApi<
-      TFormData,
-      TOnMount,
-      TOnChange,
-      TOnChangeAsync,
-      TOnBlur,
-      TOnBlurAsync,
-      TOnSubmit,
-      TOnSubmitAsync,
-      TOnServer,
-      TSubmitMeta
+      TFFormData,
+      TFOnMount,
+      TFOnChange,
+      TFOnChangeAsync,
+      TFOnBlur,
+      TFOnBlurAsync,
+      TFOnSubmit,
+      TFOnSubmitAsync,
+      TFOnServer,
+      TFSubmitMeta
     >
   }) => void
-  transform?: FormTransform<
-    NoInfer<TFormData>,
-    NoInfer<TOnMount>,
-    NoInfer<TOnChange>,
-    NoInfer<TOnChangeAsync>,
-    NoInfer<TOnBlur>,
-    NoInfer<TOnBlurAsync>,
-    NoInfer<TOnSubmit>,
-    NoInfer<TOnSubmitAsync>,
-    NoInfer<TOnServer>,
-    NoInfer<TSubmitMeta>
-  >
+  transform?: FormTransform<NoInfer<TFormData>>
 }
 
 /**


### PR DESCRIPTION
The goal here is to eventually allow a `withForm` component to accept "extending" forms, or those which are bigger then what they know about but do contain what they need.
I suspect that even an alternative solution to `withForm` would still need those changes to work.

While looking at the TS error that comes when trying this, I noticed that it was always about the types in the functions but never about the object attributes. So after some experimenting, it turns out that this fails:
```ts
type Test<T> = {
  defaultValues: T
  fun: (props: { value: T }) => {}
}
const t: Test<{ firstName: string }> =
  {} as Test<{ firstName: string, lastName: string }>
```

While this works:
```ts
type Test2<T> = {
  defaultValues: T,
  fun: <TF extends T = T>(props: { value: TF }) => void
}

// ist fine, the actual type has all that was asked for and then some
const t2: Test2<{ firstName: string }> =
  {} as Test2<{ firstName: string, lastName: string }>
```

and still ensures that `firstName` is included on t2. The main idea is unless `props.value` only extends T, TypeScript checks the equality both ways. If it does extend T, the checking becomes unidirectional.

This obviously still needs a lot of work to be done as most likely all function signatures would have to be changed in such a matter and more type errors will come up along the way.

But at least this works to prove the concept:
```ts
const f1 = {} as FormOptions<
  { firstName: string, lastName: string },
  undefined,
  undefined,
  undefined,
  undefined,
  undefined,
  undefined,
  undefined,
  undefined
>

const f2: FormOptions<
  { firstName: string },
  undefined,
  undefined,
  undefined,
  undefined,
  undefined,
  undefined,
  undefined,
  undefined
> = f1
```
with surprisingly few errors in `FieldApi.ts` to track down.

Once its all the way done, the inference should still work just fine.