### PR TITLE
fix: prevent manually setting derived meta

### DIFF
--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -1217,7 +1217,7 @@ export class FieldApi<
    */
   setMeta = (
     updater: Updater<
-      FieldMeta<
+      FieldMetaBase<
         TParentData,
         TName,
         TData,

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -1844,7 +1844,7 @@ export class FormApi<
    */
   setFieldMeta = <TField extends DeepKeys<TFormData>>(
     field: TField,
-    updater: Updater<AnyFieldMeta>,
+    updater: Updater<AnyFieldMetaBase>,
   ) => {
     this.baseStore.setState((prev) => {
       return {

--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -1,11 +1,11 @@
+import type { FieldValidators } from './FieldApi'
+import type { FormValidators } from './FormApi'
 import type {
   GlobalFormValidationError,
   ValidationCause,
   ValidationError,
   ValidationSource,
 } from './types'
-import type { FormValidators } from './FormApi'
-import type { AnyFieldMeta, FieldValidators } from './FieldApi'
 
 export type UpdaterFn<TInput, TOutput = TInput> = (input: TInput) => TOutput
 


### PR DESCRIPTION
Technically a breaking change on the types, but I feel manually setting derived meta (like `errors`) shouldn't be allowed as they would get overridden in the next update anyway.