### PR TITLE
tests: replace assertType with expectTypeOf

### DIFF
--- a/packages/form-core/tests/FieldApi.test-d.ts
+++ b/packages/form-core/tests/FieldApi.test-d.ts
@@ -1,4 +1,4 @@
-import { assertType, describe, it } from 'vitest'
+import { expectTypeOf, it } from 'vitest'
 import { z } from 'zod'
 import { FieldApi, FormApi } from '../src/index'
 import type { StandardSchemaV1Issue } from '../src/index'
@@ -15,9 +15,9 @@ it('should type value properly', () => {
     name: 'name',
   })
 
-  assertType<'test'>(field.state.value)
-  assertType<'name'>(field.options.name)
-  assertType<'test'>(field.getValue())
+  expectTypeOf(field.state.value).toEqualTypeOf<'test'>()
+  expectTypeOf(field.options.name).toEqualTypeOf<'name'>()
+  expectTypeOf(field.getValue()).toEqualTypeOf<'test'>()
 })
 
 it('should type value when nothing is passed into constructor', () => {
@@ -33,9 +33,9 @@ it('should type value when nothing is passed into constructor', () => {
     name: 'name' as const,
   })
 
-  assertType<string | undefined>(field.state.value)
-  assertType<'name'>(field.options.name)
-  assertType<string | undefined>(field.getValue())
+  expectTypeOf(field.state.value).toEqualTypeOf<string | undefined>()
+  expectTypeOf(field.options.name).toEqualTypeOf<'name'>()
+  expectTypeOf(field.getValue()).toEqualTypeOf<string | undefined>()
 })
 
 it('should type required fields in constructor', () => {
@@ -55,9 +55,9 @@ it('should type required fields in constructor', () => {
     name: 'name' as const,
   })
 
-  assertType<string>(field.state.value)
-  assertType<'name' | 'age'>(field.options.name)
-  assertType<string>(field.getValue())
+  expectTypeOf(field.state.value).toEqualTypeOf<string>()
+  expectTypeOf(field.options.name).toEqualTypeOf<'name'>()
+  expectTypeOf(field.getValue()).toEqualTypeOf<string>()
 })
 
 it('should type value properly for completely partial forms', () => {
@@ -75,9 +75,9 @@ it('should type value properly for completely partial forms', () => {
     name: 'name' as const,
   })
 
-  assertType<'test' | undefined>(field.state.value)
-  assertType<'name' | 'age'>(field.options.name)
-  assertType<'test' | undefined>(field.getValue())
+  expectTypeOf(field.state.value).toEqualTypeOf<'test' | undefined>()
+  expectTypeOf(field.options.name).toEqualTypeOf<'name'>()
+  expectTypeOf(field.getValue()).toEqualTypeOf<'test' | undefined>()
 })
 
 it('should type onChange properly', () => {
@@ -92,7 +92,7 @@ it('should type onChange properly', () => {
     name: 'name',
     validators: {
       onChange: ({ value }) => {
-        assertType<'test'>(value)
+        expectTypeOf(value).toEqualTypeOf<'test'>()
 
         return undefined
       },
@@ -112,7 +112,7 @@ it('should type onChangeAsync properly', () => {
     name: 'name',
     validators: {
       onChangeAsync: async ({ value }) => {
-        assertType<'test'>(value)
+        expectTypeOf(value).toEqualTypeOf<'test'>()
 
         return undefined
       },
@@ -139,14 +139,14 @@ it('should type an array sub-field properly', () => {
     name: `nested.people[1].name`,
     validators: {
       onChangeAsync: async ({ value }) => {
-        assertType<string>(value)
+        expectTypeOf(value).toEqualTypeOf<string>()
 
         return undefined
       },
     },
   })
 
-  assertType<string>(field.state.value)
+  expectTypeOf(field.state.value).toEqualTypeOf<string>()
 })
 
 it('should have the correct types returned from form validators', () => {
@@ -161,7 +161,7 @@ it('should have the correct types returned from form validators', () => {
     },
   } as const)
 
-  assertType<'123' | undefined>(form.state.errorMap.onChange)
+  expectTypeOf(form.state.errorMap.onChange).toEqualTypeOf<'123' | undefined>()
 })
 
 it('should have the correct types returned from form validators even when both onChange and onChangeAsync are present', () => {
@@ -179,7 +179,7 @@ it('should have the correct types returned from form validators even when both o
     },
   } as const)
 
-  assertType<'123' | undefined>(form.state.errorMap.onChange)
+  expectTypeOf(form.state.errorMap.onChange).toEqualTypeOf<'123' | undefined>()
 })
 
 it('should have the correct types returned from field validators', () => {
@@ -199,7 +199,9 @@ it('should have the correct types returned from field validators', () => {
     },
   })
 
-  assertType<'123' | undefined>(field.state.meta.errorMap.onChange)
+  expectTypeOf(field.state.meta.errorMap.onChange).toEqualTypeOf<
+    '123' | undefined
+  >()
 })
 
 it('should have the correct types returned from field validators in array', () => {
@@ -219,7 +221,9 @@ it('should have the correct types returned from field validators in array', () =
     },
   })
 
-  assertType<Array<'123' | undefined>>(field.state.meta.errors)
+  expectTypeOf(field.state.meta.errors).toEqualTypeOf<
+    Array<'123' | undefined>
+  >()
 })
 
 it('should have the correct types returned from form validators in array', () => {
@@ -234,7 +238,7 @@ it('should have the correct types returned from form validators in array', () =>
     },
   } as const)
 
-  assertType<Array<'123' | undefined>>(form.state.errors)
+  expectTypeOf(form.state.errors).toEqualTypeOf<Array<'123' | undefined>>()
 })
 
 it('should handle "fields" return types added to the field\'s errorMap itself', () => {
@@ -258,7 +262,9 @@ it('should handle "fields" return types added to the field\'s errorMap itself', 
     name: 'firstName',
   })
 
-  assertType<'Testing' | undefined>(field.getMeta().errorMap.onChange)
+  expectTypeOf(field.getMeta().errorMap.onChange).toEqualTypeOf<
+    'Testing' | undefined
+  >()
 })
 
 it('should handle "fields" return types added to the field\'s error array itself', () => {
@@ -282,7 +288,9 @@ it('should handle "fields" return types added to the field\'s error array itself
     name: 'firstName',
   })
 
-  assertType<Array<'Testing' | undefined>>(field.getMeta().errors)
+  expectTypeOf(field.getMeta().errors).toEqualTypeOf<
+    Array<'Testing' | undefined>
+  >()
 })
 
 it('should handle "fields" async return types added to the field\'s errorMap itself', () => {
@@ -306,7 +314,9 @@ it('should handle "fields" async return types added to the field\'s errorMap its
     name: 'firstName',
   })
 
-  assertType<'Testing' | undefined>(field.getMeta().errorMap.onChange)
+  expectTypeOf(field.getMeta().errorMap.onChange).toEqualTypeOf<
+    'Testing' | undefined
+  >()
 })
 
 it('should handle "fields" async return types added to the field\'s error array itself', () => {
@@ -330,7 +340,9 @@ it('should handle "fields" async return types added to the field\'s error array 
     name: 'firstName',
   })
 
-  assertType<Array<'Testing' | undefined>>(field.getMeta().errors)
+  expectTypeOf(field.getMeta().errors).toEqualTypeOf<
+    Array<'Testing' | undefined>
+  >()
 })
 
 it('should handle "sub-fields" async return types added to the field\'s error array itself', () => {
@@ -356,7 +368,9 @@ it('should handle "sub-fields" async return types added to the field\'s error ar
     name: 'person.firstName',
   })
 
-  assertType<Array<'Testing' | undefined>>(field.getMeta().errors)
+  expectTypeOf(field.getMeta().errors).toEqualTypeOf<
+    Array<'Testing' | undefined>
+  >()
 })
 
 it('should only have field-level error types returned from parseValueWithSchema and parseValueWithSchemaAsync', () => {
@@ -373,10 +387,10 @@ it('should only have field-level error types returned from parseValueWithSchema 
 
   const schema = z.string()
   // assert that it doesn't think it's a form-level error
-  assertType<StandardSchemaV1Issue[] | undefined>(
-    field.parseValueWithSchema(schema),
-  )
-  assertType<Promise<StandardSchemaV1Issue[] | undefined>>(
-    field.parseValueWithSchemaAsync(schema),
-  )
+  expectTypeOf(field.parseValueWithSchema(schema)).toEqualTypeOf<
+    StandardSchemaV1Issue[] | undefined
+  >()
+  expectTypeOf(field.parseValueWithSchemaAsync(schema)).toEqualTypeOf<
+    Promise<StandardSchemaV1Issue[] | undefined>
+  >()
 })

--- a/packages/form-core/tests/FormApi.test-d.ts
+++ b/packages/form-core/tests/FormApi.test-d.ts
@@ -1,4 +1,4 @@
-import { assertType, it } from 'vitest'
+import { expectTypeOf, it } from 'vitest'
 import { z } from 'zod'
 import { FormApi } from '../src'
 import type {
@@ -28,15 +28,15 @@ it('should return all errors matching the right type from getAllErrors', () => {
 
   errors.form.errorMap.onChange
 
-  assertType<{
+  expectTypeOf(errors.form.errorMap).toEqualTypeOf<{
     onBlur?: { onBlur: true; onBlurNumber: number } | 'onBlurAsync'
     onChange?: readonly ['onChange'] | 'onChangeAsync'
     onMount?: 10
     onSubmit?: 'onSubmit' | 'onSubmitAsync'
     onServer?: undefined
-  }>(errors.form.errorMap)
+  }>()
 
-  assertType<
+  expectTypeOf(errors.form.errors).toEqualTypeOf<
     (
       | readonly ['onChange']
       | 'onChangeAsync'
@@ -47,9 +47,9 @@ it('should return all errors matching the right type from getAllErrors', () => {
       | 'onBlurAsync'
       | undefined
     )[]
-  >(errors.form.errors)
+  >()
 
-  assertType<{
+  expectTypeOf(errors.fields).toEqualTypeOf<{
     firstName: {
       errors: ValidationError[]
       errorMap: ValidationErrorMap
@@ -58,7 +58,7 @@ it('should return all errors matching the right type from getAllErrors', () => {
       errors: ValidationError[]
       errorMap: ValidationErrorMap
     }
-  }>(errors.fields)
+  }>()
 })
 
 it('should type handleSubmit as never when onSubmitMeta is not passed', () => {
@@ -68,7 +68,10 @@ it('should type handleSubmit as never when onSubmitMeta is not passed', () => {
     },
   } as const)
 
-  assertType<() => Promise<void>>(form.handleSubmit)
+  expectTypeOf(form.handleSubmit).toEqualTypeOf<{
+    (): Promise<void>
+    (submitMeta: never): Promise<void>
+  }>()
 })
 
 type OnSubmitMeta = {
@@ -85,9 +88,10 @@ it('should type handleChange correctly', () => {
 
   form.handleSubmit({ group: 'track' })
 
-  assertType<(submitMeta: { group: string }) => Promise<void>>(
-    form.handleSubmit,
-  )
+  expectTypeOf(form.handleSubmit).toEqualTypeOf<{
+    (): Promise<void>
+    (submitMeta: OnSubmitMeta): Promise<void>
+  }>()
 })
 
 type FormLevelStandardSchemaIssue = {
@@ -105,10 +109,10 @@ it('should only have form-level error types returned from parseFieldValuesWithSc
     name: z.string(),
   })
   // assert that it doesn't think it's a field-level error
-  assertType<FormLevelStandardSchemaIssue | undefined>(
-    form.parseValuesWithSchema(schema),
-  )
-  assertType<Promise<FormLevelStandardSchemaIssue | undefined>>(
-    form.parseValuesWithSchemaAsync(schema),
-  )
+  expectTypeOf(form.parseValuesWithSchema(schema)).toEqualTypeOf<
+    FormLevelStandardSchemaIssue | undefined
+  >()
+  expectTypeOf(form.parseValuesWithSchemaAsync(schema)).toEqualTypeOf<
+    Promise<FormLevelStandardSchemaIssue | undefined>
+  >()
 })

--- a/packages/form-core/tests/formOptions.test-d.ts
+++ b/packages/form-core/tests/formOptions.test-d.ts
@@ -1,4 +1,4 @@
-import { assertType, describe, expect, it } from 'vitest'
+import { describe, expectTypeOf, it } from 'vitest'
 import { FormApi, formOptions } from '../src/index'
 
 describe('formOptions', () => {
@@ -19,7 +19,7 @@ describe('formOptions', () => {
       ...formOpts,
     })
 
-    assertType<Person>(form.state.values)
+    expectTypeOf(form.state.values).toEqualTypeOf<Person>()
   })
 
   it('types should be properly inferred when passing args alongside formOptions', () => {
@@ -42,9 +42,10 @@ describe('formOptions', () => {
       },
     })
 
-    assertType<(submitMeta: { test: string }) => Promise<void>>(
-      form.handleSubmit,
-    )
+    expectTypeOf(form.handleSubmit).toEqualTypeOf<{
+      (): Promise<void>
+      (submitMeta: { test: string }): Promise<void>
+    }>()
   })
 
   it('types should be properly inferred when formOptions are being overridden', () => {
@@ -73,6 +74,6 @@ describe('formOptions', () => {
       },
     })
 
-    assertType<PersonWithAge>(form.state.values)
+    expectTypeOf(form.state.values).toExtend<PersonWithAge>()
   })
 })

--- a/packages/form-core/tests/standardSchemaValidator.test-d.ts
+++ b/packages/form-core/tests/standardSchemaValidator.test-d.ts
@@ -1,4 +1,4 @@
-import { assertType, describe, it } from 'vitest'
+import { describe, expectTypeOf, it } from 'vitest'
 import { z } from 'zod'
 import { FieldApi, FormApi, standardSchemaValidators } from '../src/index'
 import type { StandardSchemaV1Issue } from '../src/index'
@@ -23,9 +23,9 @@ describe('standard schema validator', () => {
       name: 'firstName',
     })
 
-    assertType<undefined | StandardSchemaV1Issue[]>(
-      field.getMeta().errorMap.onChange,
-    )
+    expectTypeOf(field.getMeta().errorMap.onChange).toEqualTypeOf<
+      undefined | StandardSchemaV1Issue[]
+    >()
   })
 
   it("Should add sub-field's onChange errorMap from the form", () => {
@@ -52,9 +52,9 @@ describe('standard schema validator', () => {
       name: 'person.firstName',
     })
 
-    assertType<undefined | StandardSchemaV1Issue[]>(
-      field.getMeta().errorMap.onChange,
-    )
+    expectTypeOf(field.getMeta().errorMap.onChange).toEqualTypeOf<
+      undefined | StandardSchemaV1Issue[]
+    >()
   })
 
   type FormLevelStandardSchemaIssue = {
@@ -72,8 +72,12 @@ describe('standard schema validator', () => {
       z.string(),
     )
 
-    assertType<FormLevelStandardSchemaIssue | undefined>(formSourceError)
-    assertType<StandardSchemaV1Issue[] | undefined>(fieldSourceError)
+    expectTypeOf(formSourceError).toEqualTypeOf<
+      FormLevelStandardSchemaIssue | undefined
+    >()
+    expectTypeOf(fieldSourceError).toEqualTypeOf<
+      StandardSchemaV1Issue[] | undefined
+    >()
   })
 
   it('Should return different Standard Schema Issue types from validateAsync based on scope', () => {
@@ -86,9 +90,11 @@ describe('standard schema validator', () => {
       z.string(),
     )
 
-    assertType<Promise<FormLevelStandardSchemaIssue | undefined>>(
+    expectTypeOf<Promise<FormLevelStandardSchemaIssue | undefined>>(
       formSourceError,
     )
-    assertType<Promise<StandardSchemaV1Issue[] | undefined>>(fieldSourceError)
+    expectTypeOf(fieldSourceError).toEqualTypeOf<
+      Promise<StandardSchemaV1Issue[] | undefined>
+    >()
   })
 })

--- a/packages/form-core/tests/standardSchemaValidator.test-d.ts
+++ b/packages/form-core/tests/standardSchemaValidator.test-d.ts
@@ -90,9 +90,9 @@ describe('standard schema validator', () => {
       z.string(),
     )
 
-    expectTypeOf<Promise<FormLevelStandardSchemaIssue | undefined>>(
-      formSourceError,
-    )
+    expectTypeOf(formSourceError).toEqualTypeOf<
+      Promise<FormLevelStandardSchemaIssue | undefined>
+    >()
     expectTypeOf(fieldSourceError).toEqualTypeOf<
       Promise<StandardSchemaV1Issue[] | undefined>
     >()

--- a/packages/react-form/tests/createFormHook.test-d.tsx
+++ b/packages/react-form/tests/createFormHook.test-d.tsx
@@ -1,4 +1,4 @@
-import { assertType, describe, expect, it } from 'vitest'
+import { describe, expectTypeOf, it } from 'vitest'
 import { render } from '@testing-library/react'
 import { formOptions } from '@tanstack/form-core'
 import { createFormHook, createFormHookContexts } from '../src'
@@ -90,7 +90,7 @@ describe('createFormHook', () => {
           <div className="m-3">
             <form.AppField name={`editors.${initialValues}.key` as const}>
               {(field) => {
-                assertType<string>(field.state.value)
+                expectTypeOf(field.state.value).toExtend<string>()
                 return null
               }}
             </form.AppField>
@@ -119,7 +119,7 @@ describe('createFormHook', () => {
     const WithFormComponent = withForm({
       ...formOpts,
       render: ({ form }) => {
-        assertType<Person>(form.state.values)
+        expectTypeOf(form.state.values).toEqualTypeOf<Person>()
         return <form.Test />
       },
     })
@@ -144,7 +144,7 @@ describe('createFormHook', () => {
         test: 'test',
       },
       render: ({ form }) => {
-        assertType<(submitMeta: { test: string }) => Promise<void>>(
+        expectTypeOf<(submitMeta: { test: string }) => Promise<void>>(
           form.handleSubmit,
         )
         return <form.Test />
@@ -175,9 +175,9 @@ describe('createFormHook', () => {
         firstName: 'FirstName',
         lastName: 'LastName',
         age: 10,
-      } as PersonWithAge,
+      },
       render: ({ form }) => {
-        assertType<PersonWithAge>(form.state.values)
+        expectTypeOf(form.state.values).toExtend<PersonWithAge>()
         return <form.Test />
       },
     })
@@ -190,7 +190,7 @@ describe('createFormHook', () => {
         prop2: 10,
       },
       render: ({ form, ...props }) => {
-        assertType<{
+        expectTypeOf<{
           prop1: string
           prop2: number
           children?: React.ReactNode
@@ -217,7 +217,7 @@ describe('createFormHook', () => {
         prop2: 10,
       },
       render: ({ form, ...props }) => {
-        assertType<{
+        expectTypeOf<{
           prop1: string
           prop2: number
         }>(props)

--- a/packages/react-form/tests/createFormHook.test-d.tsx
+++ b/packages/react-form/tests/createFormHook.test-d.tsx
@@ -144,9 +144,10 @@ describe('createFormHook', () => {
         test: 'test',
       },
       render: ({ form }) => {
-        expectTypeOf<(submitMeta: { test: string }) => Promise<void>>(
-          form.handleSubmit,
-        )
+        expectTypeOf(form.handleSubmit).toEqualTypeOf<{
+          (): Promise<void>
+          (submitMeta: { test: string }): Promise<void>
+        }>
         return <form.Test />
       },
     })
@@ -190,11 +191,11 @@ describe('createFormHook', () => {
         prop2: 10,
       },
       render: ({ form, ...props }) => {
-        expectTypeOf<{
+        expectTypeOf(props).toEqualTypeOf<{
           prop1: string
           prop2: number
           children?: React.ReactNode
-        }>(props)
+        }>()
         return <form.Test />
       },
     })
@@ -216,11 +217,11 @@ describe('createFormHook', () => {
         prop1: 'test',
         prop2: 10,
       },
-      render: ({ form, ...props }) => {
-        expectTypeOf<{
+      render: ({ form, children, ...props }) => {
+        expectTypeOf(props).toEqualTypeOf<{
           prop1: string
           prop2: number
-        }>(props)
+        }>()
         return <form.Test />
       },
     })

--- a/packages/react-form/tests/useField.test-d.tsx
+++ b/packages/react-form/tests/useField.test-d.tsx
@@ -1,4 +1,4 @@
-import { assertType, it } from 'vitest'
+import { expectTypeOf, it } from 'vitest'
 import { useForm } from '../src/index'
 
 it('should type state.value properly', () => {
@@ -15,14 +15,14 @@ it('should type state.value properly', () => {
         <form.Field
           name="firstName"
           children={(field) => {
-            assertType<'test'>(field.state.value)
+            expectTypeOf(field.state.value).toEqualTypeOf<'test'>()
             return null
           }}
         />
         <form.Field
           name="age"
           children={(field) => {
-            assertType<84>(field.state.value)
+            expectTypeOf(field.state.value).toEqualTypeOf<84>()
             return null
           }}
         />
@@ -46,7 +46,7 @@ it('should type onChange properly', () => {
           name="firstName"
           validators={{
             onChange: ({ value }) => {
-              assertType<'test'>(value)
+              expectTypeOf(value).toEqualTypeOf<'test'>()
               return null
             },
           }}
@@ -56,7 +56,7 @@ it('should type onChange properly', () => {
           name="age"
           validators={{
             onChange: ({ value }) => {
-              assertType<84>(value)
+              expectTypeOf(value).toEqualTypeOf<84>()
               return null
             },
           }}

--- a/packages/react-form/tests/useForm.test-d.tsx
+++ b/packages/react-form/tests/useForm.test-d.tsx
@@ -1,4 +1,4 @@
-import { assertType, describe, it } from 'vitest'
+import { describe, expectTypeOf, it } from 'vitest'
 import { formOptions, useForm } from '../src/index'
 import type { FormAsyncValidateOrFn, FormValidateOrFn } from '../src/index'
 import type { ReactFormExtendedApi } from '../src/useForm'
@@ -13,7 +13,7 @@ describe('useForm', () => {
           // as const is required here
         } as const,
         onSubmit({ value }) {
-          assertType<84>(value.age)
+          expectTypeOf(value.age).toEqualTypeOf<84>()
         },
       })
     }
@@ -29,7 +29,7 @@ describe('useForm', () => {
         } as const,
         validators: {
           onChange({ value }) {
-            assertType<84>(value.age)
+            expectTypeOf(value.age).toEqualTypeOf<84>()
             return undefined
           },
         },
@@ -93,7 +93,7 @@ describe('useForm', () => {
 
     const form = useForm(formOpts)
 
-    assertType<Person>(form.state.values)
+    expectTypeOf(form.state.values).toEqualTypeOf<Person>()
   })
 
   it('types should be properly inferred when passing args alongside formOptions', () => {
@@ -116,9 +116,10 @@ describe('useForm', () => {
       },
     })
 
-    assertType<(submitMeta: { test: string }) => Promise<void>>(
-      form.handleSubmit,
-    )
+    expectTypeOf(form.handleSubmit).toEqualTypeOf<{
+      (): Promise<void>
+      (submitMeta: { test: string }): Promise<void>
+    }>()
   })
 
   it('types should be properly inferred when formOptions are being overridden', () => {
@@ -144,9 +145,9 @@ describe('useForm', () => {
         firstName: 'FirstName',
         lastName: 'LastName',
         age: 10,
-      } as PersonWithAge,
+      },
     })
 
-    assertType<Person>(form.state.values)
+    expectTypeOf(form.state.values).toExtend<PersonWithAge>()
   })
 })

--- a/packages/react-form/tests/useTransform.test-d.tsx
+++ b/packages/react-form/tests/useTransform.test-d.tsx
@@ -1,4 +1,4 @@
-import { assertType, it } from 'vitest'
+import { expectTypeOf, it } from 'vitest'
 import { formOptions, mergeForm, useForm, useTransform } from '../src'
 import type { ServerFormState } from '../src/nextjs/types'
 
@@ -21,7 +21,7 @@ it('should maintain the type of the form', () => {
       ),
     })
 
-    assertType<123>(form.state.values.age)
-    assertType<string>(form.state.values.firstName)
+    expectTypeOf(form.state.values.age).toEqualTypeOf<123>()
+    expectTypeOf(form.state.values.firstName).toEqualTypeOf<''>()
   }
 })

--- a/packages/solid-form/tests/createField.test-d.tsx
+++ b/packages/solid-form/tests/createField.test-d.tsx
@@ -1,4 +1,4 @@
-import { assertType, it } from 'vitest'
+import { expectTypeOf, it } from 'vitest'
 import { createForm } from '../src/createForm'
 
 it('should type state.value properly', () => {
@@ -18,14 +18,14 @@ it('should type state.value properly', () => {
         <form.Field
           name="firstName"
           children={(field) => {
-            assertType<'test'>(field().state.value)
+            expectTypeOf(field().state.value).toEqualTypeOf<'test'>()
             return null
           }}
         />
         <form.Field
           name="age"
           children={(field) => {
-            assertType<84>(field().state.value)
+            expectTypeOf(field().state.value).toEqualTypeOf<84>()
             return null
           }}
         />
@@ -52,7 +52,7 @@ it('should type onChange properly', () => {
           name="firstName"
           validators={{
             onChange: ({ value }) => {
-              assertType<'test'>(value)
+              expectTypeOf(value).toEqualTypeOf<'test'>()
               return null
             },
           }}
@@ -62,7 +62,7 @@ it('should type onChange properly', () => {
           name="age"
           validators={{
             onChange: ({ value }) => {
-              assertType<84>(value)
+              expectTypeOf(value).toEqualTypeOf<84>()
               return null
             },
           }}


### PR DESCRIPTION
Migrate all type tests to `expectTypeOf`

```ts
assertType<string>(0 as never) // <- no errors
expectTypeOf<string>(0 as never) // <- no errors
expectTypeOf(0 as never).toEqualTypeOf<string>() // <- flags the error
```