### PR TITLE
docs: add ESLint rule exception for react/no-children-prop

### DIFF
--- a/docs/framework/react/guides/basic-concepts.md
+++ b/docs/framework/react/guides/basic-concepts.md
@@ -72,6 +72,18 @@ Example:
   )}
 />
 ```
+If you are using ESLint, make sure to add this to your eslintrc to avoid linting errors.
+```json
+  "rules": {
+    "react/no-children-prop": [
+      true,
+      {
+        "allowFunctions": true
+      }
+    ],
+  }
+```
+
 
 ## Field State
 


### PR DESCRIPTION
I ran into an error caused by ESLint and I have found that a few other people did too, I think it would be good to include this in the docs. 