### PR TITLE
feat(react-form): add display name to components

### DIFF
--- a/packages/react-form/src/createFormHook.tsx
+++ b/packages/react-form/src/createFormHook.tsx
@@ -270,15 +270,17 @@ export function createFormHook<
     const form = useForm(props)
 
     const AppForm = useMemo(() => {
-      return (({ children }) => {
+      const AppForm = (({ children }) => {
         return (
           <formContext.Provider value={form}>{children}</formContext.Provider>
         )
       }) as ComponentType<PropsWithChildren>
+      AppForm.displayName = 'AppForm'
+      return AppForm
     }, [form])
 
     const AppField = useMemo(() => {
-      return (({ children, ...props }) => {
+      const AppField = (({ children, ...props }) => {
         return (
           <form.Field {...props}>
             {(field) => (
@@ -302,6 +304,9 @@ export function createFormHook<
         TSubmitMeta,
         TComponents
       >
+      // @ts-expect-error React component property
+      AppField.displayName = 'AppField'
+      return AppField
     }, [form])
 
     const extendedForm = useMemo(() => {

--- a/packages/react-form/src/createFormHook.tsx
+++ b/packages/react-form/src/createFormHook.tsx
@@ -275,7 +275,6 @@ export function createFormHook<
           <formContext.Provider value={form}>{children}</formContext.Provider>
         )
       }) as ComponentType<PropsWithChildren>
-      AppForm.displayName = 'AppForm'
       return AppForm
     }, [form])
 
@@ -304,8 +303,6 @@ export function createFormHook<
         TSubmitMeta,
         TComponents
       >
-      // @ts-expect-error React component property
-      AppField.displayName = 'AppField'
       return AppField
     }, [form])
 

--- a/packages/react-form/src/useForm.tsx
+++ b/packages/react-form/src/useForm.tsx
@@ -193,7 +193,7 @@ export function useForm<
     extendedApi.Field = function APIField(props) {
       return <Field {...props} form={api} />
     }
-    extendedApi.Subscribe = (props: any) => {
+    extendedApi.Subscribe = function Subscribe(props: any) {
       return (
         <LocalSubscribe
           form={api}


### PR DESCRIPTION
Currently, with the following code:

```jsx
<AppForm>
  <ContainerForm>
    <AppField name="animal">
      {() => <RadioGroupField {...props} />}
    </AppField>
  </ContainerForm>
</AppForm>
```

Storybook's "Show code" function displays "No Display Name" for `<AppForm>` and `<AppField>`:

<img width="1019" alt="Screenshot 2025-05-08 at 1 17 07 PM" src="https://github.com/user-attachments/assets/776a8a3f-101f-435e-b03b-53b8885df4e3" />

By assigning a [`displayName`](https://legacy.reactjs.org/docs/react-component.html#displayname), they are displayed with correct names:

<img width="1026" alt="Screenshot 2025-05-08 at 1 16 20 PM" src="https://github.com/user-attachments/assets/f3445528-aff0-4cd7-acb4-92d2b945885d" />

Assigning `displayName` is necessary since merely this...

```diff
    const AppForm = useMemo(() => {
-      return (({ children }) => {
+      const AppForm = (({ children }) => {
```

...would display as `<AppForm2>` instead since it is renamed when compiled:

```js
const AppForm = useMemo(() => {
  const AppForm2 = ({ children }) => {
    return /* @__PURE__ */ jsx(formContext.Provider, { value: form, children });
  };
  AppForm2.displayName = "AppForm";
  return AppForm2;
}, [form]);
```

EDIT: since assigning `displayName` triggers a lint error, I'm resorting to simple named functions.