### PR TITLE
docs(vue): use event modifiers to enhance readability

### DIFF
--- a/docs/framework/vue/quick-start.md
+++ b/docs/framework/vue/quick-start.md
@@ -23,15 +23,7 @@ const form = useForm({
 
 <template>
   <div>
-    <form
-      @submit="
-        (e) => {
-          e.preventDefault()
-          e.stopPropagation()
-          form.handleSubmit()
-        }
-      "
-    >
+    <form @submit.prevent.stop="form.handleSubmit">
       <div>
         <form.Field name="fullName">
           <template v-slot="{ field }">


### PR DESCRIPTION
Instead of using the arrow function:

```vue
(e) => {
  e.preventDefault()
  e.stopPropagation()
  form.handleSubmit()
}
```

we can just use [event modifiers](https://vuejs.org/guide/essentials/event-handling#event-modifiers) like this:

```vue
@submit.prevent.stop="form.handleSubmit"
```

enhancing readability ✨ 