### PR TITLE
perf(react-form): skip updating isValidating by default

### DIFF
--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -439,6 +439,10 @@ export interface FieldOptions<
    * Disable the `flat(1)` operation on `field.errors`. This is useful if you want to keep the error structure as is. Not suggested for most use-cases.
    */
   disableErrorFlat?: boolean
+  /**
+   * Should the field's isValidating state be updated during validation
+   */
+  trackValidationState?: boolean
 }
 
 /**
@@ -1473,12 +1477,14 @@ export class FieldApi<
       >,
     )
 
-    if (!this.state.meta.isValidating) {
+    if (!this.state.meta.isValidating && this.options.trackValidationState) {
       this.setMeta((prev) => ({ ...prev, isValidating: true }))
     }
 
     for (const linkedField of linkedFields) {
-      linkedField.setMeta((prev) => ({ ...prev, isValidating: true }))
+      if (linkedField.options.trackValidationState) {
+        linkedField.setMeta((prev) => ({ ...prev, isValidating: true }))
+      }
     }
 
     /**
@@ -1577,10 +1583,14 @@ export class FieldApi<
       await Promise.all(linkedPromises)
     }
 
-    this.setMeta((prev) => ({ ...prev, isValidating: false }))
+    if (this.options.trackValidationState) {
+      this.setMeta((prev) => ({ ...prev, isValidating: false }))
+    }
 
     for (const linkedField of linkedFields) {
-      linkedField.setMeta((prev) => ({ ...prev, isValidating: false }))
+      if (linkedField.options.trackValidationState) {
+        linkedField.setMeta((prev) => ({ ...prev, isValidating: false }))
+      }
     }
 
     return results.filter(Boolean)

--- a/packages/react-form/tests/useField.test.tsx
+++ b/packages/react-form/tests/useField.test.tsx
@@ -290,26 +290,27 @@ describe('useField', () => {
                   </form.Field>
                 )
               }
-              return null
+              return (
+                <form.Field name="secondField">
+                  {({ handleChange, state }) => (
+                    <label>
+                      second field
+                      <input
+                        data-testid="second-field"
+                        value={state.value}
+                        onChange={(e) => handleChange(e.target.value)}
+                      />
+                    </label>
+                  )}
+                </form.Field>
+              )
             }}
           </form.Subscribe>
-          <form.Field name="secondField">
-            {({ handleChange, state }) => (
-              <label>
-                second field
-                <input
-                  data-testid="second-field"
-                  value={state.value}
-                  onChange={(e) => handleChange(e.target.value)}
-                />
-              </label>
-            )}
-          </form.Field>
         </>
       )
     }
 
-    const { getByTestId, debug } = render(<Comp />)
+    const { getByTestId } = render(<Comp />)
 
     const showFirstFieldInput = getByTestId('show-first-field')
 


### PR DESCRIPTION
fixes https://github.com/TanStack/form/issues/1130

BREAKING CHANGE: isValidating is now opt-in