### PR TITLE
docs(form): fix mention of onSubmitInvalid

### DIFF
--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -1607,7 +1607,7 @@ export class FormApi<
   }
 
   /**
-   * Handles the form submission, performs validation, and calls the appropriate onSubmit or onInvalidSubmit callbacks.
+   * Handles the form submission, performs validation, and calls the appropriate onSubmit or onSubmitInvalid callbacks.
    */
   handleSubmit(): Promise<void>
   handleSubmit(submitMeta: TSubmitMeta): Promise<void>


### PR DESCRIPTION
`onSubmitInvalid`: is 
 the correct one: https://tanstack.com/form/latest/docs/reference/interfaces/formoptions#onsubmitinvalid