### PR TITLE
chore(deps): remove form-core package as it is unused and re-exported from react-form

### DIFF
--- a/examples/react/tanstack-start/package.json
+++ b/examples/react/tanstack-start/package.json
@@ -9,7 +9,6 @@
     "start": "vinxi start"
   },
   "dependencies": {
-    "@tanstack/form-core": "^1.1.2",
     "@tanstack/react-form": "^1.1.2",
     "@tanstack/react-router": "^1.112.0",
     "@tanstack/react-start": "^1.112.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -492,9 +492,6 @@ importers:
 
   examples/react/tanstack-start:
     dependencies:
-      '@tanstack/form-core':
-        specifier: ^1.1.2
-        version: link:../../../packages/form-core
       '@tanstack/react-form':
         specifier: ^1.1.2
         version: link:../../../packages/react-form


### PR DESCRIPTION
This PR eliminates the @tanstack/form-core package from the example, as it’s currently unused. If its functionality is needed, it's already [re-exported](https://github.com/TanStack/form/blob/v1.1.2/packages/react-form/src/index.ts#L1) from @tanstack/react-form. By dropping it, we avoid the hassle of keeping an extra package in sync with the adapter.