### PR TITLE
fix(core, react): export formAPI and update imports for start Example

### DIFF
--- a/examples/react/tanstack-start/app/client.tsx
+++ b/examples/react/tanstack-start/app/client.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vinxi/types/client" />
 import { hydrateRoot } from 'react-dom/client'
 import { StartClient } from '@tanstack/react-start'
 import { createRouter } from './router'

--- a/examples/react/tanstack-start/app/router.tsx
+++ b/examples/react/tanstack-start/app/router.tsx
@@ -5,6 +5,7 @@ export function createRouter() {
   const router = createTanStackRouter({
     routeTree,
     defaultPreload: 'intent',
+    scrollRestoration: true,
   })
 
   return router

--- a/examples/react/tanstack-start/app/routes/__root.tsx
+++ b/examples/react/tanstack-start/app/routes/__root.tsx
@@ -1,10 +1,11 @@
 import {
+  HeadContent,
   Outlet,
-  ScrollRestoration,
+  Scripts,
   createRootRoute,
 } from '@tanstack/react-router'
-import { Meta, Scripts } from '@tanstack/react-start'
-import * as React from 'react'
+
+import type { ReactNode } from 'react'
 
 export const Route = createRootRoute({
   head: () => ({
@@ -32,15 +33,14 @@ function RootComponent() {
   )
 }
 
-function RootDocument({ children }: { children: React.ReactNode }) {
+function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <html>
       <head>
-        <Meta />
+        <HeadContent />
       </head>
       <body>
         {children}
-        <ScrollRestoration />
         <Scripts />
       </body>
     </html>

--- a/examples/react/tanstack-start/app/ssr.tsx
+++ b/examples/react/tanstack-start/app/ssr.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vinxi/types/server" />
 import {
   createStartHandler,
   defaultStreamHandler,

--- a/examples/react/tanstack-start/app/utils/form-isomorphic.ts
+++ b/examples/react/tanstack-start/app/utils/form-isomorphic.ts
@@ -1,4 +1,4 @@
-import { formOptions } from '@tanstack/react-form'
+import { formOptions } from '@tanstack/react-form/start'
 
 export const formOpts = formOptions({
   defaultValues: {

--- a/packages/react-form/src/start/index.ts
+++ b/packages/react-form/src/start/index.ts
@@ -1,3 +1,5 @@
+export * from '@tanstack/form-core'
+
 export * from './createServerValidate'
 export * from './getFormData'
 export * from './error'


### PR DESCRIPTION
Updates of imports:

TanStack/router has deprecated the ScrollRestoration, tanstack/start has renamed Meta to HeadContent, and moved Scripts from tanstack/start to tanstack/router

[x] meta -> HeadContent
[x] ScrollRestoration deprecated
[x] Scripts moved to tanstack/router

<img width="733" alt="Screenshot 2025-03-24 at 09 33 41" src="https://github.com/user-attachments/assets/e720e4fe-553c-4626-8b61-857ab89a2282" />

---
Export of formApi:

Form's tanstack/react-form/start docs show `// Notice the import path is different from the typical import location` however, tanstack/react-from/start dose not export formApi (like is done in tanstack/react-form/next) so `formOptions` isn't available from this path.

[x] export formApi from tanstack/react-form/start

<img width="543" alt="Screenshot 2025-03-24 at 10 01 19" src="https://github.com/user-attachments/assets/023ca590-7223-45e9-8c6c-509961129af3" />
