### PR TITLE
Merging Form-level server errors with Field-level errors

### DIFF
--- a/examples/react/next-server-actions/src/app/action.ts
+++ b/examples/react/next-server-actions/src/app/action.ts
@@ -9,9 +9,8 @@ import { formOpts } from './shared-code'
 const serverValidate = createServerValidate({
   ...formOpts,
   onServerValidate: ({ value }) => {
-    if (value.age < 12) {
-      return 'Server validation: You must be at least 12 to sign up'
-    }
+    if (value.age < 12)
+      return { age: 'Server validation: You must be at least 12 to sign up' }
   },
 })
 

--- a/examples/react/next-server-actions/src/app/client-component.tsx
+++ b/examples/react/next-server-actions/src/app/client-component.tsx
@@ -3,7 +3,6 @@
 import { useActionState } from 'react'
 import { mergeForm, useForm, useTransform } from '@tanstack/react-form'
 import { initialFormState } from '@tanstack/react-form/nextjs'
-import { useStore } from '@tanstack/react-store'
 import someAction from './action'
 import { formOpts } from './shared-code'
 
@@ -18,14 +17,8 @@ export const ClientComp = () => {
     ),
   })
 
-  const formErrors = useStore(form.store, (formState) => formState.errors)
-
   return (
     <form action={action as never} onSubmit={() => form.handleSubmit()}>
-      {formErrors.map((error) => (
-        <p key={error as unknown as string}>{error}</p>
-      ))}
-
       <form.Field
         name="age"
         validators={{

--- a/examples/react/next-server-actions/src/app/shared-code.ts
+++ b/examples/react/next-server-actions/src/app/shared-code.ts
@@ -2,7 +2,6 @@ import { formOptions } from '@tanstack/react-form/nextjs'
 
 export const formOpts = formOptions({
   defaultValues: {
-    firstName: '',
     age: 0,
   },
 })

--- a/packages/react-form/src/nextjs/createServerValidate.ts
+++ b/packages/react-form/src/nextjs/createServerValidate.ts
@@ -104,12 +104,25 @@ export const createServerValidate =
         : onServerError
     ) as UnwrapFormAsyncValidateOrFn<TOnServer>
 
+    // Extract string values from errors if they're in object format
+    const errorsArray = onServerErrorVal
+      ? Array.isArray(onServerErrorVal)
+        ? onServerErrorVal.map((err) =>
+            typeof err === 'object' ? Object.values(err)[0] : err,
+          )
+        : [
+            typeof onServerErrorVal === 'object'
+              ? Object.values(onServerErrorVal)[0]
+              : onServerErrorVal,
+          ]
+      : []
+
     const formState: ServerFormState<TFormData, TOnServer> = {
       errorMap: {
         onServer: onServerError,
       },
       values,
-      errors: onServerErrorVal ? [onServerErrorVal] : [],
+      errors: errorsArray,
     }
 
     throw new ServerValidateError({


### PR DESCRIPTION
Instead of the previous `serverValidate` function just returning a string, we now return an object:
```ts
const serverValidate = createServerValidate({
  ...formOpts,
  onServerValidate: ({ value }) => {
    if (value.age < 12)
      return { age: 'Server validation: You must be at least 12 to sign up' }
  },
})
```

This then maps to the field-level errors with the `setMeta` options.

The only reason this is called a preliminary approach is because we are setting the `onServer` key of the errorMap differently.

Previously, the error map for the form looked like so:
```ts
{
  onServer: "You need to be 12 years or older to sign up"
}
```

Now however, the onServer map is slightly different:
```ts
{
  onServer: { age: "You need to be 12 years or older to sign up" }
}
```

This causes some degree of inconsistency, which is why I would love some feedback on whether we can use some other property (or maybe create our own!) to manage the errors between fields and forms. This would not be a comprehensive property but just a map to sync them back and forth.

NextJS support has been pushed. Remix and Start coming soon.
Support for Array field types will also be done shortly.

Would love your feedback and comments on this approach before I proceed!