### PR TITLE
feat(react-form): return parsed data from serverValidate function

### DIFF
--- a/docs/framework/react/guides/ssr.md
+++ b/docs/framework/react/guides/ssr.md
@@ -69,6 +69,11 @@ export const handleForm = createServerFn({
     try {
       const validatedData = await serverValidate(ctx.data)
       console.log('validatedData', validatedData)
+      // Persist the form data to the database
+      // await sql`
+      //   INSERT INTO users (name, email, password)
+      //   VALUES (${validatedData.name}, ${validatedData.email}, ${validatedData.password})
+      // `
     } catch (e) {
       if (e instanceof ServerValidateError) {
         // Log form errors or do any other logic here
@@ -226,6 +231,11 @@ export default async function someAction(prev: unknown, formData: FormData) {
   try {
     const validatedData = await serverValidate(formData)
     console.log('validatedData', validatedData)
+    // Persist the form data to the database
+    // await sql`
+    //   INSERT INTO users (name, email, password)
+    //   VALUES (${validatedData.name}, ${validatedData.email}, ${validatedData.password})
+    // `
   } catch (e) {
     if (e instanceof ServerValidateError) {
       return e.formState
@@ -379,6 +389,11 @@ export async function action({ request }: ActionFunctionArgs) {
   try {
     const validatedData = await serverValidate(formData)
     console.log('validatedData', validatedData)
+    // Persist the form data to the database
+    // await sql`
+    //   INSERT INTO users (name, email, password)
+    //   VALUES (${validatedData.name}, ${validatedData.email}, ${validatedData.password})
+    // `
   } catch (e) {
     if (e instanceof ServerValidateError) {
       return e.formState

--- a/docs/framework/react/guides/ssr.md
+++ b/docs/framework/react/guides/ssr.md
@@ -67,7 +67,8 @@ export const handleForm = createServerFn({
   })
   .handler(async (ctx) => {
     try {
-      await serverValidate(ctx.data)
+      const validatedData = await serverValidate(ctx.data)
+      console.log('validatedData', validatedData)
     } catch (e) {
       if (e instanceof ServerValidateError) {
         // Log form errors or do any other logic here
@@ -223,7 +224,8 @@ const serverValidate = createServerValidate({
 
 export default async function someAction(prev: unknown, formData: FormData) {
   try {
-    await serverValidate(formData)
+    const validatedData = await serverValidate(formData)
+    console.log('validatedData', validatedData)
   } catch (e) {
     if (e instanceof ServerValidateError) {
       return e.formState
@@ -375,7 +377,8 @@ const serverValidate = createServerValidate({
 export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData()
   try {
-    await serverValidate(formData)
+    const validatedData = await serverValidate(formData)
+    console.log('validatedData', validatedData)
   } catch (e) {
     if (e instanceof ServerValidateError) {
       return e.formState

--- a/examples/react/next-server-actions/src/app/action.ts
+++ b/examples/react/next-server-actions/src/app/action.ts
@@ -19,6 +19,11 @@ export default async function someAction(prev: unknown, formData: FormData) {
   try {
     const validatedData = await serverValidate(formData)
     console.log('validatedData', validatedData)
+    // Persist the form data to the database
+    // await sql`
+    //   INSERT INTO users (name, email, password)
+    //   VALUES (${validatedData.name}, ${validatedData.email}, ${validatedData.password})
+    // `
   } catch (e) {
     if (e instanceof ServerValidateError) {
       return e.formState

--- a/examples/react/next-server-actions/src/app/action.ts
+++ b/examples/react/next-server-actions/src/app/action.ts
@@ -17,7 +17,8 @@ const serverValidate = createServerValidate({
 
 export default async function someAction(prev: unknown, formData: FormData) {
   try {
-    await serverValidate(formData)
+    const validatedData = await serverValidate(formData)
+    console.log('validatedData', validatedData)
   } catch (e) {
     if (e instanceof ServerValidateError) {
       return e.formState

--- a/examples/react/remix/app/routes/_index/route.tsx
+++ b/examples/react/remix/app/routes/_index/route.tsx
@@ -30,7 +30,8 @@ const serverValidate = createServerValidate({
 export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData()
   try {
-    await serverValidate(formData)
+    const validatedData = await serverValidate(formData)
+    console.log('validatedData', validatedData)
   } catch (e) {
     if (e instanceof ServerValidateError) {
       return e.formState

--- a/examples/react/remix/app/routes/_index/route.tsx
+++ b/examples/react/remix/app/routes/_index/route.tsx
@@ -32,6 +32,11 @@ export async function action({ request }: ActionFunctionArgs) {
   try {
     const validatedData = await serverValidate(formData)
     console.log('validatedData', validatedData)
+    // Persist the form data to the database
+    // await sql`
+    //   INSERT INTO users (name, email, password)
+    //   VALUES (${validatedData.name}, ${validatedData.email}, ${validatedData.password})
+    // `
   } catch (e) {
     if (e instanceof ServerValidateError) {
       return e.formState

--- a/examples/react/tanstack-start/app/utils/form.tsx
+++ b/examples/react/tanstack-start/app/utils/form.tsx
@@ -29,6 +29,11 @@ export const handleForm = createServerFn({
     try {
       const validatedData = await serverValidate(ctx.data)
       console.log('validatedData', validatedData)
+      // Persist the form data to the database
+      // await sql`
+      //   INSERT INTO users (name, email, password)
+      //   VALUES (${validatedData.name}, ${validatedData.email}, ${validatedData.password})
+      // `
     } catch (e) {
       if (e instanceof ServerValidateError) {
         // Log form errors or do any other logic here

--- a/examples/react/tanstack-start/app/utils/form.tsx
+++ b/examples/react/tanstack-start/app/utils/form.tsx
@@ -27,7 +27,8 @@ export const handleForm = createServerFn({
   })
   .handler(async (ctx) => {
     try {
-      await serverValidate(ctx.data)
+      const validatedData = await serverValidate(ctx.data)
+      console.log('validatedData', validatedData)
     } catch (e) {
       if (e instanceof ServerValidateError) {
         // Log form errors or do any other logic here

--- a/packages/react-form/src/nextjs/createServerValidate.ts
+++ b/packages/react-form/src/nextjs/createServerValidate.ts
@@ -96,7 +96,7 @@ export const createServerValidate =
       validationSource: 'form',
     })) as UnwrapFormAsyncValidateOrFn<TOnServer> | undefined
 
-    if (!onServerError) return values;
+    if (!onServerError) return values
 
     const onServerErrorVal = (
       isGlobalFormValidationError(onServerError)

--- a/packages/react-form/src/nextjs/createServerValidate.ts
+++ b/packages/react-form/src/nextjs/createServerValidate.ts
@@ -96,7 +96,7 @@ export const createServerValidate =
       validationSource: 'form',
     })) as UnwrapFormAsyncValidateOrFn<TOnServer> | undefined
 
-    if (!onServerError) return
+    if (!onServerError) return values;
 
     const onServerErrorVal = (
       isGlobalFormValidationError(onServerError)

--- a/packages/react-form/src/remix/createServerValidate.ts
+++ b/packages/react-form/src/remix/createServerValidate.ts
@@ -96,7 +96,7 @@ export const createServerValidate =
       validationSource: 'form',
     })) as UnwrapFormAsyncValidateOrFn<TOnServer> | undefined
 
-    if (!onServerError) return values;
+    if (!onServerError) return values
 
     const onServerErrorVal = (
       isGlobalFormValidationError(onServerError)

--- a/packages/react-form/src/remix/createServerValidate.ts
+++ b/packages/react-form/src/remix/createServerValidate.ts
@@ -96,7 +96,7 @@ export const createServerValidate =
       validationSource: 'form',
     })) as UnwrapFormAsyncValidateOrFn<TOnServer> | undefined
 
-    if (!onServerError) return
+    if (!onServerError) return values;
 
     const onServerErrorVal = (
       isGlobalFormValidationError(onServerError)

--- a/packages/react-form/src/start/createServerValidate.tsx
+++ b/packages/react-form/src/start/createServerValidate.tsx
@@ -100,7 +100,7 @@ export const createServerValidate =
       validationSource: 'form',
     })) as UnwrapFormAsyncValidateOrFn<TOnServer> | undefined
 
-    if (!onServerError) return
+    if (!onServerError) return data;
 
     const onServerErrorVal = (
       isGlobalFormValidationError(onServerError)

--- a/packages/react-form/src/start/createServerValidate.tsx
+++ b/packages/react-form/src/start/createServerValidate.tsx
@@ -100,7 +100,7 @@ export const createServerValidate =
       validationSource: 'form',
     })) as UnwrapFormAsyncValidateOrFn<TOnServer> | undefined
 
-    if (!onServerError) return data;
+    if (!onServerError) return data
 
     const onServerErrorVal = (
       isGlobalFormValidationError(onServerError)


### PR DESCRIPTION
Change serverValidate return type from `Promise<void>` to `Promise<TData>` to provide direct access to validated and parsed data. Eliminates the need to decode formData twice, enhancing developer experience with immediate typed access to validation results.

Closes #1317