### PR TITLE
fix(react-form): cookie deletion in getFormData

### DIFF
--- a/packages/react-form/src/start/getFormData.tsx
+++ b/packages/react-form/src/start/getFormData.tsx
@@ -1,4 +1,4 @@
-import { getHeader, removeResponseHeader } from '@tanstack/react-start/server'
+import { deleteCookie, getHeader } from '@tanstack/react-start/server'
 import { _tanstackInternalsCookie } from './utils'
 import type { ServerFormState } from './types'
 
@@ -13,8 +13,8 @@ export const getFormData = async () => {
   const data = (await _tanstackInternalsCookie.parse(getHeader('Cookie')!)) as
     | undefined
     | ServerFormState<any, undefined>
-  // Delete the cookie before it hits the client again¸
-  removeResponseHeader('Cookie')
+  // Delete the temporary cookie from the client after reading it
+  deleteCookie(_tanstackInternalsCookie.name)
   if (!data) return initialFormState
   return data
 }


### PR DESCRIPTION
Removing the response header didn't do anything as the cookie had already been set on the client. This replaces it with the h3 deleteCookie method to ensure it actually gets deleted. Before this the error message would persist whenever the page was loaded.