### PR TITLE
chore: remove svelte tsconfig explicit path to form-core

### DIFF
--- a/packages/svelte-form/tsconfig.json
+++ b/packages/svelte-form/tsconfig.json
@@ -2,10 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "paths": {
-      "@tanstack/form-core": ["../form-core/src"]
-    }
+    "moduleResolution": "NodeNext"
   },
   "include": ["src", "tests", "*.config.js", "*.config.ts"]
 }


### PR DESCRIPTION
For some reason this generates .d.ts files on form-core when building svelte. I don't think this config is needed anyway as form-core is already from `workspace:*` in package.json