### PR TITLE
docs(svelte-form): add docs for svelte-form

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -75,6 +75,15 @@
               "to": "framework/lit/quick-start"
             }
           ]
+        },
+        {
+          "label": "svelte",
+          "children": [
+            {
+              "label": "Quick Start",
+              "to": "framework/svelte/quick-start"
+            }
+          ]
         }
       ]
     },
@@ -220,6 +229,31 @@
             {
               "label": "Arrays",
               "to": "framework/lit/guides/arrays"
+            }
+          ]
+        },
+        {
+          "label": "svelte",
+          "children": [
+            {
+              "label": "Basic Concepts",
+              "to": "framework/svelte/guides/basic-concepts"
+            },
+            {
+              "label": "Form Validation",
+              "to": "framework/svelte/guides/validation"
+            },
+            {
+              "label": "Async Initial Values",
+              "to": "framework/svelte/guides/async-initial-values"
+            },
+            {
+              "label": "Arrays",
+              "to": "framework/svelte/guides/arrays"
+            },
+            {
+              "label": "Linked Fields",
+              "to": "framework/svelte/guides/linked-fields"
             }
           ]
         }
@@ -556,6 +590,19 @@
             {
               "label": "UI Libraries",
               "to": "framework/lit/examples/ui-libraries"
+            }
+          ]
+        },
+        {
+          "label": "svelte",
+          "children": [
+            {
+              "label": "Simple",
+              "to": "framework/svelte/examples/simple"
+            },
+            {
+              "label": "Arrays",
+              "to": "framework/svelte/examples/array"
             }
           ]
         }

--- a/docs/framework/svelte/guides/arrays.md
+++ b/docs/framework/svelte/guides/arrays.md
@@ -1,0 +1,112 @@
+---
+id: arrays
+title: Arrays
+---
+
+TanStack Form supports arrays as values in a form, including sub-object values inside of an array.
+
+## Basic Usage
+
+To use an array, you can use `field.state.value` on an array value in conjunction
+with [`each blocks`](https://svelte.dev/docs/svelte/each):
+
+```svelte
+<script>
+  import { createForm } from '@tanstack/svelte-form'
+
+  const form = createForm(() => ({
+    defaultValues: {
+      people: [],
+    },
+  }))
+</script>
+
+<form.Field name="people" mode="array">
+  {#snippet children(field)}
+    {#each field.state.value as person, i}
+      <!-- ... -->
+    {/each}
+  {/snippet}
+</form.Field>
+```
+
+This will regenerate the list every time you run `pushValue` on `field`:
+
+```svelte
+<button onclick={() => field.pushValue({ name: '', age: 0 })} type="button">
+  Add person
+</button>
+```
+
+Finally, you can use a subfield like so:
+
+```svelte
+<form.Field name={`people[${i}].name`}>
+  {#snippet children(subField)}
+    <input
+      value={subField.state.value}
+      oninput={(e) => {
+        subField.handleChange(e.currentTarget.value)
+      }}
+    />
+  {/snippet}
+</form.Field>
+```
+
+## Full Example
+
+```svelte
+<script lang="ts">
+  import { createForm } from '@tanstack/svelte-form'
+
+  const form = createForm(() => ({
+    defaultValues: {
+      people: [] as Array<{ age: number; name: string }>,
+    },
+    onSubmit: ({ value }) => alert(JSON.stringify(value)),
+  }))
+</script>
+
+<form
+  id="form"
+  onsubmit={(e) => {
+    e.preventDefault()
+    e.stopPropagation()
+    form.handleSubmit()
+  }}
+>
+  <form.Field name="people">
+    {#snippet children(field)}
+      <div>
+        {#each field.state.value as person, i}
+          <form.Field name={`people[${i}].name`}>
+            {#snippet children(subField)}
+              <div>
+                <label>
+                  <div>Name for person {i}</div>
+                  <input
+                    value={person.name}
+                    oninput={(e: Event) => {
+                      const target = e.target as HTMLInputElement
+                      subField.handleChange(target.value)
+                    }}
+                  />
+                </label>
+              </div>
+            {/snippet}
+          </form.Field>
+        {/each}
+
+        <button
+          onclick={() => field.pushValue({ name: '', age: 0 })}
+          type="button"
+        >
+          Add person
+        </button>
+      </div>
+    {/snippet}
+  </form.Field>
+
+  <button type="submit"> Submit </button>
+</form>
+```

--- a/docs/framework/svelte/guides/async-initial-values.md
+++ b/docs/framework/svelte/guides/async-initial-values.md
@@ -1,0 +1,51 @@
+---
+id: async-initial-values
+title: Async Initial Values
+---
+
+Let's say that you want to fetch some data from an API and use it as the initial value of a form.
+
+While this problem sounds simple on the surface, there are hidden complexities you might not have thought of thus far.
+
+For example, you might want to show a loading spinner while the data is being fetched, or you might want to handle errors gracefully.
+Likewise, you could also find yourself looking for a way to cache the data so that you don't have to fetch it every time the form is rendered.
+
+While we could implement many of these features from scratch, it would end up looking a lot like another project we maintain: [TanStack Query](https://tanstack.com/query).
+
+As such, this guide shows you how you can mix-n-match TanStack Form with TanStack Query to achieve the desired behavior.
+
+## Basic Usage
+
+```svelte
+<script>
+  import { createForm } from '@tanstack/svelte-form'
+  import { createQuery } from '@tanstack/svelte-query'
+
+    const { data, isLoading } = createQuery(() => ({
+      queryKey: ['data'],
+      queryFn: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+        return { firstName: 'FirstName', lastName: 'LastName' }
+      },
+    }))
+
+    const form = createForm(() => ({
+      defaultValues: {
+        firstName: $data?.firstName ?? '',
+        lastName: $data?.lastName ?? '',
+      },
+      onSubmit: async ({ value }) => {
+        // Do something with form data
+        console.log(value)
+      },
+    }))
+</script>
+
+{#if $isLoading}
+  <p>Loading...</p>
+{:else}
+  <!-- form... -->
+{/if}
+```
+
+This will show a loading spinner until the data is fetched, and then it will render the form with the fetched data as the initial values.

--- a/docs/framework/svelte/guides/basic-concepts.md
+++ b/docs/framework/svelte/guides/basic-concepts.md
@@ -1,0 +1,288 @@
+---
+id: basic-concepts
+title: Basic Concepts and Terminology
+---
+
+This page introduces the basic concepts and terminology used in the `@tanstack/svelte-form` library. Familiarizing yourself with these concepts will help you better understand and work with the library.
+
+## Form Options
+
+You can create options for your form so that it can be shared between multiple forms by using the `formOptions` function.
+
+Example:
+
+```ts
+const formOpts = formOptions({
+  defaultValues: {
+    firstName: '',
+    lastName: '',
+    hobbies: [],
+  } as Person,
+})
+```
+
+## Form Instance
+
+A Form Instance is an object that represents an individual form and provides methods and properties for working with the form. You create a form instance using the `createForm` function. The function accepts an object with an `onSubmit` function, which is called when the form is submitted.
+
+```ts
+const form = createForm(() => ({
+  ...formOpts,
+  onSubmit: async ({ value }) => {
+    // Do something with form data
+    console.log(value)
+  },
+}))
+```
+
+You may also create a form instance without using `formOptions`:
+
+```ts
+const form = createForm<Person>(() => ({
+  onSubmit: async ({ value }) => {
+    // Do something with form data
+    console.log(value)
+  },
+  defaultValues: {
+    firstName: '',
+    lastName: '',
+    hobbies: [],
+  },
+}))
+```
+
+## Field
+
+A Field represents a single form input element, such as a text input or a checkbox. Fields are created using the `form.Field` component provided by the form instance. The component accepts a name prop, which should match a key in the form's default values. It also accepts a children prop, which is a render prop function that takes a field object as its argument.
+
+Example:
+
+```svelte
+<form.Field name="firstName">
+  {#snippet children(field)}
+    <input
+      name={field.name}
+      value={field.state.value}
+      onblur={field.handleBlur}
+      oninput={(e) => field.handleChange(e.target.value)}
+    />
+  {/snippet}
+</form.Field>
+```
+
+## Field State
+
+Each field has its own state, which includes its current value, validation status, error messages, and other metadata. You can access a field's state using the `field.state` property.
+
+Example:
+
+```ts
+const {
+  value,
+  meta: { errors, isValidating },
+} = field.state
+```
+
+There are three field states can be very useful to see how the user interacts with a field. A field is _"touched"_ when the user clicks/tabs into it, _"pristine"_ until the user changes value in it, and _"dirty"_ after the value has been changed. You can check these states via the `isTouched`, `isPristine` and `isDirty` flags, as seen below.
+
+```ts
+const { isTouched, isPristine, isDirty } = field.state.meta
+```
+
+![Field states](https://raw.githubusercontent.com/TanStack/form/main/docs/assets/field-states.png)
+
+## Field API
+
+The Field API is an object passed to the render prop function when creating a field. It provides methods for working with the field's state.
+
+Example:
+
+```svelte
+<input
+  name={field.name}
+  value={field.state.value}
+  onblur={field.handleBlur}
+  oninput={(e) => field.handleChange(e.target.value)}
+/>
+```
+
+## Validation
+
+`@tanstack/svelte-form` provides both synchronous and asynchronous validation out of the box. Validation functions can be passed to the `form.Field` component using the `validators` prop.
+
+Example:
+
+```svelte
+<form.Field
+  name="firstName"
+  validators={{
+    onChange: ({ value }) =>
+      !value
+        ? 'A first name is required'
+        : value.length < 3
+          ? 'First name must be at least 3 characters'
+          : undefined,
+    onChangeAsync: async ({ value }) => {
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      return value.includes('error') && 'No "error" allowed in first name'
+    },
+  }}
+>
+  {#snippet children(field)}
+    <input
+      name={field.name}
+      value={field.state.value}
+      onBlur={field.handleBlur}
+      onInput={(e) => field.handleChange(e.target.value)}
+    />
+    <p>{field.state.meta.errors[0]}</p>
+  {/snippet}
+</form.Field>
+```
+
+## Validation with Standard Schema Libraries
+
+In addition to hand-rolled validation options, we also support the [Standard Schema](https://github.com/standard-schema/standard-schema) specification.
+
+You can define a schema using any of the libraries implementing the specification and pass it to a form or field validator.
+
+Supported libraries include:
+
+- [Zod](https://zod.dev/)
+- [Valibot](https://valibot.dev/)
+- [ArkType](https://arktype.io/)
+
+```svelte
+<script>
+  import { z } from 'zod'
+
+  // ...
+</script>
+
+<form.Field
+  name="firstName"
+  validators={{
+    onChange: z.string().min(3, 'First name must be at least 3 characters'),
+    onChangeAsyncDebounceMs: 500,
+    onChangeAsync: z.string().refine(
+      async (value) => {
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+        return !value.includes('error')
+      },
+      {
+        message: 'No "error" allowed in first name',
+      },
+    ),
+  }}
+>
+  {#snippet children(field)}
+    <input
+      name={field.name}
+      value={field.state.value}
+      onBlur={field.handleBlur}
+      onInput={(e) => field.handleChange(e.target.value)}
+    />
+    <p>{field.state.meta.errors[0]}</p>
+  {/snippet}
+</form.Field>
+```
+
+## Reactivity
+
+`@tanstack/svelte-form` offers various ways to subscribe to form and field state changes, most notably the `form.useStore` hook and the `form.Subscribe` component. These methods allow you to optimize your form's rendering performance by only updating components when necessary.
+
+Example:
+
+```svelte
+<script>
+  //...
+  const firstName = form.useStore((state) => state.values.firstName)
+</script>
+
+<form.Subscribe
+  selector={(state) => ({
+    canSubmit: state.canSubmit,
+    isSubmitting: state.isSubmitting,
+  })}
+>
+  {#snippet children(state)}
+    <button type="submit" disabled={!state.canSubmit}>
+      {state.isSubmitting ? '...' : 'Submit'}
+    </button>
+  {/snippet}
+</form.Subscribe>
+```
+
+## Array Fields
+
+Array fields allow you to manage a list of values within a form, such as a list of hobbies. You can create an array field using the `form.Field` component with the `mode="array"` prop.
+
+When working with array fields, you can use the fields `pushValue`, `removeValue`, `swapValues` and `moveValue` methods to add, remove, and swap values in the array.
+
+Example:
+
+```svelte
+<form.Field name="hobbies" mode="array">
+  {#snippet children(hobbiesField)}
+    <div>
+      Hobbies
+      <div>
+        {#each hobbiesField.state.value as _, i}
+            <div>
+              <form.Field name={`hobbies[${i}].name`}>
+                {#snippet children(field)}
+                  <div>
+                    <label for={field.name}>Name:</label>
+                    <input
+                      id={field.name}
+                      name={field.name}
+                      value={field.state.value}
+                      onblur={field.handleBlur}
+                      onchange={(e) => field.handleChange(e.target.value)}
+                    />
+                    <button
+                      type="button"
+                      onclick={() => hobbiesField.removeValue(i)}
+                    >
+                      X
+                    </button>
+                  </div>
+                {/snippet}
+              </form.Field>
+              <form.Field name={`hobbies[${i}].description`}>
+                {#snippet children(field)}
+                    <div>
+                      <label for={field.name}>Description:</label>
+                      <input
+                        id={field.name}
+                        name={field.name}
+                        value={field.state.value}
+                        onblur={field.handleBlur}
+                        onchange={(e) => field.handleChange(e.target.value)}
+                      />
+                    </div>
+                {/snippet}
+              </form.Field>
+            </div>
+          {:else}
+            No hobbies found.
+          {/each}
+      </div>
+      <button
+        type="button"
+        onclick={() =>
+          hobbiesField.pushValue({
+            name: '',
+            description: '',
+            yearsOfExperience: 0,
+          })
+        }
+      >
+        Add hobby
+      </button>
+    </div>
+  {/snippet}
+</form.Field>
+```
+
+These are the basic concepts and terminology used in the `@tanstack/svelte-form` library. Understanding these concepts will help you work more effectively with the library and create complex forms with ease.

--- a/docs/framework/svelte/guides/linked-fields.md
+++ b/docs/framework/svelte/guides/linked-fields.md
@@ -1,0 +1,77 @@
+---
+id: linked-fields
+title: Link Two Form Fields Together
+---
+
+You may find yourself needing to link two fields together; when one is validated as another field's value has changed.
+One such usage is when you have both a `password` and `confirm_password` field,
+where you want to `confirm_password` to error out when `password`'s value does not match;
+regardless of which field triggered the value change.
+
+Imagine the following userflow:
+
+- User updates confirm password field.
+- User updates the non-confirm password field.
+
+In this example, the form will still have errors present,
+as the "confirm password" field validation has not been re-ran to mark as accepted.
+
+To solve this, we need to make sure that the "confirm password" validation is re-run when the password field is updated.
+To do this, you can add a `onChangeListenTo` property to the `confirm_password` field.
+
+```svelte
+<script>
+  import { createForm } from '@tanstack/svelte-form'
+
+  const form = createForm(() => ({
+    defaultValues: {
+      password: '',
+      confirm_password: '',
+    },
+    // ...
+  }))
+</script>
+
+<div>
+  <form.Field name="password">
+    {#snippet children(field)}
+      <label>
+        <div>Password</div>
+        <input
+          value={field.state.value}
+          onChange={(e) => field.handleChange(e.target.value)}
+        />
+      </label>
+    {/snippet}
+  </form.Field>
+  <form.Field
+    name="confirm_password"
+    validators={{
+      onChangeListenTo: ['password'],
+      onChange: ({ value, fieldApi }) => {
+        if (value !== fieldApi.form.getFieldValue('password')) {
+          return 'Passwords do not match'
+        }
+        return undefined
+      },
+    }}
+  >
+    {#snippet children(field)}
+      <div>
+        <label>
+          <div>Confirm Password</div>
+          <input
+            value={field.state.value}
+            onchange={(e) => field.handleChange(e.target.value)}
+          />
+        </label>
+        {#each field.state.meta.errors as err}
+          <div>{err}</div>
+        {/each}
+      </div>
+    {/snippet}
+  </form.Field>
+</div>
+```
+
+This similarly works with `onBlurListenTo` property, which will re-run the validation when the field is blurred.

--- a/docs/framework/svelte/guides/validation.md
+++ b/docs/framework/svelte/guides/validation.md
@@ -1,0 +1,406 @@
+---
+id: form-validation
+title: Form and Field Validation
+---
+
+At the core of TanStack Form's functionalities is the concept of validation. TanStack Form makes validation highly customizable:
+
+- You can control when to perform the validation (on change, on input, on blur, on submit...)
+- Validation rules can be defined at the field level or at the form level
+- Validation can be synchronous or asynchronous (for example, as a result of an API call)
+
+## When is validation performed?
+
+It's up to you! The `<form.Field />` component accepts some callbacks as props such as `onChange` or `onBlur`. Those callbacks are passed the current value of the field, as well as the fieldAPI object, so that you can perform the validation. If you find a validation error, simply return the error message as string and it will be available in `field.state.meta.errors`.
+
+Here is an example:
+
+```svelte
+<form.Field
+  name="age"
+  validators={{
+    onChange: ({ value }) =>
+      value < 13 ? 'You must be 13 to make an account' : undefined,
+  }}
+>
+  {#snippet children(field)}
+    <label for={field.name}>Age:</label>
+    <input
+      id={field.name}
+      name={field.name}
+      value={field.state.value}
+      type="number"
+      onchange={(e) => field.handleChange(e.target.valueAsNumber)}
+    />
+    {#if field.state.meta.errors}
+      <em role="alert">{field.state.meta.errors.join(', ')}</em>
+    {/if}
+  {/snippet}
+</form.Field>
+```
+
+In the example above, the validation is done at each keystroke (`onchange`). If, instead, we wanted the validation to be done when the field is blurred, we would change the code above like so:
+
+```svelte
+<form.Field
+  name="age"
+  validators={{
+    onBlur: ({ value }) =>
+      value < 13 ? 'You must be 13 to make an account' : undefined,
+  }}
+>
+  {#snippet children(field)}
+    <label for={field.name}>Age:</label>
+    <input
+      id={field.name}
+      name={field.name}
+      value={field.state.value}
+      type="number"
+      onblur={field.handleBlur}
+      onchange={(e) => field.handleChange(e.target.valueAsNumber)}
+    />
+    {#if field.state.meta.errors}
+      <em role="alert">{field.state.meta.errors.join(', ')}</em>
+    {/if}
+  {/snippet}
+</form.Field>
+```
+
+So you can control when the validation is done by implementing the desired callback. You can even perform different pieces of validation at different times:
+
+```svelte
+<form.Field
+  name="age"
+  validators={{
+    onChange: ({ value }) =>
+      value < 13 ? 'You must be 13 to make an account' : undefined,
+    onBlur: ({ value }) => (value < 0 ? 'Invalid value' : undefined),
+  }}
+>
+  {#snippet children(field)}
+    <label for={field.name}>Age:</label>
+    <input
+      id={field.name}
+      name={field.name}
+      value={field.state.value}
+      type="number"
+      onblur={field.handleBlur}
+      onchange={(e) => field.handleChange(e.target.valueAsNumber)}
+    />
+    {#if field.state.meta.errors}
+      <em role="alert">{field.state.meta.errors.join(', ')}</em>
+    {/if}
+  {/snippet}
+</form.Field>
+```
+
+In the example above, we are validating different things on the same field at different times (at each keystroke and when blurring the field). Since `field.state.meta.errors` is an array, all the relevant errors at a given time are displayed. You can also use `field.state.meta.errorMap` to get errors based on _when_ the validation was done (onChange, onBlur etc...). More info about displaying errors below.
+
+## Displaying Errors
+
+Once you have your validation in place, you can map the errors from an array to be displayed in your UI:
+
+```svelte
+<form.Field
+  name="age"
+  validators={{
+    onChange: ({ value }) =>
+      value < 13 ? 'You must be 13 to make an account' : undefined,
+  }}
+>
+  {#snippet children(field)}
+    <!-- ... -->
+    {#if field.state.meta.errors}
+      <em role="alert">{field.state.meta.errors.join(', ')}</em>
+    {/if}
+  {/snippet}
+</form.Field>
+```
+
+Or use the `errorMap` property to access the specific error you're looking for:
+
+```svelte
+<form.Field
+  name="age"
+  validators={{
+    onChange: ({ value }) =>
+      value < 13 ? 'You must be 13 to make an account' : undefined,
+  }}
+>
+  {#snippet children(field)}
+    <!-- ... -->
+    {#if field.state.meta.errorMap['onChange']}
+      <em role="alert">{field.state.meta.errorMap['onChange']}</em>
+    {/if}
+  {/snippet}
+</form.Field>
+```
+
+It's worth mentioning that our `errors` array and the `errorMap` matches the types returned by the validators. This means that:
+
+```svelte
+<form.Field
+  name="age"
+  validators={{
+    onChange: ({ value }) => (value < 13 ? { isOldEnough: false } : undefined),
+  }}
+>
+  {#snippet children(field)}
+    <!-- ... -->
+    <!-- errorMap.onChange is type `{isOldEnough: false} | undefined` -->
+    <!-- meta.errors is type `Array<{isOldEnough: false} | undefined>` -->
+    {#if field.state.meta.errorMap['onChange']?.isOldEnough}
+        <em>The user is not old enough</em>
+    {/if}
+  {/snippet}
+</form.Field>
+```
+
+## Validation at field level vs at form level
+
+As shown above, each `<form.Field>` accepts its own validation rules via the `onChange`, `onBlur` etc... callbacks. It is also possible to define validation rules at the form level (as opposed to field by field) by passing similar callbacks to the `createForm()` hook.
+
+Example:
+
+```svelte
+<script>
+  import { createForm } from '@tanstack/svelte-form'
+
+  const form = createForm(() => ({
+    defaultValues: {
+      age: 0,
+    },
+    onSubmit: async ({ value }) => {
+      console.log(value)
+    },
+    validators: {
+      // Add validators to the form the same way you would add them to a field
+      onChange({ value }) {
+        if (value.age < 13) {
+          return 'Must be 13 or older to sign'
+        }
+        return undefined
+      },
+    },
+  }))
+
+  // Subscribe to the form's error map so that updates to it will render
+  // alternately, you can use `form.Subscribe`
+  const formErrorMap = form.useStore((state) => state.errorMap)
+</script>
+
+<div>
+  <!-- ... -->
+  {#if formErrorMap.current.onChange}
+    <div>
+      <em>There was an error on the form: {formErrorMap.current.onChange}</em>
+    </div>
+  {/if}
+  <!-- ... -->
+</div>
+```
+
+## Asynchronous Functional Validation
+
+While we suspect most validations will be synchronous, there are many instances where a network call or some other async operation would be useful to validate against.
+
+To do this, we have dedicated `onChangeAsync`, `onBlurAsync`, and other methods that can be used to validate against:
+
+```svelte
+<form.Field
+  name="age"
+  validators={{
+    onChangeAsync: async ({ value }) => {
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      return value < 13 ? 'You must be 13 to make an account' : undefined
+    },
+  }}
+>
+  {#snippet children(field)}
+    <label for={field.name}>Age:</label>
+    <input
+      id={field.name}
+      name={field.name}
+      value={field.state.value}
+      type="number"
+      onchange={(e) => field.handleChange(e.target.valueAsNumber)}
+    />
+    {#if field.state.meta.errors}
+      <em role="alert">{field.state.meta.errors.join(', ')}</em>
+    {/if}
+  {/snippet}
+</form.Field>
+```
+
+Synchronous and Asynchronous validations can coexist. For example, it is possible to define both `onBlur` and `onBlurAsync` on the same field:
+
+```svelte
+<form.Field
+  name="age"
+  validators={{
+    onBlur: ({ value }) => (value < 13 ? 'You must be at least 13' : undefined),
+    onBlurAsync: async ({ value }) => {
+      const currentAge = await fetchCurrentAgeOnProfile()
+      return value < currentAge ? 'You can only increase the age' : undefined
+    },
+  }}
+>
+  {#snippet children(field)}
+    <label for={field.name}>Age:</label>
+    <input
+      id={field.name}
+      name={field.name}
+      value={field.state.value}
+      type="number"
+      onblur={field.handleBlur}
+      onchange={(e) => field.handleChange(e.target.valueAsNumber)}
+    />
+    {#if field.state.meta.errors}
+      <em role="alert">{field.state.meta.errors.join(', ')}</em>
+    {/if}
+  {/snippet}
+</form.Field>
+```
+
+The synchronous validation method (`onBlur`) is run first and the asynchronous method (`onBlurAsync`) is only run if the synchronous one (`onBlur`) succeeds. To change this behaviour, set the `asyncAlways` option to `true`, and the async method will be run regardless of the result of the sync method.
+
+### Built-in Debouncing
+
+While async calls are the way to go when validating against the database, running a network request on every keystroke is a good way to DDOS your database.
+
+Instead, we enable an easy method for debouncing your `async` calls by adding a single property:
+
+```svelte
+<form.Field
+  name="age"
+  asyncDebounceMs={500}
+  validators={{
+    onChangeAsync: async ({ value }) => {
+      // ...
+    },
+  }}
+>
+  <!-- ... -->
+</form.Field>
+```
+
+This will debounce every async call with a 500ms delay. You can even override this property on a per-validation property:
+
+```svelte
+<form.Field
+  name="age"
+  asyncDebounceMs={500}
+  validators={{
+    onChangeAsyncDebounceMs: 1500,
+    onChangeAsync: async ({ value }) => {
+      // ...
+    },
+    onBlurAsync: async ({ value }) => {
+      // ...
+    },
+  }}
+>
+  <!-- ... -->
+</form.Field>
+```
+
+> This will run `onChangeAsync` every 1500ms while `onBlurAsync` will run every 500ms.
+
+## Validation through Schema Libraries
+
+While functions provide more flexibility and customization over your validation, they can be a bit verbose. To help solve this, there are libraries that provide schema-based validation to make shorthand and type-strict validation substantially easier. You can also define a single schema for your entire form and pass it to the form level, errors will be automatically propagated to the fields.
+
+### Standard Schema Libraries
+
+TanStack Form natively supports all libraries following the [Standard Schema specification](https://github.com/standard-schema/standard-schema), most notably:
+
+- [Zod](https://zod.dev/)
+- [Valibot](https://valibot.dev/)
+- [ArkType](https://arktype.io/)
+
+_Note:_ make sure to use the latest version of the schema libraries as older versions might not support Standard Schema yet.
+
+To use schemas from these libraries you can pass them to the `validators` props as you would do with a custom function:
+
+```svelte
+<script>
+  import { z } from 'zod'
+
+  // ...
+
+  const form = createForm(() => ({
+    // ...
+  }))
+</script>
+
+<form.Field
+  name="age"
+  validators={{
+    onChange: z.number().gte(13, 'You must be 13 to make an account'),
+  }}
+>
+  <!-- ... -->
+</form.Field>
+```
+
+Async validations on form and field level are supported as well:
+
+```svelte
+<form.Field
+  name="age"
+  validators={{
+    onChange: z.number().gte(13, 'You must be 13 to make an account'),
+    onChangeAsyncDebounceMs: 500,
+    onChangeAsync: z.number().refine(
+      async (value) => {
+        const currentAge = await fetchCurrentAgeOnProfile()
+        return value >= currentAge
+      },
+      {
+        message: 'You can only increase the age',
+      },
+    ),
+  }}
+>
+  <!-- ... -->
+</form.Field>
+```
+
+## Preventing invalid forms from being submitted
+
+The `onChange`, `onBlur` etc... callbacks are also run when the form is submitted and the submission is blocked if the form is invalid.
+
+The form state object has a `canSubmit` flag that is false when any field is invalid and the form has been touched (`canSubmit` is true until the form has been touched, even if some fields are "technically" invalid based on their `onChange`/`onBlur` props).
+
+You can subscribe to it via `form.Subscribe` and use the value in order to, for example, disable the submit button when the form is invalid (in practice, disabled buttons are not accessible, use `aria-disabled` instead).
+
+```svelte
+<script>
+  import { createForm } from '@tanstack/svelte-form'
+
+  const form = createForm(() => ({
+    /* ... */
+  }))
+</script>
+
+<!-- ... -->
+
+<!-- Dynamic submit button -->
+<form.Subscribe
+  selector={(state) => ({
+    canSubmit: state.canSubmit,
+    isSubmitting: state.isSubmitting,
+  })}
+  children={(state) => (
+    <button type="submit" disabled={!state().canSubmit}>
+      {state().isSubmitting ? '...' : 'Submit'}
+    </button>
+  )}
+>
+  {#snippet children(state)}
+    <button type="submit" disabled={!state.canSubmit}>
+      {state.isSubmitting ? '...' : 'Submit'}
+    </button>
+  {/snippet}
+</form.Subscribe>
+```

--- a/docs/framework/svelte/quick-start.md
+++ b/docs/framework/svelte/quick-start.md
@@ -1,0 +1,49 @@
+---
+id: quick-start
+title: Quick Start
+---
+
+The bare minimum to get started with TanStack Form is to create a form and add a field. Keep in mind that this example does not include any validation or error handling... yet.
+
+```svelte
+<script>
+  import { createForm } from '@tanstack/svelte-form'
+
+  const form = createForm(() => ({
+    defaultValues: {
+      fullName: '',
+    },
+    onSubmit: async ({ value }) => {
+      // Do something with form data
+      console.log(value)
+    },
+  }))
+</script>
+
+<div>
+  <h1>Simple Form Example</h1>
+  <form
+    onsubmit={(e) => {
+      e.preventDefault()
+      e.stopPropagation()
+      form.handleSubmit()
+    }}
+  >
+    <div>
+      <form.Field name="fullName">
+        {#snippet children(field)}
+          <input
+            name={field.name}
+            value={field.state.value}
+            onblur={field.handleBlur}
+            oninput={(e) => field.handleChange(e.target.value)}
+          />
+        {/snippet}
+      </form.Field>
+    </div>
+    <button type="submit">Submit</button>
+  </form>
+</div>
+```
+
+From here, you'll be ready to explore all of the other features of TanStack Form!

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,4 +70,17 @@ $ bun add @tanstack/lit-form
 $ yarn add @tanstack/lit-form
 ```
 
+### Svelte Example
+
+```bash
+# npm
+$ npm i @tanstack/svelte-form
+# pnpm
+$ pnpm add @tanstack/svelte-form
+# bun
+$ bun add @tanstack/svelte-form
+# yarn
+$ yarn add @tanstack/svelte-form
+```
+
 > Depending on your environment, you might need to add polyfills. If you want to support older browsers, you need to transpile the library from `node_modules` yourselves.


### PR DESCRIPTION
without reference docs for now because they can't be generated, as the generator doesn't know how to deal with Svelte imports