### PR TITLE
docs: suggest using `satisfies` instead of `as`

### DIFF
--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -56,7 +56,7 @@ useForm({
   defaultValues: {
     name: 'Bill Luo',
     age: 24,
-  } as MyForm,
+  } satisfies MyForm,
 })
 ```
 


### PR DESCRIPTION
At least `satisfies` do type checking for us.