### PR TITLE
fix(core, react): export of formOptions results in build error

### DIFF
--- a/docs/framework/react/guides/ssr.md
+++ b/docs/framework/react/guides/ssr.md
@@ -26,8 +26,7 @@ Let's start by creating a `formOption` that we'll use to share the form's shape 
 
 ```typescript
 // app/routes/index.tsx, but can be extracted to any other path
-// Notice the import path is different from the typical import location
-import { formOptions } from '@tanstack/react-form/start'
+import { formOptions } from '@tanstack/react-form'
 
 // You can pass other form options here
 export const formOpts = formOptions({

--- a/examples/react/tanstack-start/app/utils/form-isomorphic.ts
+++ b/examples/react/tanstack-start/app/utils/form-isomorphic.ts
@@ -1,4 +1,4 @@
-import { formOptions } from '@tanstack/react-form/start'
+import { formOptions } from '@tanstack/react-form'
 
 export const formOpts = formOptions({
   defaultValues: {

--- a/packages/react-form/src/start/index.ts
+++ b/packages/react-form/src/start/index.ts
@@ -1,5 +1,3 @@
-export * from '@tanstack/form-core'
-
 export * from './createServerValidate'
 export * from './getFormData'
 export * from './error'


### PR DESCRIPTION
Exporting formOptions from start results in build error this PR reverts those changes and updated to docs to reflect this.

- revert export of form core
- updated SSR docs 
- updated tanstack start example