### PR TITLE
docs(react-form): Update docs to reflect a change that was made pre-1.0.

### DIFF
--- a/docs/framework/react/guides/validation.md
+++ b/docs/framework/react/guides/validation.md
@@ -34,7 +34,7 @@ Here is an example:
         onChange={(e) => field.handleChange(e.target.valueAsNumber)}
       />
       {field.state.meta.errors ? (
-        <em role="alert">{field.state.meta.errors.join(', ')}</em>
+        <em role="alert">{field.state.meta.errors.map(error => error.message).join(', ')}</em>
       ) : null}
     </>
   )}
@@ -65,7 +65,7 @@ In the example above, the validation is done at each keystroke (`onChange`). If,
         onChange={(e) => field.handleChange(e.target.valueAsNumber)}
       />
       {field.state.meta.errors ? (
-        <em role="alert">{field.state.meta.errors.join(', ')}</em>
+        <em role="alert">{field.state.meta.errors.map(error => error.message).join(', ')}</em>
       ) : null}
     </>
   )}
@@ -97,7 +97,7 @@ So you can control when the validation is done by implementing the desired callb
         onChange={(e) => field.handleChange(e.target.valueAsNumber)}
       />
       {field.state.meta.errors ? (
-        <em role="alert">{field.state.meta.errors.join(', ')}</em>
+        <em role="alert">{field.state.meta.errors.map(error => error.message).join(', ')}</em>
       ) : null}
     </>
   )}
@@ -267,7 +267,7 @@ export default function App() {
                 onChange={(e) => field.handleChange(e.target.valueAsNumber)}
               />
               {field.state.meta.errors ? (
-                <em role="alert">{field.state.meta.errors.join(', ')}</em>
+                <em role="alert">{field.state.meta.errors.map(error => error.message).join(', ')}</em>
               ) : null}
             </>
           )}
@@ -350,7 +350,7 @@ To do this, we have dedicated `onChangeAsync`, `onBlurAsync`, and other methods 
         onChange={(e) => field.handleChange(e.target.valueAsNumber)}
       />
       {field.state.meta.errors ? (
-        <em role="alert">{field.state.meta.errors.join(', ')}</em>
+        <em role="alert">{field.state.meta.errors.map(error => error.message).join(', ')}</em>
       ) : null}
     </>
   )}
@@ -382,7 +382,7 @@ Synchronous and Asynchronous validations can coexist. For example, it is possibl
         onChange={(e) => field.handleChange(e.target.valueAsNumber)}
       />
       {field.state.meta.errors ? (
-        <em role="alert">{field.state.meta.errors.join(', ')}</em>
+        <em role="alert">{field.state.meta.errors.map(error => error.message).join(', ')}</em>
       ) : null}
     </>
   )}

--- a/docs/framework/react/quick-start.md
+++ b/docs/framework/react/quick-start.md
@@ -121,7 +121,7 @@ const PeoplePage = () => {
             onChange={(e) => field.handleChange(e.target.valueAsNumber)}
           />
           {field.state.meta.errors.length ? (
-            <em>{field.state.meta.errors.join(',')}</em>
+            <em>{field.state.meta.errors.map(error => error.message).join(', ')}</em>
           ) : null}
         </>
       )}


### PR DESCRIPTION
Previously, the result of field.state.errors was an array of strings. Now, it is an array of objects, from which you need to extract the "message" values. This commit updates the TanStack Form docs for React to reflect this. I am not sure of the correct syntax for Angular, Solid, or Vue, but they will have the same issues.  Just search for "errors.join" and this will locate the things that need to be changed.

Authoritative source for this change was a comment on my discussion post: https://github.com/TanStack/form/discussions/1284#discussioncomment-12510456