### PR TITLE
fix(react-form): fallback array field value during index change to prevent uncontrolled error

### DIFF
--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -993,11 +993,16 @@ export class FieldApi<
     this.form = opts.form as never
     this.name = opts.name as never
     this.timeoutIds = {} as Record<ValidationCause, never>
+    // Only really relevant for arrays, the value could be gone once Derived's update fn is triggered
+    const potentialPreviousValue = this.form.getFieldValue(this.name)
 
     this.store = new Derived({
       deps: [this.form.store],
       fn: () => {
-        const value = this.form.getFieldValue(this.name)
+        let value = this.form.getFieldValue(this.name)
+        if (value === undefined && potentialPreviousValue !== undefined) {
+          value = potentialPreviousValue
+        }
         const meta = this.form.getFieldMeta(this.name) ?? {
           ...defaultFieldMeta,
           ...opts.defaultMeta,


### PR DESCRIPTION
Fixes https://github.com/TanStack/form/issues/1363

More of a draft, while this seems to fix the issue it could have unintended side-effects.
Perhaps it's useful in finding a better solution.

What seems to happen:
Have at least 2 array elements that are not keyed by index.
Remove the first element.
This will cause the second element to be moved up, but it attempts to retrieve a value with the old index, resulting in an undefined value for a short bit.