### PR TITLE
docs(vue): fix TypeScript type assertion in quick-start.md input event handler example

### DIFF
--- a/docs/framework/vue/quick-start.md
+++ b/docs/framework/vue/quick-start.md
@@ -31,7 +31,7 @@ const form = useForm({
               :name="field.name"
               :value="field.state.value"
               @blur="field.handleBlur"
-              @input="(e) => field.handleChange(e.target.value)"
+              @input="(e) => field.handleChange((e.target as HTMLInputElement).value)"
             />
           </template>
         </form.Field>


### PR DESCRIPTION
### Description
This PR corrects a TypeScript-related issue in the `quick-start.md` documentation file. The original example for the `<input>` event handler used `e.target.value` directly in the `@input` callback, which could cause TypeScript errors in an IDE due to the lack of type inference for `e.target`.

I updated the example to use `(e.target as HTMLInputElement).value`, aligning it with the correct implementation found in an example file in another directory. This ensures the documentation provides a TypeScript-safe code snippet for users.

### Changes
- Updated the `@input` event handler example in `quick-start.md` from `(e) => field.handleChange(e.target.value)` to `(e) => field.handleChange((e.target as HTMLInputElement).value)`.

### Why
This change improves the accuracy of the `quick-start.md` documentation by providing a type-safe example, making it easier for TypeScript users to follow without encountering IDE errors.

### Testing
- Verified that the updated example matches the working implementation in the referenced example file.
- Ensured the markdown syntax remains valid.

First-time contributor here—happy to adjust based on feedback!