### PR TITLE
fix: canSubmit with valibot variant schema

### DIFF
--- a/docs/framework/angular/reference/classes/tanstackfield.md
+++ b/docs/framework/angular/reference/classes/tanstackfield.md
@@ -7,7 +7,7 @@ title: TanStackField
 
 # Class: TanStackField\<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TSubmitMeta\>
 
-Defined in: [tanstack-field.directive.ts:31](https://github.com/TanStack/form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L31)
+Defined in: [tanstack-field.directive.ts:31](https://github.com/Pascalmh/tanstack-form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L31)
 
 ## Type Parameters
 
@@ -76,7 +76,7 @@ new TanStackField<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync
 api: FieldApi<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TSubmitMeta>;
 ```
 
-Defined in: [tanstack-field.directive.ts:129](https://github.com/TanStack/form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L129)
+Defined in: [tanstack-field.directive.ts:129](https://github.com/Pascalmh/tanstack-form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L129)
 
 ***
 
@@ -86,7 +86,7 @@ Defined in: [tanstack-field.directive.ts:129](https://github.com/TanStack/form/b
 optional asyncAlways: boolean;
 ```
 
-Defined in: [tanstack-field.directive.ts:78](https://github.com/TanStack/form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L78)
+Defined in: [tanstack-field.directive.ts:78](https://github.com/Pascalmh/tanstack-form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L78)
 
 If `true`, always run async validation, even if there are errors emitted during synchronous validation.
 
@@ -104,7 +104,7 @@ FieldOptions.asyncAlways
 optional asyncDebounceMs: number;
 ```
 
-Defined in: [tanstack-field.directive.ts:77](https://github.com/TanStack/form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L77)
+Defined in: [tanstack-field.directive.ts:77](https://github.com/Pascalmh/tanstack-form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L77)
 
 The default time to debounce async validation if there is not a more specific debounce time passed.
 
@@ -122,7 +122,7 @@ FieldOptions.asyncDebounceMs
 optional defaultMeta: Partial<FieldMeta<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync>>;
 ```
 
-Defined in: [tanstack-field.directive.ts:106](https://github.com/TanStack/form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L106)
+Defined in: [tanstack-field.directive.ts:106](https://github.com/Pascalmh/tanstack-form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L106)
 
 An optional object with default metadata for the field.
 
@@ -140,7 +140,7 @@ FieldOptions.defaultMeta
 optional defaultValue: NoInfer<TData>;
 ```
 
-Defined in: [tanstack-field.directive.ts:76](https://github.com/TanStack/form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L76)
+Defined in: [tanstack-field.directive.ts:76](https://github.com/Pascalmh/tanstack-form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L76)
 
 An optional default value for the field.
 
@@ -158,7 +158,7 @@ FieldOptions.defaultValue
 optional disableErrorFlat: boolean;
 ```
 
-Defined in: [tanstack-field.directive.ts:127](https://github.com/TanStack/form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L127)
+Defined in: [tanstack-field.directive.ts:127](https://github.com/Pascalmh/tanstack-form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L127)
 
 Disable the `flat(1)` operation on `field.errors`. This is useful if you want to keep the error structure as is. Not suggested for most use-cases.
 
@@ -176,7 +176,7 @@ FieldOptions.disableErrorFlat
 optional listeners: NoInfer<FieldListeners<TParentData, TName, TData>>;
 ```
 
-Defined in: [tanstack-field.directive.ts:105](https://github.com/TanStack/form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L105)
+Defined in: [tanstack-field.directive.ts:105](https://github.com/Pascalmh/tanstack-form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L105)
 
 A list of listeners which attach to the corresponding events
 
@@ -194,7 +194,7 @@ FieldOptions.listeners
 name: TName;
 ```
 
-Defined in: [tanstack-field.directive.ts:75](https://github.com/TanStack/form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L75)
+Defined in: [tanstack-field.directive.ts:75](https://github.com/Pascalmh/tanstack-form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L75)
 
 The field name. The type will be `DeepKeys<TParentData>` to ensure your name is a deep key of the parent dataset.
 
@@ -212,7 +212,7 @@ FieldOptions.name
 tanstackField: FormApi<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TSubmitMeta>;
 ```
 
-Defined in: [tanstack-field.directive.ts:79](https://github.com/TanStack/form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L79)
+Defined in: [tanstack-field.directive.ts:79](https://github.com/Pascalmh/tanstack-form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L79)
 
 ***
 
@@ -222,7 +222,7 @@ Defined in: [tanstack-field.directive.ts:79](https://github.com/TanStack/form/bl
 optional unmount: () => void;
 ```
 
-Defined in: [tanstack-field.directive.ts:185](https://github.com/TanStack/form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L185)
+Defined in: [tanstack-field.directive.ts:185](https://github.com/Pascalmh/tanstack-form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L185)
 
 #### Returns
 
@@ -236,7 +236,7 @@ Defined in: [tanstack-field.directive.ts:185](https://github.com/TanStack/form/b
 optional validators: NoInfer<FieldValidators<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync>>;
 ```
 
-Defined in: [tanstack-field.directive.ts:91](https://github.com/TanStack/form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L91)
+Defined in: [tanstack-field.directive.ts:91](https://github.com/Pascalmh/tanstack-form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L91)
 
 A list of validators to pass to the field
 
@@ -254,7 +254,7 @@ FieldOptions.validators
 ngOnChanges(): void
 ```
 
-Defined in: [tanstack-field.directive.ts:197](https://github.com/TanStack/form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L197)
+Defined in: [tanstack-field.directive.ts:197](https://github.com/Pascalmh/tanstack-form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L197)
 
 A callback method that is invoked immediately after the
 default change detector has checked data-bound properties
@@ -279,7 +279,7 @@ OnChanges.ngOnChanges
 ngOnDestroy(): void
 ```
 
-Defined in: [tanstack-field.directive.ts:193](https://github.com/TanStack/form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L193)
+Defined in: [tanstack-field.directive.ts:193](https://github.com/Pascalmh/tanstack-form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L193)
 
 A callback method that performs custom clean-up, invoked immediately
 before a directive, pipe, or service instance is destroyed.
@@ -302,7 +302,7 @@ OnDestroy.ngOnDestroy
 ngOnInit(): void
 ```
 
-Defined in: [tanstack-field.directive.ts:187](https://github.com/TanStack/form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L187)
+Defined in: [tanstack-field.directive.ts:187](https://github.com/Pascalmh/tanstack-form/blob/main/packages/angular-form/src/tanstack-field.directive.ts#L187)
 
 A callback method that is invoked immediately after the
 default change detector has checked the directive's

--- a/docs/framework/angular/reference/functions/injectform.md
+++ b/docs/framework/angular/reference/functions/injectform.md
@@ -11,7 +11,7 @@ title: injectForm
 function injectForm<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer, TSubmitMeta>(opts?): FormApi<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer, TSubmitMeta>
 ```
 
-Defined in: [inject-form.ts:9](https://github.com/TanStack/form/blob/main/packages/angular-form/src/inject-form.ts#L9)
+Defined in: [inject-form.ts:9](https://github.com/Pascalmh/tanstack-form/blob/main/packages/angular-form/src/inject-form.ts#L9)
 
 ## Type Parameters
 

--- a/docs/framework/angular/reference/functions/injectstore.md
+++ b/docs/framework/angular/reference/functions/injectstore.md
@@ -11,7 +11,7 @@ title: injectStore
 function injectStore<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer, TSubmitMeta, TSelected>(form, selector?): Signal<TSelected>
 ```
 
-Defined in: [inject-store.ts:9](https://github.com/TanStack/form/blob/main/packages/angular-form/src/inject-store.ts#L9)
+Defined in: [inject-store.ts:9](https://github.com/Pascalmh/tanstack-form/blob/main/packages/angular-form/src/inject-store.ts#L9)
 
 ## Type Parameters
 

--- a/docs/framework/lit/reference/classes/tanstackformcontroller.md
+++ b/docs/framework/lit/reference/classes/tanstackformcontroller.md
@@ -7,7 +7,7 @@ title: TanStackFormController
 
 # Class: TanStackFormController\<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TSubmitMeta\>
 
-Defined in: [tanstack-form-controller.ts:190](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L190)
+Defined in: [tanstack-form-controller.ts:190](https://github.com/Pascalmh/tanstack-form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L190)
 
 ## Type Parameters
 
@@ -43,7 +43,7 @@ Defined in: [tanstack-form-controller.ts:190](https://github.com/TanStack/form/b
 new TanStackFormController<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TSubmitMeta>(host, config?): TanStackFormController<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TSubmitMeta>
 ```
 
-Defined in: [tanstack-form-controller.ts:219](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L219)
+Defined in: [tanstack-form-controller.ts:219](https://github.com/Pascalmh/tanstack-form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L219)
 
 #### Parameters
 
@@ -67,7 +67,7 @@ Defined in: [tanstack-form-controller.ts:219](https://github.com/TanStack/form/b
 api: FormApi<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TSubmitMeta>;
 ```
 
-Defined in: [tanstack-form-controller.ts:206](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L206)
+Defined in: [tanstack-form-controller.ts:206](https://github.com/Pascalmh/tanstack-form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L206)
 
 ## Methods
 
@@ -77,7 +77,7 @@ Defined in: [tanstack-form-controller.ts:206](https://github.com/TanStack/form/b
 field<TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync>(fieldConfig, render): object
 ```
 
-Defined in: [tanstack-form-controller.ts:259](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L259)
+Defined in: [tanstack-form-controller.ts:259](https://github.com/Pascalmh/tanstack-form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L259)
 
 #### Type Parameters
 
@@ -145,7 +145,7 @@ render: renderCallback<TParentData, TName, TData, TOnMount, TOnChange, TOnChange
 hostConnected(): void
 ```
 
-Defined in: [tanstack-form-controller.ts:249](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L249)
+Defined in: [tanstack-form-controller.ts:249](https://github.com/Pascalmh/tanstack-form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L249)
 
 Called when the host is connected to the component tree. For custom
 element hosts, this corresponds to the `connectedCallback()` lifecycle,
@@ -169,7 +169,7 @@ ReactiveController.hostConnected
 hostDisconnected(): void
 ```
 
-Defined in: [tanstack-form-controller.ts:255](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L255)
+Defined in: [tanstack-form-controller.ts:255](https://github.com/Pascalmh/tanstack-form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L255)
 
 Called when the host is disconnected from the component tree. For custom
 element hosts, this corresponds to the `disconnectedCallback()` lifecycle,

--- a/docs/framework/react/reference/functions/createformhook.md
+++ b/docs/framework/react/reference/functions/createformhook.md
@@ -11,7 +11,7 @@ title: createFormHook
 function createFormHook<TComponents, TFormComponents>(__namedParameters): object
 ```
 
-Defined in: [packages/react-form/src/createFormHook.tsx:223](https://github.com/TanStack/form/blob/main/packages/react-form/src/createFormHook.tsx#L223)
+Defined in: [packages/react-form/src/createFormHook.tsx:223](https://github.com/Pascalmh/tanstack-form/blob/main/packages/react-form/src/createFormHook.tsx#L223)
 
 ## Type Parameters
 

--- a/docs/framework/react/reference/functions/createformhookcontexts.md
+++ b/docs/framework/react/reference/functions/createformhookcontexts.md
@@ -11,7 +11,7 @@ title: createFormHookContexts
 function createFormHookContexts(): object
 ```
 
-Defined in: [packages/react-form/src/createFormHook.tsx:53](https://github.com/TanStack/form/blob/main/packages/react-form/src/createFormHook.tsx#L53)
+Defined in: [packages/react-form/src/createFormHook.tsx:53](https://github.com/Pascalmh/tanstack-form/blob/main/packages/react-form/src/createFormHook.tsx#L53)
 
 ## Returns
 

--- a/docs/framework/react/reference/functions/field.md
+++ b/docs/framework/react/reference/functions/field.md
@@ -11,7 +11,7 @@ title: Field
 function Field<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TPatentSubmitMeta>(__namedParameters): ReactNode
 ```
 
-Defined in: [packages/react-form/src/useField.tsx:428](https://github.com/TanStack/form/blob/main/packages/react-form/src/useField.tsx#L428)
+Defined in: [packages/react-form/src/useField.tsx:428](https://github.com/Pascalmh/tanstack-form/blob/main/packages/react-form/src/useField.tsx#L428)
 
 A function component that takes field options and a render function as children and returns a React component.
 

--- a/docs/framework/react/reference/functions/usefield.md
+++ b/docs/framework/react/reference/functions/usefield.md
@@ -11,7 +11,7 @@ title: useField
 function useField<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TPatentSubmitMeta>(opts): FieldApi<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TPatentSubmitMeta> & ReactFieldApi<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TPatentSubmitMeta>
 ```
 
-Defined in: [packages/react-form/src/useField.tsx:118](https://github.com/TanStack/form/blob/main/packages/react-form/src/useField.tsx#L118)
+Defined in: [packages/react-form/src/useField.tsx:118](https://github.com/Pascalmh/tanstack-form/blob/main/packages/react-form/src/useField.tsx#L118)
 
 A hook for managing a field in a form.
 

--- a/docs/framework/react/reference/functions/useform.md
+++ b/docs/framework/react/reference/functions/useform.md
@@ -11,7 +11,7 @@ title: useForm
 function useForm<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer, TSubmitMeta>(opts?): ReactFormExtendedApi<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer, TSubmitMeta>
 ```
 
-Defined in: [packages/react-form/src/useForm.tsx:142](https://github.com/TanStack/form/blob/main/packages/react-form/src/useForm.tsx#L142)
+Defined in: [packages/react-form/src/useForm.tsx:142](https://github.com/Pascalmh/tanstack-form/blob/main/packages/react-form/src/useForm.tsx#L142)
 
 A custom React Hook that returns an extended instance of the `FormApi` class.
 

--- a/docs/framework/react/reference/functions/usetransform.md
+++ b/docs/framework/react/reference/functions/usetransform.md
@@ -11,7 +11,7 @@ title: useTransform
 function useTransform(fn, deps): FormTransform<any, any, any, any, any, any, any, any, any, any>
 ```
 
-Defined in: [packages/react-form/src/useTransform.ts:9](https://github.com/TanStack/form/blob/main/packages/react-form/src/useTransform.ts#L9)
+Defined in: [packages/react-form/src/useTransform.ts:9](https://github.com/Pascalmh/tanstack-form/blob/main/packages/react-form/src/useTransform.ts#L9)
 
 ## Parameters
 

--- a/docs/framework/react/reference/interfaces/reactformapi.md
+++ b/docs/framework/react/reference/interfaces/reactformapi.md
@@ -7,7 +7,7 @@ title: ReactFormApi
 
 # Interface: ReactFormApi\<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer, TSubmitMeta\>
 
-Defined in: [packages/react-form/src/useForm.tsx:21](https://github.com/TanStack/form/blob/main/packages/react-form/src/useForm.tsx#L21)
+Defined in: [packages/react-form/src/useForm.tsx:21](https://github.com/Pascalmh/tanstack-form/blob/main/packages/react-form/src/useForm.tsx#L21)
 
 Fields that are added onto the `FormAPI` from `@tanstack/form-core` and returned from `useForm`
 
@@ -41,7 +41,7 @@ Fields that are added onto the `FormAPI` from `@tanstack/form-core` and returned
 Field: FieldComponent<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer, TSubmitMeta>;
 ```
 
-Defined in: [packages/react-form/src/useForm.tsx:36](https://github.com/TanStack/form/blob/main/packages/react-form/src/useForm.tsx#L36)
+Defined in: [packages/react-form/src/useForm.tsx:36](https://github.com/Pascalmh/tanstack-form/blob/main/packages/react-form/src/useForm.tsx#L36)
 
 A React component to render form fields. With this, you can render and manage individual form fields.
 
@@ -53,7 +53,7 @@ A React component to render form fields. With this, you can render and manage in
 Subscribe: <TSelected>(props) => ReactNode;
 ```
 
-Defined in: [packages/react-form/src/useForm.tsx:51](https://github.com/TanStack/form/blob/main/packages/react-form/src/useForm.tsx#L51)
+Defined in: [packages/react-form/src/useForm.tsx:51](https://github.com/Pascalmh/tanstack-form/blob/main/packages/react-form/src/useForm.tsx#L51)
 
 A `Subscribe` function that allows you to listen and react to changes in the form's state. It's especially useful when you need to execute side effects or render specific components in response to state updates.
 

--- a/docs/framework/react/reference/interfaces/withformprops.md
+++ b/docs/framework/react/reference/interfaces/withformprops.md
@@ -7,7 +7,7 @@ title: WithFormProps
 
 # Interface: WithFormProps\<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer, TSubmitMeta, TFieldComponents, TFormComponents, TRenderProps\>
 
-Defined in: [packages/react-form/src/createFormHook.tsx:173](https://github.com/TanStack/form/blob/main/packages/react-form/src/createFormHook.tsx#L173)
+Defined in: [packages/react-form/src/createFormHook.tsx:173](https://github.com/Pascalmh/tanstack-form/blob/main/packages/react-form/src/createFormHook.tsx#L173)
 
 ## Extends
 
@@ -49,7 +49,7 @@ Defined in: [packages/react-form/src/createFormHook.tsx:173](https://github.com/
 optional props: TRenderProps;
 ```
 
-Defined in: [packages/react-form/src/createFormHook.tsx:200](https://github.com/TanStack/form/blob/main/packages/react-form/src/createFormHook.tsx#L200)
+Defined in: [packages/react-form/src/createFormHook.tsx:200](https://github.com/Pascalmh/tanstack-form/blob/main/packages/react-form/src/createFormHook.tsx#L200)
 
 ***
 
@@ -59,7 +59,7 @@ Defined in: [packages/react-form/src/createFormHook.tsx:200](https://github.com/
 render: (props) => Element;
 ```
 
-Defined in: [packages/react-form/src/createFormHook.tsx:201](https://github.com/TanStack/form/blob/main/packages/react-form/src/createFormHook.tsx#L201)
+Defined in: [packages/react-form/src/createFormHook.tsx:201](https://github.com/Pascalmh/tanstack-form/blob/main/packages/react-form/src/createFormHook.tsx#L201)
 
 #### Parameters
 

--- a/docs/framework/react/reference/type-aliases/fieldcomponent.md
+++ b/docs/framework/react/reference/type-aliases/fieldcomponent.md
@@ -14,7 +14,7 @@ type FieldComponent<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync
 }) => ReactNode;
 ```
 
-Defined in: [packages/react-form/src/useField.tsx:363](https://github.com/TanStack/form/blob/main/packages/react-form/src/useField.tsx#L363)
+Defined in: [packages/react-form/src/useField.tsx:363](https://github.com/Pascalmh/tanstack-form/blob/main/packages/react-form/src/useField.tsx#L363)
 
 A type alias representing a field component for a specific form data type.
 

--- a/docs/framework/react/reference/type-aliases/reactformextendedapi.md
+++ b/docs/framework/react/reference/type-aliases/reactformextendedapi.md
@@ -11,7 +11,7 @@ title: ReactFormExtendedApi
 type ReactFormExtendedApi<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer, TSubmitMeta> = FormApi<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer, TSubmitMeta> & ReactFormApi<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer, TSubmitMeta>;
 ```
 
-Defined in: [packages/react-form/src/useForm.tsx:88](https://github.com/TanStack/form/blob/main/packages/react-form/src/useForm.tsx#L88)
+Defined in: [packages/react-form/src/useForm.tsx:88](https://github.com/Pascalmh/tanstack-form/blob/main/packages/react-form/src/useForm.tsx#L88)
 
 An extended version of the `FormApi` class that includes React-specific functionalities from `ReactFormApi`
 

--- a/docs/framework/react/reference/type-aliases/usefield.md
+++ b/docs/framework/react/reference/type-aliases/usefield.md
@@ -11,7 +11,7 @@ title: UseField
 type UseField<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TPatentSubmitMeta> = <TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync>(opts) => FieldApi<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TPatentSubmitMeta>;
 ```
 
-Defined in: [packages/react-form/src/useField.tsx:50](https://github.com/TanStack/form/blob/main/packages/react-form/src/useField.tsx#L50)
+Defined in: [packages/react-form/src/useField.tsx:50](https://github.com/Pascalmh/tanstack-form/blob/main/packages/react-form/src/useField.tsx#L50)
 
 A type representing a hook for using a field in a form with the given form data type.
 

--- a/docs/framework/solid/reference/functions/createfield.md
+++ b/docs/framework/solid/reference/functions/createfield.md
@@ -11,7 +11,7 @@ title: createField
 function createField<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta>(opts): () => FieldApi<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta> & SolidFieldApi<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta>
 ```
 
-Defined in: [packages/solid-form/src/createField.tsx:223](https://github.com/TanStack/form/blob/main/packages/solid-form/src/createField.tsx#L223)
+Defined in: [packages/solid-form/src/createField.tsx:223](https://github.com/Pascalmh/tanstack-form/blob/main/packages/solid-form/src/createField.tsx#L223)
 
 ## Type Parameters
 

--- a/docs/framework/solid/reference/functions/createform.md
+++ b/docs/framework/solid/reference/functions/createform.md
@@ -11,7 +11,7 @@ title: createForm
 function createForm<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TSubmitMeta>(opts?): FormApi<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TSubmitMeta> & SolidFormApi<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TSubmitMeta>
 ```
 
-Defined in: [packages/solid-form/src/createForm.tsx:115](https://github.com/TanStack/form/blob/main/packages/solid-form/src/createForm.tsx#L115)
+Defined in: [packages/solid-form/src/createForm.tsx:115](https://github.com/Pascalmh/tanstack-form/blob/main/packages/solid-form/src/createForm.tsx#L115)
 
 ## Type Parameters
 

--- a/docs/framework/solid/reference/functions/field.md
+++ b/docs/framework/solid/reference/functions/field.md
@@ -11,7 +11,7 @@ title: Field
 function Field<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta>(props): Element
 ```
 
-Defined in: [packages/solid-form/src/createField.tsx:524](https://github.com/TanStack/form/blob/main/packages/solid-form/src/createField.tsx#L524)
+Defined in: [packages/solid-form/src/createField.tsx:524](https://github.com/Pascalmh/tanstack-form/blob/main/packages/solid-form/src/createField.tsx#L524)
 
 ## Type Parameters
 

--- a/docs/framework/solid/reference/interfaces/solidformapi.md
+++ b/docs/framework/solid/reference/interfaces/solidformapi.md
@@ -7,7 +7,7 @@ title: SolidFormApi
 
 # Interface: SolidFormApi\<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TSubmitMeta\>
 
-Defined in: [packages/solid-form/src/createForm.tsx:14](https://github.com/TanStack/form/blob/main/packages/solid-form/src/createForm.tsx#L14)
+Defined in: [packages/solid-form/src/createForm.tsx:14](https://github.com/Pascalmh/tanstack-form/blob/main/packages/solid-form/src/createForm.tsx#L14)
 
 ## Type Parameters
 
@@ -39,7 +39,7 @@ Defined in: [packages/solid-form/src/createForm.tsx:14](https://github.com/TanSt
 createField: CreateField<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TSubmitMeta>;
 ```
 
-Defined in: [packages/solid-form/src/createForm.tsx:38](https://github.com/TanStack/form/blob/main/packages/solid-form/src/createForm.tsx#L38)
+Defined in: [packages/solid-form/src/createForm.tsx:38](https://github.com/Pascalmh/tanstack-form/blob/main/packages/solid-form/src/createForm.tsx#L38)
 
 ***
 
@@ -49,7 +49,7 @@ Defined in: [packages/solid-form/src/createForm.tsx:38](https://github.com/TanSt
 Field: FieldComponent<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TSubmitMeta>;
 ```
 
-Defined in: [packages/solid-form/src/createForm.tsx:26](https://github.com/TanStack/form/blob/main/packages/solid-form/src/createForm.tsx#L26)
+Defined in: [packages/solid-form/src/createForm.tsx:26](https://github.com/Pascalmh/tanstack-form/blob/main/packages/solid-form/src/createForm.tsx#L26)
 
 ***
 
@@ -59,7 +59,7 @@ Defined in: [packages/solid-form/src/createForm.tsx:26](https://github.com/TanSt
 Subscribe: <TSelected>(props) => Element;
 ```
 
-Defined in: [packages/solid-form/src/createForm.tsx:81](https://github.com/TanStack/form/blob/main/packages/solid-form/src/createForm.tsx#L81)
+Defined in: [packages/solid-form/src/createForm.tsx:81](https://github.com/Pascalmh/tanstack-form/blob/main/packages/solid-form/src/createForm.tsx#L81)
 
 #### Type Parameters
 
@@ -89,7 +89,7 @@ Defined in: [packages/solid-form/src/createForm.tsx:81](https://github.com/TanSt
 useStore: <TSelected>(selector?) => () => TSelected;
 ```
 
-Defined in: [packages/solid-form/src/createForm.tsx:50](https://github.com/TanStack/form/blob/main/packages/solid-form/src/createForm.tsx#L50)
+Defined in: [packages/solid-form/src/createForm.tsx:50](https://github.com/Pascalmh/tanstack-form/blob/main/packages/solid-form/src/createForm.tsx#L50)
 
 #### Type Parameters
 

--- a/docs/framework/solid/reference/type-aliases/createfield.md
+++ b/docs/framework/solid/reference/type-aliases/createfield.md
@@ -11,7 +11,7 @@ title: CreateField
 type CreateField<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta> = <TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync>(opts) => () => FieldApi<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta> & SolidFieldApi<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta>;
 ```
 
-Defined in: [packages/solid-form/src/createField.tsx:49](https://github.com/TanStack/form/blob/main/packages/solid-form/src/createField.tsx#L49)
+Defined in: [packages/solid-form/src/createField.tsx:49](https://github.com/Pascalmh/tanstack-form/blob/main/packages/solid-form/src/createField.tsx#L49)
 
 ## Type Parameters
 

--- a/docs/framework/solid/reference/type-aliases/fieldcomponent.md
+++ b/docs/framework/solid/reference/type-aliases/fieldcomponent.md
@@ -14,7 +14,7 @@ type FieldComponent<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync
 }) => JSXElement;
 ```
 
-Defined in: [packages/solid-form/src/createField.tsx:400](https://github.com/TanStack/form/blob/main/packages/solid-form/src/createField.tsx#L400)
+Defined in: [packages/solid-form/src/createField.tsx:400](https://github.com/Pascalmh/tanstack-form/blob/main/packages/solid-form/src/createField.tsx#L400)
 
 ## Type Parameters
 

--- a/docs/framework/vue/reference/functions/usefield.md
+++ b/docs/framework/vue/reference/functions/usefield.md
@@ -11,7 +11,7 @@ title: useField
 function useField<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta>(opts): object
 ```
 
-Defined in: [packages/vue-form/src/useField.tsx:267](https://github.com/TanStack/form/blob/main/packages/vue-form/src/useField.tsx#L267)
+Defined in: [packages/vue-form/src/useField.tsx:267](https://github.com/Pascalmh/tanstack-form/blob/main/packages/vue-form/src/useField.tsx#L267)
 
 ## Type Parameters
 

--- a/docs/framework/vue/reference/functions/useform.md
+++ b/docs/framework/vue/reference/functions/useform.md
@@ -11,7 +11,7 @@ title: useForm
 function useForm<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TSubmitMeta>(opts?): FormApi<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TSubmitMeta> & VueFormApi<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TSubmitMeta>
 ```
 
-Defined in: [packages/vue-form/src/useForm.tsx:195](https://github.com/TanStack/form/blob/main/packages/vue-form/src/useForm.tsx#L195)
+Defined in: [packages/vue-form/src/useForm.tsx:195](https://github.com/Pascalmh/tanstack-form/blob/main/packages/vue-form/src/useForm.tsx#L195)
 
 ## Type Parameters
 

--- a/docs/framework/vue/reference/interfaces/vuefieldapi.md
+++ b/docs/framework/vue/reference/interfaces/vuefieldapi.md
@@ -7,7 +7,7 @@ title: VueFieldApi
 
 # Interface: VueFieldApi\<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta\>
 
-Defined in: [packages/vue-form/src/useField.tsx:140](https://github.com/TanStack/form/blob/main/packages/vue-form/src/useField.tsx#L140)
+Defined in: [packages/vue-form/src/useField.tsx:140](https://github.com/Pascalmh/tanstack-form/blob/main/packages/vue-form/src/useField.tsx#L140)
 
 ## Type Parameters
 
@@ -39,4 +39,4 @@ Defined in: [packages/vue-form/src/useField.tsx:140](https://github.com/TanStack
 Field: FieldComponent<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta>;
 ```
 
-Defined in: [packages/vue-form/src/useField.tsx:152](https://github.com/TanStack/form/blob/main/packages/vue-form/src/useField.tsx#L152)
+Defined in: [packages/vue-form/src/useField.tsx:152](https://github.com/Pascalmh/tanstack-form/blob/main/packages/vue-form/src/useField.tsx#L152)

--- a/docs/framework/vue/reference/interfaces/vueformapi.md
+++ b/docs/framework/vue/reference/interfaces/vueformapi.md
@@ -7,7 +7,7 @@ title: VueFormApi
 
 # Interface: VueFormApi\<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TSubmitMeta\>
 
-Defined in: [packages/vue-form/src/useForm.tsx:115](https://github.com/TanStack/form/blob/main/packages/vue-form/src/useForm.tsx#L115)
+Defined in: [packages/vue-form/src/useForm.tsx:115](https://github.com/Pascalmh/tanstack-form/blob/main/packages/vue-form/src/useForm.tsx#L115)
 
 ## Type Parameters
 
@@ -39,7 +39,7 @@ Defined in: [packages/vue-form/src/useForm.tsx:115](https://github.com/TanStack/
 Field: FieldComponent<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TSubmitMeta>;
 ```
 
-Defined in: [packages/vue-form/src/useForm.tsx:127](https://github.com/TanStack/form/blob/main/packages/vue-form/src/useForm.tsx#L127)
+Defined in: [packages/vue-form/src/useForm.tsx:127](https://github.com/Pascalmh/tanstack-form/blob/main/packages/vue-form/src/useForm.tsx#L127)
 
 ***
 
@@ -49,7 +49,7 @@ Defined in: [packages/vue-form/src/useForm.tsx:127](https://github.com/TanStack/
 Subscribe: SubscribeComponent<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer>;
 ```
 
-Defined in: [packages/vue-form/src/useForm.tsx:182](https://github.com/TanStack/form/blob/main/packages/vue-form/src/useForm.tsx#L182)
+Defined in: [packages/vue-form/src/useForm.tsx:182](https://github.com/Pascalmh/tanstack-form/blob/main/packages/vue-form/src/useForm.tsx#L182)
 
 ***
 
@@ -59,7 +59,7 @@ Defined in: [packages/vue-form/src/useForm.tsx:182](https://github.com/TanStack/
 useField: UseField<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TSubmitMeta>;
 ```
 
-Defined in: [packages/vue-form/src/useForm.tsx:139](https://github.com/TanStack/form/blob/main/packages/vue-form/src/useForm.tsx#L139)
+Defined in: [packages/vue-form/src/useForm.tsx:139](https://github.com/Pascalmh/tanstack-form/blob/main/packages/vue-form/src/useForm.tsx#L139)
 
 ***
 
@@ -69,7 +69,7 @@ Defined in: [packages/vue-form/src/useForm.tsx:139](https://github.com/TanStack/
 useStore: <TSelected>(selector?) => Readonly<Ref<TSelected, TSelected>>;
 ```
 
-Defined in: [packages/vue-form/src/useForm.tsx:151](https://github.com/TanStack/form/blob/main/packages/vue-form/src/useForm.tsx#L151)
+Defined in: [packages/vue-form/src/useForm.tsx:151](https://github.com/Pascalmh/tanstack-form/blob/main/packages/vue-form/src/useForm.tsx#L151)
 
 #### Type Parameters
 

--- a/docs/framework/vue/reference/type-aliases/fieldcomponent.md
+++ b/docs/framework/vue/reference/type-aliases/fieldcomponent.md
@@ -16,7 +16,7 @@ type FieldComponent<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync
 }>>;
 ```
 
-Defined in: [packages/vue-form/src/useField.tsx:24](https://github.com/TanStack/form/blob/main/packages/vue-form/src/useField.tsx#L24)
+Defined in: [packages/vue-form/src/useField.tsx:24](https://github.com/Pascalmh/tanstack-form/blob/main/packages/vue-form/src/useField.tsx#L24)
 
 ## Type Parameters
 

--- a/docs/framework/vue/reference/type-aliases/fieldcomponentboundprops.md
+++ b/docs/framework/vue/reference/type-aliases/fieldcomponentboundprops.md
@@ -11,7 +11,7 @@ title: FieldComponentBoundProps
 type FieldComponentBoundProps<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync> = UseFieldOptionsBound<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync>;
 ```
 
-Defined in: [packages/vue-form/src/useField.tsx:412](https://github.com/TanStack/form/blob/main/packages/vue-form/src/useField.tsx#L412)
+Defined in: [packages/vue-form/src/useField.tsx:412](https://github.com/Pascalmh/tanstack-form/blob/main/packages/vue-form/src/useField.tsx#L412)
 
 ## Type Parameters
 

--- a/docs/framework/vue/reference/type-aliases/fieldcomponentprops.md
+++ b/docs/framework/vue/reference/type-aliases/fieldcomponentprops.md
@@ -11,7 +11,7 @@ title: FieldComponentProps
 type FieldComponentProps<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta> = UseFieldOptions<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta>;
 ```
 
-Defined in: [packages/vue-form/src/useField.tsx:364](https://github.com/TanStack/form/blob/main/packages/vue-form/src/useField.tsx#L364)
+Defined in: [packages/vue-form/src/useField.tsx:364](https://github.com/Pascalmh/tanstack-form/blob/main/packages/vue-form/src/useField.tsx#L364)
 
 ## Type Parameters
 

--- a/docs/framework/vue/reference/type-aliases/usefield.md
+++ b/docs/framework/vue/reference/type-aliases/usefield.md
@@ -11,7 +11,7 @@ title: UseField
 type UseField<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta> = <TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync>(opts) => object;
 ```
 
-Defined in: [packages/vue-form/src/useField.tsx:166](https://github.com/TanStack/form/blob/main/packages/vue-form/src/useField.tsx#L166)
+Defined in: [packages/vue-form/src/useField.tsx:166](https://github.com/Pascalmh/tanstack-form/blob/main/packages/vue-form/src/useField.tsx#L166)
 
 ## Type Parameters
 

--- a/docs/framework/vue/reference/variables/field.md
+++ b/docs/framework/vue/reference/variables/field.md
@@ -11,7 +11,7 @@ title: Field
 const Field: <TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta>(props) => CreateComponentPublicInstanceWithMixins<UseFieldOptions<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta> & {} | {}, {}, {}, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, EmitsOptions, PublicProps, {}, false, {}, {}>;
 ```
 
-Defined in: [packages/vue-form/src/useField.tsx:442](https://github.com/TanStack/form/blob/main/packages/vue-form/src/useField.tsx#L442)
+Defined in: [packages/vue-form/src/useField.tsx:442](https://github.com/Pascalmh/tanstack-form/blob/main/packages/vue-form/src/useField.tsx#L442)
 
 ## Parameters
 

--- a/docs/reference/classes/fieldapi.md
+++ b/docs/reference/classes/fieldapi.md
@@ -7,7 +7,7 @@ title: FieldApi
 
 # Class: FieldApi\<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta\>
 
-Defined in: [packages/form-core/src/FieldApi.ts:863](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L863)
+Defined in: [packages/form-core/src/FieldApi.ts:863](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L863)
 
 A class representing the API for managing a form field.
 
@@ -65,7 +65,7 @@ the `new FieldApi` constructor.
 new FieldApi<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta>(opts): FieldApi<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta>
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:995](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L995)
+Defined in: [packages/form-core/src/FieldApi.ts:995](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L995)
 
 Initializes a new `FieldApi` instance.
 
@@ -87,7 +87,7 @@ Initializes a new `FieldApi` instance.
 form: FormApi<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:907](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L907)
+Defined in: [packages/form-core/src/FieldApi.ts:907](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L907)
 
 A reference to the form API instance.
 
@@ -99,7 +99,7 @@ A reference to the form API instance.
 name: DeepKeys<TParentData>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:931](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L931)
+Defined in: [packages/form-core/src/FieldApi.ts:931](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L931)
 
 The field name.
 
@@ -111,7 +111,7 @@ The field name.
 options: FieldApiOptions<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:935](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L935)
+Defined in: [packages/form-core/src/FieldApi.ts:935](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L935)
 
 The field options.
 
@@ -123,7 +123,7 @@ The field options.
 store: Derived<FieldState<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync>>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:959](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L959)
+Defined in: [packages/form-core/src/FieldApi.ts:959](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L959)
 
 The field state store.
 
@@ -135,7 +135,7 @@ The field state store.
 timeoutIds: object;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:986](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L986)
+Defined in: [packages/form-core/src/FieldApi.ts:986](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L986)
 
 #### formListeners
 
@@ -165,7 +165,7 @@ validations: Record<ValidationCause, null | Timeout>;
 get state(): FieldState<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync>
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:983](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L983)
+Defined in: [packages/form-core/src/FieldApi.ts:983](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L983)
 
 The current field state.
 
@@ -181,7 +181,7 @@ The current field state.
 getInfo(): FieldInfo<TParentData>
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:1249](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L1249)
+Defined in: [packages/form-core/src/FieldApi.ts:1249](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L1249)
 
 Gets the field information object.
 
@@ -197,7 +197,7 @@ Gets the field information object.
 getMeta(): FieldMeta<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync>
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:1217](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L1217)
+Defined in: [packages/form-core/src/FieldApi.ts:1217](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L1217)
 
 #### Returns
 
@@ -211,7 +211,7 @@ Defined in: [packages/form-core/src/FieldApi.ts:1217](https://github.com/TanStac
 getValue(): TData
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:1202](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L1202)
+Defined in: [packages/form-core/src/FieldApi.ts:1202](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L1202)
 
 Gets the current field value.
 
@@ -231,7 +231,7 @@ Use `field.state.value` instead.
 handleBlur(): void
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:1661](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L1661)
+Defined in: [packages/form-core/src/FieldApi.ts:1661](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L1661)
 
 Handles the blur event.
 
@@ -247,7 +247,7 @@ Handles the blur event.
 handleChange(updater): void
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:1654](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L1654)
+Defined in: [packages/form-core/src/FieldApi.ts:1654](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L1654)
 
 Handles the change event.
 
@@ -272,7 +272,7 @@ insertValue(
    opts?): void
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:1266](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L1266)
+Defined in: [packages/form-core/src/FieldApi.ts:1266](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L1266)
 
 Inserts a value at the specified index, shifting the subsequent values to the right.
 
@@ -302,7 +302,7 @@ Inserts a value at the specified index, shifting the subsequent values to the ri
 mount(): () => void
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:1092](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L1092)
+Defined in: [packages/form-core/src/FieldApi.ts:1092](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L1092)
 
 Mounts the field instance to the form.
 
@@ -325,7 +325,7 @@ moveValue(
    opts?): void
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:1310](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L1310)
+Defined in: [packages/form-core/src/FieldApi.ts:1310](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L1310)
 
 Moves the value at the first specified index to the second specified index.
 
@@ -357,7 +357,7 @@ parseValueWithSchema(schema):
   | StandardSchemaV1Issue[]
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:1703](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L1703)
+Defined in: [packages/form-core/src/FieldApi.ts:1703](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L1703)
 
 Parses the field's value with the given schema and returns
 issues (if any). This method does NOT set any internal errors.
@@ -385,7 +385,7 @@ parseValueWithSchemaAsync(schema): Promise<
 | StandardSchemaV1Issue[]>
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:1715](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L1715)
+Defined in: [packages/form-core/src/FieldApi.ts:1715](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L1715)
 
 Parses the field's value with the given schema and returns
 issues (if any). This method does NOT set any internal errors.
@@ -412,7 +412,7 @@ The standard schema to parse this field's value with.
 pushValue(value, opts?): void
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:1254](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L1254)
+Defined in: [packages/form-core/src/FieldApi.ts:1254](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L1254)
 
 Pushes a new value to the field.
 
@@ -438,7 +438,7 @@ Pushes a new value to the field.
 removeValue(index, opts?): void
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:1292](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L1292)
+Defined in: [packages/form-core/src/FieldApi.ts:1292](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L1292)
 
 Removes a value at the specified index.
 
@@ -467,7 +467,7 @@ replaceValue(
    opts?): void
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:1279](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L1279)
+Defined in: [packages/form-core/src/FieldApi.ts:1279](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L1279)
 
 Replaces a value at the specified index.
 
@@ -497,7 +497,7 @@ Replaces a value at the specified index.
 setErrorMap(errorMap): void
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:1678](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L1678)
+Defined in: [packages/form-core/src/FieldApi.ts:1678](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L1678)
 
 Updates the field's errorMap
 
@@ -519,7 +519,7 @@ Updates the field's errorMap
 setMeta(updater): void
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:1222](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L1222)
+Defined in: [packages/form-core/src/FieldApi.ts:1222](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L1222)
 
 Sets the field metadata.
 
@@ -541,7 +541,7 @@ Sets the field metadata.
 setValue(updater, options?): void
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:1209](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L1209)
+Defined in: [packages/form-core/src/FieldApi.ts:1209](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L1209)
 
 Sets the field value and run the `change` validator.
 
@@ -570,7 +570,7 @@ swapValues(
    opts?): void
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:1301](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L1301)
+Defined in: [packages/form-core/src/FieldApi.ts:1301](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L1301)
 
 Swaps the values at the specified indices.
 
@@ -600,7 +600,7 @@ Swaps the values at the specified indices.
 update(opts): void
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:1145](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L1145)
+Defined in: [packages/form-core/src/FieldApi.ts:1145](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L1145)
 
 Updates the field instance with new options.
 
@@ -622,7 +622,7 @@ Updates the field instance with new options.
 validate(cause, opts?): unknown[] | Promise<unknown[]>
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:1621](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L1621)
+Defined in: [packages/form-core/src/FieldApi.ts:1621](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L1621)
 
 Validates the field value.
 

--- a/docs/reference/classes/formapi.md
+++ b/docs/reference/classes/formapi.md
@@ -7,7 +7,7 @@ title: FormApi
 
 # Class: FormApi\<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer, TSubmitMeta\>
 
-Defined in: [packages/form-core/src/FormApi.ts:771](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L771)
+Defined in: [packages/form-core/src/FormApi.ts:771](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L771)
 
 A class representing the Form API. It handles the logic and interactions with the form state.
 
@@ -45,7 +45,7 @@ However, if you need to create a new instance manually, you can do so by calling
 new FormApi<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer, TSubmitMeta>(opts?): FormApi<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer, TSubmitMeta>
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:842](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L842)
+Defined in: [packages/form-core/src/FormApi.ts:842](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L842)
 
 Constructs a new `FormApi` instance with the given form options.
 
@@ -67,7 +67,7 @@ Constructs a new `FormApi` instance with the given form options.
 baseStore: Store<BaseFormState<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer>>;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:798](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L798)
+Defined in: [packages/form-core/src/FormApi.ts:798](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L798)
 
 ***
 
@@ -77,7 +77,7 @@ Defined in: [packages/form-core/src/FormApi.ts:798](https://github.com/TanStack/
 fieldInfo: Record<DeepKeys<TFormData>, FieldInfo<TFormData>>;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:828](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L828)
+Defined in: [packages/form-core/src/FormApi.ts:828](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L828)
 
 A record of field information for each field in the form.
 
@@ -89,7 +89,7 @@ A record of field information for each field in the form.
 fieldMetaDerived: Derived<Record<DeepKeys<TFormData>, AnyFieldMeta>>;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:811](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L811)
+Defined in: [packages/form-core/src/FormApi.ts:811](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L811)
 
 ***
 
@@ -99,7 +99,7 @@ Defined in: [packages/form-core/src/FormApi.ts:811](https://github.com/TanStack/
 options: FormOptions<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer, TSubmitMeta> = {};
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:786](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L786)
+Defined in: [packages/form-core/src/FormApi.ts:786](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L786)
 
 The options for the form.
 
@@ -111,7 +111,7 @@ The options for the form.
 store: Derived<FormState<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer>>;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:812](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L812)
+Defined in: [packages/form-core/src/FormApi.ts:812](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L812)
 
 ## Accessors
 
@@ -123,7 +123,7 @@ Defined in: [packages/form-core/src/FormApi.ts:812](https://github.com/TanStack/
 get state(): FormState<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer>
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:830](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L830)
+Defined in: [packages/form-core/src/FormApi.ts:830](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L830)
 
 ##### Returns
 
@@ -137,7 +137,7 @@ Defined in: [packages/form-core/src/FormApi.ts:830](https://github.com/TanStack/
 deleteField<TField>(field): void
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:1940](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L1940)
+Defined in: [packages/form-core/src/FormApi.ts:1940](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L1940)
 
 #### Type Parameters
 
@@ -161,7 +161,7 @@ Defined in: [packages/form-core/src/FormApi.ts:1940](https://github.com/TanStack
 getAllErrors(): object
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:2214](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L2214)
+Defined in: [packages/form-core/src/FormApi.ts:2214](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L2214)
 
 Returns form and field level errors
 
@@ -212,7 +212,7 @@ errors: (
 getFieldInfo<TField>(field): FieldInfo<TFormData>
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:1854](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L1854)
+Defined in: [packages/form-core/src/FormApi.ts:1854](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L1854)
 
 Gets the field info of the specified field.
 
@@ -238,7 +238,7 @@ Gets the field info of the specified field.
 getFieldMeta<TField>(field): undefined | AnyFieldMeta
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:1845](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L1845)
+Defined in: [packages/form-core/src/FormApi.ts:1845](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L1845)
 
 Gets the metadata of the specified field.
 
@@ -264,7 +264,7 @@ Gets the metadata of the specified field.
 getFieldValue<TField>(field): DeepValue<TFormData, TField>
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:1838](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L1838)
+Defined in: [packages/form-core/src/FormApi.ts:1838](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L1838)
 
 Gets the value of the specified field.
 
@@ -292,7 +292,7 @@ Gets the value of the specified field.
 handleSubmit(): Promise<void>
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:1740](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L1740)
+Defined in: [packages/form-core/src/FormApi.ts:1740](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L1740)
 
 Handles the form submission, performs validation, and calls the appropriate onSubmit or onSubmitInvalid callbacks.
 
@@ -306,7 +306,7 @@ Handles the form submission, performs validation, and calls the appropriate onSu
 handleSubmit(submitMeta): Promise<void>
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:1741](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L1741)
+Defined in: [packages/form-core/src/FormApi.ts:1741](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L1741)
 
 Handles the form submission, performs validation, and calls the appropriate onSubmit or onSubmitInvalid callbacks.
 
@@ -332,7 +332,7 @@ insertFieldValue<TField>(
 opts?): Promise<void>
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:1979](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L1979)
+Defined in: [packages/form-core/src/FormApi.ts:1979](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L1979)
 
 #### Type Parameters
 
@@ -368,7 +368,7 @@ Defined in: [packages/form-core/src/FormApi.ts:1979](https://github.com/TanStack
 mount(): () => void
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:1168](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L1168)
+Defined in: [packages/form-core/src/FormApi.ts:1168](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L1168)
 
 #### Returns
 
@@ -390,7 +390,7 @@ moveFieldValues<TField>(
    opts?): void
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:2103](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L2103)
+Defined in: [packages/form-core/src/FormApi.ts:2103](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L2103)
 
 Moves the value at the first specified index to the second specified index within an array field.
 
@@ -433,7 +433,7 @@ parseValuesWithSchema(schema):
 }
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:2274](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L2274)
+Defined in: [packages/form-core/src/FormApi.ts:2274](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L2274)
 
 Parses the form's values with a given standard schema and returns
 issues (if any). This method does NOT set any internal errors.
@@ -467,7 +467,7 @@ parseValuesWithSchemaAsync(schema): Promise<
 }>
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:2286](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L2286)
+Defined in: [packages/form-core/src/FormApi.ts:2286](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L2286)
 
 Parses the form's values with a given standard schema and returns
 issues (if any). This method does NOT set any internal errors.
@@ -500,7 +500,7 @@ pushFieldValue<TField>(
    opts?): void
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:1964](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L1964)
+Defined in: [packages/form-core/src/FormApi.ts:1964](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L1964)
 
 Pushes a value into an array field.
 
@@ -537,7 +537,7 @@ removeFieldValue<TField>(
 opts?): Promise<void>
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:2037](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L2037)
+Defined in: [packages/form-core/src/FormApi.ts:2037](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L2037)
 
 Removes a value from an array field at the specified index.
 
@@ -575,7 +575,7 @@ replaceFieldValue<TField>(
 opts?): Promise<void>
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:2011](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L2011)
+Defined in: [packages/form-core/src/FormApi.ts:2011](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L2011)
 
 Replaces a value into an array field at the specified index.
 
@@ -613,7 +613,7 @@ Replaces a value into an array field at the specified index.
 reset(values?, opts?): void
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:1256](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L1256)
+Defined in: [packages/form-core/src/FormApi.ts:1256](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L1256)
 
 Resets the form state to the default values.
 If values are provided, the form will be reset to those values instead and the default values will be updated.
@@ -646,7 +646,7 @@ Optional options to control the reset behavior.
 resetField<TField>(field): void
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:2131](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L2131)
+Defined in: [packages/form-core/src/FormApi.ts:2131](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L2131)
 
 Resets the field value and meta to default state
 
@@ -672,7 +672,7 @@ Resets the field value and meta to default state
 resetFieldMeta<TField>(fieldMeta): Record<TField, AnyFieldMeta>
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:1894](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L1894)
+Defined in: [packages/form-core/src/FormApi.ts:1894](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L1894)
 
 resets every field's meta
 
@@ -698,7 +698,7 @@ resets every field's meta
 setErrorMap(errorMap): void
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:2152](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L2152)
+Defined in: [packages/form-core/src/FormApi.ts:2152](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L2152)
 
 Updates the form's errorMap
 
@@ -720,7 +720,7 @@ Updates the form's errorMap
 setFieldMeta<TField>(field, updater): void
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:1873](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L1873)
+Defined in: [packages/form-core/src/FormApi.ts:1873](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L1873)
 
 Updates the metadata of the specified field.
 
@@ -753,7 +753,7 @@ setFieldValue<TField>(
    opts?): void
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:1910](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L1910)
+Defined in: [packages/form-core/src/FormApi.ts:1910](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L1910)
 
 Sets the value of the specified field and optionally updates the touched state.
 
@@ -791,7 +791,7 @@ swapFieldValues<TField>(
    opts?): void
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:2074](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L2074)
+Defined in: [packages/form-core/src/FormApi.ts:2074](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L2074)
 
 Swaps the values at the specified indices within an array field.
 
@@ -829,7 +829,7 @@ Swaps the values at the specified indices within an array field.
 update(options?): void
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:1188](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L1188)
+Defined in: [packages/form-core/src/FormApi.ts:1188](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L1188)
 
 Updates the form options and form state.
 
@@ -851,7 +851,7 @@ Updates the form options and form state.
 validateAllFields(cause): Promise<unknown[]>
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:1282](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L1282)
+Defined in: [packages/form-core/src/FormApi.ts:1282](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L1282)
 
 Validates all fields using the correct handlers for a given validation cause.
 
@@ -876,7 +876,7 @@ validateArrayFieldsStartingFrom<TField>(
 cause): Promise<unknown[]>
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:1312](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L1312)
+Defined in: [packages/form-core/src/FormApi.ts:1312](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L1312)
 
 Validates the children of a specified array in the form starting from a given index until the end using the correct handlers for a given validation type.
 
@@ -910,7 +910,7 @@ Validates the children of a specified array in the form starting from a given in
 validateField<TField>(field, cause): unknown[] | Promise<unknown[]>
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:1353](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L1353)
+Defined in: [packages/form-core/src/FormApi.ts:1353](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L1353)
 
 Validates a specified field in the form using the correct handlers for a given validation type.
 

--- a/docs/reference/functions/evaluate.md
+++ b/docs/reference/functions/evaluate.md
@@ -11,7 +11,7 @@ title: evaluate
 function evaluate<T>(objA, objB): boolean
 ```
 
-Defined in: [packages/form-core/src/utils.ts:339](https://github.com/TanStack/form/blob/main/packages/form-core/src/utils.ts#L339)
+Defined in: [packages/form-core/src/utils.ts:339](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/utils.ts#L339)
 
 ## Type Parameters
 

--- a/docs/reference/functions/formoptions.md
+++ b/docs/reference/functions/formoptions.md
@@ -11,7 +11,7 @@ title: formOptions
 function formOptions<T>(defaultOpts): T
 ```
 
-Defined in: [packages/form-core/src/formOptions.ts:3](https://github.com/TanStack/form/blob/main/packages/form-core/src/formOptions.ts#L3)
+Defined in: [packages/form-core/src/formOptions.ts:3](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/formOptions.ts#L3)
 
 ## Type Parameters
 

--- a/docs/reference/functions/isglobalformvalidationerror.md
+++ b/docs/reference/functions/isglobalformvalidationerror.md
@@ -11,7 +11,7 @@ title: isGlobalFormValidationError
 function isGlobalFormValidationError(error): error is GlobalFormValidationError<unknown>
 ```
 
-Defined in: [packages/form-core/src/utils.ts:333](https://github.com/TanStack/form/blob/main/packages/form-core/src/utils.ts#L333)
+Defined in: [packages/form-core/src/utils.ts:333](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/utils.ts#L333)
 
 ## Parameters
 

--- a/docs/reference/functions/isstandardschemavalidator.md
+++ b/docs/reference/functions/isstandardschemavalidator.md
@@ -11,7 +11,7 @@ title: isStandardSchemaValidator
 function isStandardSchemaValidator(validator): validator is StandardSchemaV1<unknown, unknown>
 ```
 
-Defined in: [packages/form-core/src/standardSchemaValidator.ts:90](https://github.com/TanStack/form/blob/main/packages/form-core/src/standardSchemaValidator.ts#L90)
+Defined in: [packages/form-core/src/standardSchemaValidator.ts:90](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/standardSchemaValidator.ts#L90)
 
 ## Parameters
 

--- a/docs/reference/functions/mergeform.md
+++ b/docs/reference/functions/mergeform.md
@@ -11,7 +11,7 @@ title: mergeForm
 function mergeForm<TFormData>(baseForm, state): FormApi<NoInfer<TFormData>, any, any, any, any, any, any, any, any, any>
 ```
 
-Defined in: [packages/form-core/src/mergeForm.ts:73](https://github.com/TanStack/form/blob/main/packages/form-core/src/mergeForm.ts#L73)
+Defined in: [packages/form-core/src/mergeForm.ts:73](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/mergeForm.ts#L73)
 
 ## Type Parameters
 

--- a/docs/reference/interfaces/anydeepkeyandvalue.md
+++ b/docs/reference/interfaces/anydeepkeyandvalue.md
@@ -7,7 +7,7 @@ title: AnyDeepKeyAndValue
 
 # Interface: AnyDeepKeyAndValue\<K, V\>
 
-Defined in: [packages/form-core/src/util-types.ts:22](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L22)
+Defined in: [packages/form-core/src/util-types.ts:22](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L22)
 
 ## Extended by
 
@@ -30,7 +30,7 @@ Defined in: [packages/form-core/src/util-types.ts:22](https://github.com/TanStac
 key: K;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:26](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L26)
+Defined in: [packages/form-core/src/util-types.ts:26](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L26)
 
 ***
 
@@ -40,4 +40,4 @@ Defined in: [packages/form-core/src/util-types.ts:26](https://github.com/TanStac
 value: V;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:27](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L27)
+Defined in: [packages/form-core/src/util-types.ts:27](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L27)

--- a/docs/reference/interfaces/arraydeepkeyandvalue.md
+++ b/docs/reference/interfaces/arraydeepkeyandvalue.md
@@ -7,7 +7,7 @@ title: ArrayDeepKeyAndValue
 
 # Interface: ArrayDeepKeyAndValue\<TParent, T\>
 
-Defined in: [packages/form-core/src/util-types.ts:33](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L33)
+Defined in: [packages/form-core/src/util-types.ts:33](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L33)
 
 ## Extends
 
@@ -27,7 +27,7 @@ Defined in: [packages/form-core/src/util-types.ts:33](https://github.com/TanStac
 key: `${TParent["key"] extends never ? "" : TParent["key"]}[${number}]`;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:37](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L37)
+Defined in: [packages/form-core/src/util-types.ts:37](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L37)
 
 #### Overrides
 
@@ -43,7 +43,7 @@ value:
 | Nullable<TParent["value"]>;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:38](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L38)
+Defined in: [packages/form-core/src/util-types.ts:38](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L38)
 
 #### Overrides
 

--- a/docs/reference/interfaces/fieldapioptions.md
+++ b/docs/reference/interfaces/fieldapioptions.md
@@ -7,7 +7,7 @@ title: FieldApiOptions
 
 # Interface: FieldApiOptions\<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta\>
 
-Defined in: [packages/form-core/src/FieldApi.ts:455](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L455)
+Defined in: [packages/form-core/src/FieldApi.ts:455](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L455)
 
 An object type representing the required options for the FieldApi class.
 
@@ -63,7 +63,7 @@ An object type representing the required options for the FieldApi class.
 optional asyncAlways: boolean;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:402](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L402)
+Defined in: [packages/form-core/src/FieldApi.ts:402](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L402)
 
 If `true`, always run async validation, even if there are errors emitted during synchronous validation.
 
@@ -79,7 +79,7 @@ If `true`, always run async validation, even if there are errors emitted during 
 optional asyncDebounceMs: number;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:398](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L398)
+Defined in: [packages/form-core/src/FieldApi.ts:398](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L398)
 
 The default time to debounce async validation if there is not a more specific debounce time passed.
 
@@ -95,7 +95,7 @@ The default time to debounce async validation if there is not a more specific de
 optional defaultMeta: Partial<FieldMeta<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, any, any, any, any, any, any, any>>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:421](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L421)
+Defined in: [packages/form-core/src/FieldApi.ts:421](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L421)
 
 An optional object with default metadata for the field.
 
@@ -111,7 +111,7 @@ An optional object with default metadata for the field.
 optional defaultValue: NoInfer<TData>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:394](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L394)
+Defined in: [packages/form-core/src/FieldApi.ts:394](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L394)
 
 An optional default value for the field.
 
@@ -127,7 +127,7 @@ An optional default value for the field.
 optional disableErrorFlat: boolean;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:449](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L449)
+Defined in: [packages/form-core/src/FieldApi.ts:449](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L449)
 
 Disable the `flat(1)` operation on `field.errors`. This is useful if you want to keep the error structure as is. Not suggested for most use-cases.
 
@@ -143,7 +143,7 @@ Disable the `flat(1)` operation on `field.errors`. This is useful if you want to
 form: FormApi<TParentData, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync, TFormOnServer, TParentSubmitMeta>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:507](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L507)
+Defined in: [packages/form-core/src/FieldApi.ts:507](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L507)
 
 ***
 
@@ -153,7 +153,7 @@ Defined in: [packages/form-core/src/FieldApi.ts:507](https://github.com/TanStack
 optional listeners: FieldListeners<TParentData, TName, TData>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:445](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L445)
+Defined in: [packages/form-core/src/FieldApi.ts:445](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L445)
 
 A list of listeners which attach to the corresponding events
 
@@ -169,7 +169,7 @@ A list of listeners which attach to the corresponding events
 name: TName;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:390](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L390)
+Defined in: [packages/form-core/src/FieldApi.ts:390](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L390)
 
 The field name. The type will be `DeepKeys<TParentData>` to ensure your name is a deep key of the parent dataset.
 
@@ -185,7 +185,7 @@ The field name. The type will be `DeepKeys<TParentData>` to ensure your name is 
 optional validators: FieldValidators<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:406](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L406)
+Defined in: [packages/form-core/src/FieldApi.ts:406](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L406)
 
 A list of validators to pass to the field
 

--- a/docs/reference/interfaces/fieldlisteners.md
+++ b/docs/reference/interfaces/fieldlisteners.md
@@ -7,7 +7,7 @@ title: FieldListeners
 
 # Interface: FieldListeners\<TParentData, TName, TData\>
 
-Defined in: [packages/form-core/src/FieldApi.ts:353](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L353)
+Defined in: [packages/form-core/src/FieldApi.ts:353](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L353)
 
 ## Type Parameters
 
@@ -25,7 +25,7 @@ Defined in: [packages/form-core/src/FieldApi.ts:353](https://github.com/TanStack
 optional onBlur: FieldListenerFn<TParentData, TName, TData>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:360](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L360)
+Defined in: [packages/form-core/src/FieldApi.ts:360](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L360)
 
 ***
 
@@ -35,7 +35,7 @@ Defined in: [packages/form-core/src/FieldApi.ts:360](https://github.com/TanStack
 optional onBlurDebounceMs: number;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:361](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L361)
+Defined in: [packages/form-core/src/FieldApi.ts:361](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L361)
 
 ***
 
@@ -45,7 +45,7 @@ Defined in: [packages/form-core/src/FieldApi.ts:361](https://github.com/TanStack
 optional onChange: FieldListenerFn<TParentData, TName, TData>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:358](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L358)
+Defined in: [packages/form-core/src/FieldApi.ts:358](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L358)
 
 ***
 
@@ -55,7 +55,7 @@ Defined in: [packages/form-core/src/FieldApi.ts:358](https://github.com/TanStack
 optional onChangeDebounceMs: number;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:359](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L359)
+Defined in: [packages/form-core/src/FieldApi.ts:359](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L359)
 
 ***
 
@@ -65,7 +65,7 @@ Defined in: [packages/form-core/src/FieldApi.ts:359](https://github.com/TanStack
 optional onMount: FieldListenerFn<TParentData, TName, TData>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:362](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L362)
+Defined in: [packages/form-core/src/FieldApi.ts:362](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L362)
 
 ***
 
@@ -75,4 +75,4 @@ Defined in: [packages/form-core/src/FieldApi.ts:362](https://github.com/TanStack
 optional onSubmit: FieldListenerFn<TParentData, TName, TData>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:363](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L363)
+Defined in: [packages/form-core/src/FieldApi.ts:363](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L363)

--- a/docs/reference/interfaces/fieldoptions.md
+++ b/docs/reference/interfaces/fieldoptions.md
@@ -7,7 +7,7 @@ title: FieldOptions
 
 # Interface: FieldOptions\<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync\>
 
-Defined in: [packages/form-core/src/FieldApi.ts:369](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L369)
+Defined in: [packages/form-core/src/FieldApi.ts:369](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L369)
 
 An object type representing the options for a field in a form.
 
@@ -45,7 +45,7 @@ An object type representing the options for a field in a form.
 optional asyncAlways: boolean;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:402](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L402)
+Defined in: [packages/form-core/src/FieldApi.ts:402](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L402)
 
 If `true`, always run async validation, even if there are errors emitted during synchronous validation.
 
@@ -57,7 +57,7 @@ If `true`, always run async validation, even if there are errors emitted during 
 optional asyncDebounceMs: number;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:398](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L398)
+Defined in: [packages/form-core/src/FieldApi.ts:398](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L398)
 
 The default time to debounce async validation if there is not a more specific debounce time passed.
 
@@ -69,7 +69,7 @@ The default time to debounce async validation if there is not a more specific de
 optional defaultMeta: Partial<FieldMeta<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, any, any, any, any, any, any, any>>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:421](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L421)
+Defined in: [packages/form-core/src/FieldApi.ts:421](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L421)
 
 An optional object with default metadata for the field.
 
@@ -81,7 +81,7 @@ An optional object with default metadata for the field.
 optional defaultValue: NoInfer<TData>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:394](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L394)
+Defined in: [packages/form-core/src/FieldApi.ts:394](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L394)
 
 An optional default value for the field.
 
@@ -93,7 +93,7 @@ An optional default value for the field.
 optional disableErrorFlat: boolean;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:449](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L449)
+Defined in: [packages/form-core/src/FieldApi.ts:449](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L449)
 
 Disable the `flat(1)` operation on `field.errors`. This is useful if you want to keep the error structure as is. Not suggested for most use-cases.
 
@@ -105,7 +105,7 @@ Disable the `flat(1)` operation on `field.errors`. This is useful if you want to
 optional listeners: FieldListeners<TParentData, TName, TData>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:445](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L445)
+Defined in: [packages/form-core/src/FieldApi.ts:445](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L445)
 
 A list of listeners which attach to the corresponding events
 
@@ -117,7 +117,7 @@ A list of listeners which attach to the corresponding events
 name: TName;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:390](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L390)
+Defined in: [packages/form-core/src/FieldApi.ts:390](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L390)
 
 The field name. The type will be `DeepKeys<TParentData>` to ensure your name is a deep key of the parent dataset.
 
@@ -129,6 +129,6 @@ The field name. The type will be `DeepKeys<TParentData>` to ensure your name is 
 optional validators: FieldValidators<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:406](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L406)
+Defined in: [packages/form-core/src/FieldApi.ts:406](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L406)
 
 A list of validators to pass to the field

--- a/docs/reference/interfaces/fieldvalidators.md
+++ b/docs/reference/interfaces/fieldvalidators.md
@@ -7,7 +7,7 @@ title: FieldValidators
 
 # Interface: FieldValidators\<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync\>
 
-Defined in: [packages/form-core/src/FieldApi.ts:272](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L272)
+Defined in: [packages/form-core/src/FieldApi.ts:272](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L272)
 
 ## Type Parameters
 
@@ -39,7 +39,7 @@ Defined in: [packages/form-core/src/FieldApi.ts:272](https://github.com/TanStack
 optional onBlur: TOnBlur;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:321](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L321)
+Defined in: [packages/form-core/src/FieldApi.ts:321](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L321)
 
 An optional function, that runs on the blur event of input.
 
@@ -57,7 +57,7 @@ z.string().min(1)
 optional onBlurAsync: TOnBlurAsync;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:327](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L327)
+Defined in: [packages/form-core/src/FieldApi.ts:327](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L327)
 
 An optional property similar to `onBlur` but async validation.
 
@@ -75,7 +75,7 @@ z.string().refine(async (val) => val.length > 3, { message: 'Testing 123' })
 optional onBlurAsyncDebounceMs: number;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:334](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L334)
+Defined in: [packages/form-core/src/FieldApi.ts:334](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L334)
 
 An optional number to represent how long the `onBlurAsync` should wait before running
 
@@ -89,7 +89,7 @@ If set to a number larger than 0, will debounce the async validation event by th
 optional onBlurListenTo: DeepKeys<TParentData>[];
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:338](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L338)
+Defined in: [packages/form-core/src/FieldApi.ts:338](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L338)
 
 An optional list of field names that should trigger this field's `onBlur` and `onBlurAsync` events when its value changes
 
@@ -101,7 +101,7 @@ An optional list of field names that should trigger this field's `onBlur` and `o
 optional onChange: TOnChange;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:299](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L299)
+Defined in: [packages/form-core/src/FieldApi.ts:299](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L299)
 
 An optional function, that runs on the change event of input.
 
@@ -119,7 +119,7 @@ z.string().min(1)
 optional onChangeAsync: TOnChangeAsync;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:305](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L305)
+Defined in: [packages/form-core/src/FieldApi.ts:305](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L305)
 
 An optional property similar to `onChange` but async validation
 
@@ -137,7 +137,7 @@ z.string().refine(async (val) => val.length > 3, { message: 'Testing 123' })
 optional onChangeAsyncDebounceMs: number;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:311](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L311)
+Defined in: [packages/form-core/src/FieldApi.ts:311](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L311)
 
 An optional number to represent how long the `onChangeAsync` should wait before running
 
@@ -151,7 +151,7 @@ If set to a number larger than 0, will debounce the async validation event by th
 optional onChangeListenTo: DeepKeys<TParentData>[];
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:315](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L315)
+Defined in: [packages/form-core/src/FieldApi.ts:315](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L315)
 
 An optional list of field names that should trigger this field's `onChange` and `onChangeAsync` events when its value changes
 
@@ -163,7 +163,7 @@ An optional list of field names that should trigger this field's `onChange` and 
 optional onMount: TOnMount;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:293](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L293)
+Defined in: [packages/form-core/src/FieldApi.ts:293](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L293)
 
 An optional function, that runs on the mount event of input.
 
@@ -175,7 +175,7 @@ An optional function, that runs on the mount event of input.
 optional onSubmit: TOnSubmit;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:344](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L344)
+Defined in: [packages/form-core/src/FieldApi.ts:344](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L344)
 
 An optional function, that runs on the submit event of form.
 
@@ -193,7 +193,7 @@ z.string().min(1)
 optional onSubmitAsync: TOnSubmitAsync;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:350](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L350)
+Defined in: [packages/form-core/src/FieldApi.ts:350](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L350)
 
 An optional property similar to `onSubmit` but async validation.
 

--- a/docs/reference/interfaces/formlisteners.md
+++ b/docs/reference/interfaces/formlisteners.md
@@ -7,7 +7,7 @@ title: FormListeners
 
 # Interface: FormListeners\<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer, TSubmitMeta\>
 
-Defined in: [packages/form-core/src/FormApi.ts:241](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L241)
+Defined in: [packages/form-core/src/FormApi.ts:241](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L241)
 
 ## Type Parameters
 
@@ -39,7 +39,7 @@ Defined in: [packages/form-core/src/FormApi.ts:241](https://github.com/TanStack/
 optional onBlur: (props) => void;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:270](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L270)
+Defined in: [packages/form-core/src/FormApi.ts:270](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L270)
 
 #### Parameters
 
@@ -65,7 +65,7 @@ Defined in: [packages/form-core/src/FormApi.ts:270](https://github.com/TanStack/
 optional onBlurDebounceMs: number;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:285](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L285)
+Defined in: [packages/form-core/src/FormApi.ts:285](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L285)
 
 ***
 
@@ -75,7 +75,7 @@ Defined in: [packages/form-core/src/FormApi.ts:285](https://github.com/TanStack/
 optional onChange: (props) => void;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:253](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L253)
+Defined in: [packages/form-core/src/FormApi.ts:253](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L253)
 
 #### Parameters
 
@@ -101,7 +101,7 @@ Defined in: [packages/form-core/src/FormApi.ts:253](https://github.com/TanStack/
 optional onChangeDebounceMs: number;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:268](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L268)
+Defined in: [packages/form-core/src/FormApi.ts:268](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L268)
 
 ***
 
@@ -111,7 +111,7 @@ Defined in: [packages/form-core/src/FormApi.ts:268](https://github.com/TanStack/
 optional onMount: (props) => void;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:287](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L287)
+Defined in: [packages/form-core/src/FormApi.ts:287](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L287)
 
 #### Parameters
 
@@ -133,7 +133,7 @@ Defined in: [packages/form-core/src/FormApi.ts:287](https://github.com/TanStack/
 optional onSubmit: (props) => void;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:302](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L302)
+Defined in: [packages/form-core/src/FormApi.ts:302](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L302)
 
 #### Parameters
 

--- a/docs/reference/interfaces/formoptions.md
+++ b/docs/reference/interfaces/formoptions.md
@@ -7,7 +7,7 @@ title: FormOptions
 
 # Interface: FormOptions\<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer, TSubmitMeta\>
 
-Defined in: [packages/form-core/src/FormApi.ts:321](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L321)
+Defined in: [packages/form-core/src/FormApi.ts:321](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L321)
 
 An object representing the options for a form.
 
@@ -41,7 +41,7 @@ An object representing the options for a form.
 optional asyncAlways: boolean;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:356](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L356)
+Defined in: [packages/form-core/src/FormApi.ts:356](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L356)
 
 If true, always run async validation, even when sync validation has produced an error. Defaults to undefined.
 
@@ -53,7 +53,7 @@ If true, always run async validation, even when sync validation has produced an 
 optional asyncDebounceMs: number;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:360](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L360)
+Defined in: [packages/form-core/src/FormApi.ts:360](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L360)
 
 Optional time in milliseconds if you want to introduce a delay before firing off an async action.
 
@@ -65,7 +65,7 @@ Optional time in milliseconds if you want to introduce a delay before firing off
 optional canSubmitWhenInvalid: boolean;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:364](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L364)
+Defined in: [packages/form-core/src/FormApi.ts:364](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L364)
 
 If true, allows the form to be submitted in an invalid state i.e. canSubmit will remain true regardless of validation errors. Defaults to undefined.
 
@@ -77,7 +77,7 @@ If true, allows the form to be submitted in an invalid state i.e. canSubmit will
 optional defaultState: Partial<FormState<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer>>;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:340](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L340)
+Defined in: [packages/form-core/src/FormApi.ts:340](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L340)
 
 The default state for the form.
 
@@ -89,7 +89,7 @@ The default state for the form.
 optional defaultValues: TFormData;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:336](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L336)
+Defined in: [packages/form-core/src/FormApi.ts:336](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L336)
 
 Set initial values for your form.
 
@@ -101,7 +101,7 @@ Set initial values for your form.
 optional listeners: FormListeners<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer, TSubmitMeta>;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:387](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L387)
+Defined in: [packages/form-core/src/FormApi.ts:387](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L387)
 
 form level listeners
 
@@ -113,7 +113,7 @@ form level listeners
 optional onSubmit: (props) => any;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:403](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L403)
+Defined in: [packages/form-core/src/FormApi.ts:403](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L403)
 
 A function to be called when the form is submitted, what should happen once the user submits a valid form returns `any` or a promise `Promise<any>`
 
@@ -145,7 +145,7 @@ A function to be called when the form is submitted, what should happen once the 
 optional onSubmitInvalid: (props) => void;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:422](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L422)
+Defined in: [packages/form-core/src/FormApi.ts:422](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L422)
 
 Specify an action for scenarios where the user tries to submit an invalid form.
 
@@ -173,7 +173,7 @@ Specify an action for scenarios where the user tries to submit an invalid form.
 optional onSubmitMeta: TSubmitMeta;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:382](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L382)
+Defined in: [packages/form-core/src/FormApi.ts:382](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L382)
 
 onSubmitMeta, the data passed from the handleSubmit handler, to the onSubmit function props
 
@@ -185,7 +185,7 @@ onSubmitMeta, the data passed from the handleSubmit handler, to the onSubmit fun
 optional transform: FormTransform<NoInfer<TFormData>, NoInfer<TOnMount>, NoInfer<TOnChange>, NoInfer<TOnChangeAsync>, NoInfer<TOnBlur>, NoInfer<TOnBlurAsync>, NoInfer<TOnSubmit>, NoInfer<TOnSubmitAsync>, NoInfer<TOnServer>, NoInfer<TSubmitMeta>>;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:437](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L437)
+Defined in: [packages/form-core/src/FormApi.ts:437](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L437)
 
 ***
 
@@ -195,6 +195,6 @@ Defined in: [packages/form-core/src/FormApi.ts:437](https://github.com/TanStack/
 optional validators: FormValidators<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync>;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:368](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L368)
+Defined in: [packages/form-core/src/FormApi.ts:368](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L368)
 
 A list of validators to pass to the form

--- a/docs/reference/interfaces/formstate.md
+++ b/docs/reference/interfaces/formstate.md
@@ -7,7 +7,7 @@ title: FormState
 
 # Interface: FormState\<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer\>
 
-Defined in: [packages/form-core/src/FormApi.ts:647](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L647)
+Defined in: [packages/form-core/src/FormApi.ts:647](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L647)
 
 An object representing the current state of the form.
 
@@ -43,7 +43,7 @@ An object representing the current state of the form.
 optional _force_re_eval: boolean;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:570](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L570)
+Defined in: [packages/form-core/src/FormApi.ts:570](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L570)
 
 @private, used to force a re-evaluation of the form state when options change
 
@@ -61,7 +61,7 @@ BaseFormState._force_re_eval
 canSubmit: boolean;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:640](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L640)
+Defined in: [packages/form-core/src/FormApi.ts:640](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L640)
 
 A boolean indicating if the form can be submitted based on its current state.
 
@@ -79,7 +79,7 @@ DerivedFormState.canSubmit
 errorMap: ValidationErrorMap<UnwrapFormValidateOrFn<TOnMount>, UnwrapFormValidateOrFn<TOnChange>, UnwrapFormAsyncValidateOrFn<TOnChangeAsync>, UnwrapFormValidateOrFn<TOnBlur>, UnwrapFormAsyncValidateOrFn<TOnBlurAsync>, UnwrapFormValidateOrFn<TOnSubmit>, UnwrapFormAsyncValidateOrFn<TOnSubmitAsync>, UnwrapFormAsyncValidateOrFn<TOnServer>>;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:516](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L516)
+Defined in: [packages/form-core/src/FormApi.ts:516](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L516)
 
 The error map for the form itself.
 
@@ -105,7 +105,7 @@ errors: (
   | UnwrapFormAsyncValidateOrFn<TOnServer>)[];
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:595](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L595)
+Defined in: [packages/form-core/src/FormApi.ts:595](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L595)
 
 The error array for the form itself.
 
@@ -123,7 +123,7 @@ DerivedFormState.errors
 fieldMeta: Record<DeepKeys<TFormData>, AnyFieldMeta>;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:644](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L644)
+Defined in: [packages/form-core/src/FormApi.ts:644](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L644)
 
 A record of field metadata for each field in the form.
 
@@ -141,7 +141,7 @@ DerivedFormState.fieldMeta
 fieldMetaBase: Record<DeepKeys<TFormData>, AnyFieldMetaBase>;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:533](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L533)
+Defined in: [packages/form-core/src/FormApi.ts:533](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L533)
 
 A record of field metadata for each field in the form, not including the derived properties, like `errors` and such
 
@@ -159,7 +159,7 @@ BaseFormState.fieldMetaBase
 isBlurred: boolean;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:620](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L620)
+Defined in: [packages/form-core/src/FormApi.ts:620](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L620)
 
 A boolean indicating if any of the form fields have been blurred.
 
@@ -177,7 +177,7 @@ DerivedFormState.isBlurred
 isDefaultValue: boolean;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:632](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L632)
+Defined in: [packages/form-core/src/FormApi.ts:632](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L632)
 
 A boolean indicating if all of the form's fields are the same as default values.
 
@@ -195,7 +195,7 @@ DerivedFormState.isDefaultValue
 isDirty: boolean;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:624](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L624)
+Defined in: [packages/form-core/src/FormApi.ts:624](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L624)
 
 A boolean indicating if any of the form's fields' values have been modified by the user. Evaluates `true` if the user have modified at least one of the fields. Opposite of `isPristine`.
 
@@ -213,7 +213,7 @@ DerivedFormState.isDirty
 isFieldsValid: boolean;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:612](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L612)
+Defined in: [packages/form-core/src/FormApi.ts:612](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L612)
 
 A boolean indicating if all the form fields are valid. Evaluates `true` if there are no field errors.
 
@@ -231,7 +231,7 @@ DerivedFormState.isFieldsValid
 isFieldsValidating: boolean;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:608](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L608)
+Defined in: [packages/form-core/src/FormApi.ts:608](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L608)
 
 A boolean indicating if any of the form fields are currently validating.
 
@@ -249,7 +249,7 @@ DerivedFormState.isFieldsValidating
 isFormValid: boolean;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:591](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L591)
+Defined in: [packages/form-core/src/FormApi.ts:591](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L591)
 
 A boolean indicating if the form is valid.
 
@@ -267,7 +267,7 @@ DerivedFormState.isFormValid
 isFormValidating: boolean;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:587](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L587)
+Defined in: [packages/form-core/src/FormApi.ts:587](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L587)
 
 A boolean indicating if the form is currently validating.
 
@@ -285,7 +285,7 @@ DerivedFormState.isFormValidating
 isPristine: boolean;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:628](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L628)
+Defined in: [packages/form-core/src/FormApi.ts:628](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L628)
 
 A boolean indicating if none of the form's fields' values have been modified by the user. Evaluates `true` if the user have not modified any of the fields. Opposite of `isDirty`.
 
@@ -303,7 +303,7 @@ DerivedFormState.isPristine
 isSubmitSuccessful: boolean;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:566](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L566)
+Defined in: [packages/form-core/src/FormApi.ts:566](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L566)
 
 A boolean indicating if the last submission was successful.
 
@@ -321,7 +321,7 @@ BaseFormState.isSubmitSuccessful
 isSubmitted: boolean;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:554](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L554)
+Defined in: [packages/form-core/src/FormApi.ts:554](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L554)
 
 A boolean indicating if the `onSubmit` function has completed successfully.
 
@@ -343,7 +343,7 @@ BaseFormState.isSubmitted
 isSubmitting: boolean;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:546](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L546)
+Defined in: [packages/form-core/src/FormApi.ts:546](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L546)
 
 A boolean indicating if the form is currently in the process of being submitted after `handleSubmit` is called.
 
@@ -369,7 +369,7 @@ BaseFormState.isSubmitting
 isTouched: boolean;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:616](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L616)
+Defined in: [packages/form-core/src/FormApi.ts:616](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L616)
 
 A boolean indicating if any of the form fields have been touched.
 
@@ -387,7 +387,7 @@ DerivedFormState.isTouched
 isValid: boolean;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:636](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L636)
+Defined in: [packages/form-core/src/FormApi.ts:636](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L636)
 
 A boolean indicating if the form and all its fields are valid. Evaluates `true` if there are no errors.
 
@@ -405,7 +405,7 @@ DerivedFormState.isValid
 isValidating: boolean;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:558](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L558)
+Defined in: [packages/form-core/src/FormApi.ts:558](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L558)
 
 A boolean indicating if the form or any of its fields are currently validating.
 
@@ -423,7 +423,7 @@ BaseFormState.isValidating
 submissionAttempts: number;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:562](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L562)
+Defined in: [packages/form-core/src/FormApi.ts:562](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L562)
 
 A counter for tracking the number of submission attempts.
 
@@ -441,7 +441,7 @@ BaseFormState.submissionAttempts
 validationMetaMap: Record<"onChange" | "onBlur" | "onSubmit" | "onMount" | "onServer", undefined | ValidationMeta>;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:529](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L529)
+Defined in: [packages/form-core/src/FormApi.ts:529](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L529)
 
 An internal mechanism used for keeping track of validation logic in a form.
 
@@ -459,7 +459,7 @@ BaseFormState.validationMetaMap
 values: TFormData;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:512](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L512)
+Defined in: [packages/form-core/src/FormApi.ts:512](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L512)
 
 The current values of the form fields.
 

--- a/docs/reference/interfaces/formvalidators.md
+++ b/docs/reference/interfaces/formvalidators.md
@@ -7,7 +7,7 @@ title: FormValidators
 
 # Interface: FormValidators\<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync\>
 
-Defined in: [packages/form-core/src/FormApi.ts:156](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L156)
+Defined in: [packages/form-core/src/FormApi.ts:156](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L156)
 
 ## Type Parameters
 
@@ -35,7 +35,7 @@ Defined in: [packages/form-core/src/FormApi.ts:156](https://github.com/TanStack/
 optional onBlur: TOnBlur;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:185](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L185)
+Defined in: [packages/form-core/src/FormApi.ts:185](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L185)
 
 Optional function that validates the form data when a field loses focus, returns a `FormValidationError`
 
@@ -47,7 +47,7 @@ Optional function that validates the form data when a field loses focus, returns
 optional onBlurAsync: TOnBlurAsync;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:189](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L189)
+Defined in: [packages/form-core/src/FormApi.ts:189](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L189)
 
 Optional onBlur asynchronous validation method for when a field loses focus returns a ` FormValidationError` or a promise of `Promise<FormValidationError>`
 
@@ -59,7 +59,7 @@ Optional onBlur asynchronous validation method for when a field loses focus retu
 optional onBlurAsyncDebounceMs: number;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:193](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L193)
+Defined in: [packages/form-core/src/FormApi.ts:193](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L193)
 
 The default time in milliseconds that if set to a number larger than 0, will debounce the async validation event by this length of time in milliseconds.
 
@@ -71,7 +71,7 @@ The default time in milliseconds that if set to a number larger than 0, will deb
 optional onChange: TOnChange;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:173](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L173)
+Defined in: [packages/form-core/src/FormApi.ts:173](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L173)
 
 Optional function that checks the validity of your data whenever a value changes
 
@@ -83,7 +83,7 @@ Optional function that checks the validity of your data whenever a value changes
 optional onChangeAsync: TOnChangeAsync;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:177](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L177)
+Defined in: [packages/form-core/src/FormApi.ts:177](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L177)
 
 Optional onChange asynchronous counterpart to onChange. Useful for more complex validation logic that might involve server requests.
 
@@ -95,7 +95,7 @@ Optional onChange asynchronous counterpart to onChange. Useful for more complex 
 optional onChangeAsyncDebounceMs: number;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:181](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L181)
+Defined in: [packages/form-core/src/FormApi.ts:181](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L181)
 
 The default time in milliseconds that if set to a number larger than 0, will debounce the async validation event by this length of time in milliseconds.
 
@@ -107,7 +107,7 @@ The default time in milliseconds that if set to a number larger than 0, will deb
 optional onMount: TOnMount;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:169](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L169)
+Defined in: [packages/form-core/src/FormApi.ts:169](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L169)
 
 Optional function that fires as soon as the component mounts.
 
@@ -119,7 +119,7 @@ Optional function that fires as soon as the component mounts.
 optional onSubmit: TOnSubmit;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:194](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L194)
+Defined in: [packages/form-core/src/FormApi.ts:194](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L194)
 
 ***
 
@@ -129,4 +129,4 @@ Defined in: [packages/form-core/src/FormApi.ts:194](https://github.com/TanStack/
 optional onSubmitAsync: TOnSubmitAsync;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:195](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L195)
+Defined in: [packages/form-core/src/FormApi.ts:195](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L195)

--- a/docs/reference/interfaces/objectdeepkeyandvalue.md
+++ b/docs/reference/interfaces/objectdeepkeyandvalue.md
@@ -7,7 +7,7 @@ title: ObjectDeepKeyAndValue
 
 # Interface: ObjectDeepKeyAndValue\<TParent, T, TKey\>
 
-Defined in: [packages/form-core/src/util-types.ts:97](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L97)
+Defined in: [packages/form-core/src/util-types.ts:97](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L97)
 
 ## Extends
 
@@ -29,7 +29,7 @@ Defined in: [packages/form-core/src/util-types.ts:97](https://github.com/TanStac
 key: ObjectAccessor<TParent, TKey>;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:102](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L102)
+Defined in: [packages/form-core/src/util-types.ts:102](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L102)
 
 #### Overrides
 
@@ -43,7 +43,7 @@ Defined in: [packages/form-core/src/util-types.ts:102](https://github.com/TanSta
 value: ObjectValue<TParent, T, TKey>;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:103](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L103)
+Defined in: [packages/form-core/src/util-types.ts:103](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L103)
 
 #### Overrides
 

--- a/docs/reference/interfaces/standardschemav1issue.md
+++ b/docs/reference/interfaces/standardschemav1issue.md
@@ -7,7 +7,7 @@ title: StandardSchemaV1Issue
 
 # Interface: StandardSchemaV1Issue
 
-Defined in: [packages/form-core/src/standardSchemaValidator.ts:159](https://github.com/TanStack/form/blob/main/packages/form-core/src/standardSchemaValidator.ts#L159)
+Defined in: [packages/form-core/src/standardSchemaValidator.ts:159](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/standardSchemaValidator.ts#L159)
 
 The issue interface of the failure output.
 
@@ -19,7 +19,7 @@ The issue interface of the failure output.
 readonly message: string;
 ```
 
-Defined in: [packages/form-core/src/standardSchemaValidator.ts:163](https://github.com/TanStack/form/blob/main/packages/form-core/src/standardSchemaValidator.ts#L163)
+Defined in: [packages/form-core/src/standardSchemaValidator.ts:163](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/standardSchemaValidator.ts#L163)
 
 The error message of the issue.
 
@@ -31,6 +31,6 @@ The error message of the issue.
 readonly optional path: readonly (PropertyKey | StandardSchemaV1PathSegment)[];
 ```
 
-Defined in: [packages/form-core/src/standardSchemaValidator.ts:167](https://github.com/TanStack/form/blob/main/packages/form-core/src/standardSchemaValidator.ts#L167)
+Defined in: [packages/form-core/src/standardSchemaValidator.ts:167](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/standardSchemaValidator.ts#L167)
 
 The path of the issue, if any.

--- a/docs/reference/interfaces/tupledeepkeyandvalue.md
+++ b/docs/reference/interfaces/tupledeepkeyandvalue.md
@@ -7,7 +7,7 @@ title: TupleDeepKeyAndValue
 
 # Interface: TupleDeepKeyAndValue\<TParent, T, TKey\>
 
-Defined in: [packages/form-core/src/util-types.ts:56](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L56)
+Defined in: [packages/form-core/src/util-types.ts:56](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L56)
 
 ## Extends
 
@@ -29,7 +29,7 @@ Defined in: [packages/form-core/src/util-types.ts:56](https://github.com/TanStac
 key: `${TParent["key"] extends never ? "" : TParent["key"]}[${TKey}]`;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:61](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L61)
+Defined in: [packages/form-core/src/util-types.ts:61](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L61)
 
 #### Overrides
 
@@ -45,7 +45,7 @@ value:
 | Nullable<TParent["value"]>;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:62](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L62)
+Defined in: [packages/form-core/src/util-types.ts:62](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L62)
 
 #### Overrides
 

--- a/docs/reference/interfaces/unknowndeepkeyandvalue.md
+++ b/docs/reference/interfaces/unknowndeepkeyandvalue.md
@@ -7,7 +7,7 @@ title: UnknownDeepKeyAndValue
 
 # Interface: UnknownDeepKeyAndValue\<TParent\>
 
-Defined in: [packages/form-core/src/util-types.ts:122](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L122)
+Defined in: [packages/form-core/src/util-types.ts:122](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L122)
 
 ## Extends
 
@@ -25,7 +25,7 @@ Defined in: [packages/form-core/src/util-types.ts:122](https://github.com/TanSta
 key: UnknownAccessor<TParent>;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:124](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L124)
+Defined in: [packages/form-core/src/util-types.ts:124](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L124)
 
 #### Overrides
 
@@ -39,7 +39,7 @@ Defined in: [packages/form-core/src/util-types.ts:124](https://github.com/TanSta
 value: unknown;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:125](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L125)
+Defined in: [packages/form-core/src/util-types.ts:125](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L125)
 
 #### Overrides
 

--- a/docs/reference/type-aliases/allobjectkeys.md
+++ b/docs/reference/type-aliases/allobjectkeys.md
@@ -11,7 +11,7 @@ title: AllObjectKeys
 type AllObjectKeys<T> = T extends any ? keyof T & string | number : never;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:80](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L80)
+Defined in: [packages/form-core/src/util-types.ts:80](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L80)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/alltuplekeys.md
+++ b/docs/reference/type-aliases/alltuplekeys.md
@@ -11,7 +11,7 @@ title: AllTupleKeys
 type AllTupleKeys<T> = T extends any ? keyof T & `${number}` : never;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:65](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L65)
+Defined in: [packages/form-core/src/util-types.ts:65](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L65)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/anyfieldapi.md
+++ b/docs/reference/type-aliases/anyfieldapi.md
@@ -11,6 +11,6 @@ title: AnyFieldApi
 type AnyFieldApi = FieldApi<any, any, any, any, any, any, any, any, any, any, any, any, any, any, any, any, any, any, any>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:832](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L832)
+Defined in: [packages/form-core/src/FieldApi.ts:832](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L832)
 
 A type representing the Field API with all generics set to `any` for convenience.

--- a/docs/reference/type-aliases/anyfieldmeta.md
+++ b/docs/reference/type-aliases/anyfieldmeta.md
@@ -11,4 +11,4 @@ title: AnyFieldMeta
 type AnyFieldMeta = FieldMeta<any, any, any, any, any, any, any, any, any, any, any, any, any, any, any, any, any>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:751](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L751)
+Defined in: [packages/form-core/src/FieldApi.ts:751](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L751)

--- a/docs/reference/type-aliases/anyfieldmetabase.md
+++ b/docs/reference/type-aliases/anyfieldmetabase.md
@@ -11,4 +11,4 @@ title: AnyFieldMetaBase
 type AnyFieldMetaBase = FieldMetaBase<any, any, any, any, any, any, any, any, any, any, any, any, any, any, any, any, any>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:580](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L580)
+Defined in: [packages/form-core/src/FieldApi.ts:580](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L580)

--- a/docs/reference/type-aliases/anyfieldmetaderived.md
+++ b/docs/reference/type-aliases/anyfieldmetaderived.md
@@ -11,4 +11,4 @@ title: AnyFieldMetaDerived
 type AnyFieldMetaDerived = FieldMetaDerived<any, any, any, any, any, any, any, any, any, any, any, any, any, any, any, any, any>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:665](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L665)
+Defined in: [packages/form-core/src/FieldApi.ts:665](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L665)

--- a/docs/reference/type-aliases/anyformapi.md
+++ b/docs/reference/type-aliases/anyformapi.md
@@ -11,6 +11,6 @@ title: AnyFormApi
 type AnyFormApi = FormApi<any, any, any, any, any, any, any, any, any, any>;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:751](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L751)
+Defined in: [packages/form-core/src/FormApi.ts:751](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L751)
 
 A type representing the Form API with all generics set to `any` for convenience.

--- a/docs/reference/type-aliases/anyformstate.md
+++ b/docs/reference/type-aliases/anyformstate.md
@@ -11,4 +11,4 @@ title: AnyFormState
 type AnyFormState = FormState<any, any, any, any, any, any, any, any, any>;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:680](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L680)
+Defined in: [packages/form-core/src/FormApi.ts:680](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L680)

--- a/docs/reference/type-aliases/arrayaccessor.md
+++ b/docs/reference/type-aliases/arrayaccessor.md
@@ -11,7 +11,7 @@ title: ArrayAccessor
 type ArrayAccessor<TParent> = `${TParent["key"] extends never ? "" : TParent["key"]}[${number}]`;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:30](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L30)
+Defined in: [packages/form-core/src/util-types.ts:30](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L30)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/baseformstate.md
+++ b/docs/reference/type-aliases/baseformstate.md
@@ -11,7 +11,7 @@ title: BaseFormState
 type BaseFormState<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer> = object;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:498](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L498)
+Defined in: [packages/form-core/src/FormApi.ts:498](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L498)
 
 An object representing the current state of the form.
 

--- a/docs/reference/type-aliases/deepkeyandvaluearray.md
+++ b/docs/reference/type-aliases/deepkeyandvaluearray.md
@@ -13,7 +13,7 @@ type DeepKeyAndValueArray<TParent, T, TAcc> = DeepKeysAndValuesImpl<NonNullable<
 | ArrayDeepKeyAndValue<TParent, T>>;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:41](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L41)
+Defined in: [packages/form-core/src/util-types.ts:41](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L41)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/deepkeyandvalueobject.md
+++ b/docs/reference/type-aliases/deepkeyandvalueobject.md
@@ -13,7 +13,7 @@ type DeepKeyAndValueObject<TParent, T, TAcc, TAllKeys> = TAllKeys extends any ? 
   | ObjectDeepKeyAndValue<TParent, T, TAllKeys>> : never;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:106](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L106)
+Defined in: [packages/form-core/src/util-types.ts:106](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L106)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/deepkeyandvaluetuple.md
+++ b/docs/reference/type-aliases/deepkeyandvaluetuple.md
@@ -13,7 +13,7 @@ type DeepKeyAndValueTuple<TParent, T, TAcc, TAllKeys> = TAllKeys extends any ? D
   | TupleDeepKeyAndValue<TParent, T, TAllKeys>> : never;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:67](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L67)
+Defined in: [packages/form-core/src/util-types.ts:67](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L67)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/deepkeys.md
+++ b/docs/reference/type-aliases/deepkeys.md
@@ -11,7 +11,7 @@ title: DeepKeys
 type DeepKeys<T> = unknown extends T ? string : DeepKeysAndValues<T>["key"];
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:160](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L160)
+Defined in: [packages/form-core/src/util-types.ts:160](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L160)
 
 The keys of an object or array, deeply nested.
 

--- a/docs/reference/type-aliases/deepkeysandvalues.md
+++ b/docs/reference/type-aliases/deepkeysandvalues.md
@@ -11,7 +11,7 @@ title: DeepKeysAndValues
 type DeepKeysAndValues<T> = DeepKeysAndValuesImpl<T> extends AnyDeepKeyAndValue ? DeepKeysAndValuesImpl<T> : never;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:128](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L128)
+Defined in: [packages/form-core/src/util-types.ts:128](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L128)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/deepkeysandvaluesimpl.md
+++ b/docs/reference/type-aliases/deepkeysandvaluesimpl.md
@@ -15,7 +15,7 @@ type DeepKeysAndValuesImpl<T, TParent, TAcc> = unknown extends T ?
   | UnknownDeepKeyAndValue<TParent> : T extends object ? DeepKeyAndValueObject<TParent, T, TAcc> : TAcc;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:133](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L133)
+Defined in: [packages/form-core/src/util-types.ts:133](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L133)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/deepkeysoftype.md
+++ b/docs/reference/type-aliases/deepkeysoftype.md
@@ -11,7 +11,7 @@ title: DeepKeysOfType
 type DeepKeysOfType<TData, TValue> = Extract<DeepKeysAndValues<TData>, AnyDeepKeyAndValue<string, TValue>>["key"];
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:176](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L176)
+Defined in: [packages/form-core/src/util-types.ts:176](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L176)
 
 The keys of an object or array, deeply nested and only with a value of TValue
 

--- a/docs/reference/type-aliases/deeprecord.md
+++ b/docs/reference/type-aliases/deeprecord.md
@@ -11,7 +11,7 @@ title: DeepRecord
 type DeepRecord<T> = { [TRecord in DeepKeysAndValues<T> as TRecord["key"]]: TRecord["value"] };
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:153](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L153)
+Defined in: [packages/form-core/src/util-types.ts:153](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L153)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/deepvalue.md
+++ b/docs/reference/type-aliases/deepvalue.md
@@ -11,7 +11,7 @@ title: DeepValue
 type DeepValue<TValue, TAccessor> = unknown extends TValue ? TValue : TAccessor extends DeepKeys<TValue> ? DeepRecord<TValue>[TAccessor] : never;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:167](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L167)
+Defined in: [packages/form-core/src/util-types.ts:167](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L167)
 
 Infer the type of a deeply nested property within an object or an array.
 

--- a/docs/reference/type-aliases/derivedformstate.md
+++ b/docs/reference/type-aliases/derivedformstate.md
@@ -11,7 +11,7 @@ title: DerivedFormState
 type DerivedFormState<TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnServer> = object;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:573](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L573)
+Defined in: [packages/form-core/src/FormApi.ts:573](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L573)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/fieldinfo.md
+++ b/docs/reference/type-aliases/fieldinfo.md
@@ -11,7 +11,7 @@ title: FieldInfo
 type FieldInfo<TFormData> = object;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:464](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L464)
+Defined in: [packages/form-core/src/FormApi.ts:464](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L464)
 
 An object representing the field information for a specific field within the form.
 

--- a/docs/reference/type-aliases/fieldmeta.md
+++ b/docs/reference/type-aliases/fieldmeta.md
@@ -11,7 +11,7 @@ title: FieldMeta
 type FieldMeta<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync> = FieldMetaBase<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync> & FieldMetaDerived<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync>;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:688](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L688)
+Defined in: [packages/form-core/src/FieldApi.ts:688](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L688)
 
 An object type representing the metadata of a field in a form.
 

--- a/docs/reference/type-aliases/fieldmetabase.md
+++ b/docs/reference/type-aliases/fieldmetabase.md
@@ -11,7 +11,7 @@ title: FieldMetaBase
 type FieldMetaBase<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync> = object;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:521](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L521)
+Defined in: [packages/form-core/src/FieldApi.ts:521](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L521)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/fieldmetaderived.md
+++ b/docs/reference/type-aliases/fieldmetaderived.md
@@ -11,7 +11,7 @@ title: FieldMetaDerived
 type FieldMetaDerived<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync> = object;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:600](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L600)
+Defined in: [packages/form-core/src/FieldApi.ts:600](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L600)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/fieldstate.md
+++ b/docs/reference/type-aliases/fieldstate.md
@@ -11,7 +11,7 @@ title: FieldState
 type FieldState<TParentData, TName, TData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TFormOnMount, TFormOnChange, TFormOnChangeAsync, TFormOnBlur, TFormOnBlurAsync, TFormOnSubmit, TFormOnSubmitAsync> = object;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:774](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L774)
+Defined in: [packages/form-core/src/FieldApi.ts:774](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L774)
 
 An object type representing the state of a field.
 

--- a/docs/reference/type-aliases/formvalidatefn.md
+++ b/docs/reference/type-aliases/formvalidatefn.md
@@ -11,7 +11,7 @@ title: FormValidateFn
 type FormValidateFn<TFormData> = (props) => unknown;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:71](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L71)
+Defined in: [packages/form-core/src/FormApi.ts:71](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L71)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/formvalidationerror.md
+++ b/docs/reference/type-aliases/formvalidationerror.md
@@ -13,7 +13,7 @@ type FormValidationError<TFormData> =
 | GlobalFormValidationError<TFormData>;
 ```
 
-Defined in: [packages/form-core/src/types.ts:84](https://github.com/TanStack/form/blob/main/packages/form-core/src/types.ts#L84)
+Defined in: [packages/form-core/src/types.ts:84](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/types.ts#L84)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/formvalidator.md
+++ b/docs/reference/type-aliases/formvalidator.md
@@ -11,7 +11,7 @@ title: FormValidator
 type FormValidator<TFormData, TType, TFn> = object;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:126](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L126)
+Defined in: [packages/form-core/src/FormApi.ts:126](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L126)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/nullable.md
+++ b/docs/reference/type-aliases/nullable.md
@@ -11,7 +11,7 @@ title: Nullable
 type Nullable<T> = T & undefined | null;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:89](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L89)
+Defined in: [packages/form-core/src/util-types.ts:89](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L89)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/objectaccessor.md
+++ b/docs/reference/type-aliases/objectaccessor.md
@@ -11,7 +11,7 @@ title: ObjectAccessor
 type ObjectAccessor<TParent, TKey> = TParent["key"] extends never ? `${TKey}` : `${TParent["key"]}.${TKey}`;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:84](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L84)
+Defined in: [packages/form-core/src/util-types.ts:84](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L84)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/objectvalue.md
+++ b/docs/reference/type-aliases/objectvalue.md
@@ -11,7 +11,7 @@ title: ObjectValue
 type ObjectValue<TParent, T, TKey> = T[TKey] | Nullable<TParent["value"]>;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:91](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L91)
+Defined in: [packages/form-core/src/util-types.ts:91](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L91)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/standardschemav1.md
+++ b/docs/reference/type-aliases/standardschemav1.md
@@ -11,7 +11,7 @@ title: StandardSchemaV1
 type StandardSchemaV1<Input, Output> = object;
 ```
 
-Defined in: [packages/form-core/src/standardSchemaValidator.ts:98](https://github.com/TanStack/form/blob/main/packages/form-core/src/standardSchemaValidator.ts#L98)
+Defined in: [packages/form-core/src/standardSchemaValidator.ts:98](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/standardSchemaValidator.ts#L98)
 
 The Standard Schema interface.
 

--- a/docs/reference/type-aliases/tstandardschemavalidatorissue.md
+++ b/docs/reference/type-aliases/tstandardschemavalidatorissue.md
@@ -11,7 +11,7 @@ title: TStandardSchemaValidatorIssue
 type TStandardSchemaValidatorIssue<TSource> = TSource extends "form" ? object : TSource extends "field" ? StandardSchemaV1Issue[] : never;
 ```
 
-Defined in: [packages/form-core/src/standardSchemaValidator.ts:11](https://github.com/TanStack/form/blob/main/packages/form-core/src/standardSchemaValidator.ts#L11)
+Defined in: [packages/form-core/src/standardSchemaValidator.ts:11](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/standardSchemaValidator.ts#L11)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/tstandardschemavalidatorvalue.md
+++ b/docs/reference/type-aliases/tstandardschemavalidatorvalue.md
@@ -11,7 +11,7 @@ title: TStandardSchemaValidatorValue
 type TStandardSchemaValidatorValue<TData, TSource> = object;
 ```
 
-Defined in: [packages/form-core/src/standardSchemaValidator.ts:3](https://github.com/TanStack/form/blob/main/packages/form-core/src/standardSchemaValidator.ts#L3)
+Defined in: [packages/form-core/src/standardSchemaValidator.ts:3](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/standardSchemaValidator.ts#L3)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/tupleaccessor.md
+++ b/docs/reference/type-aliases/tupleaccessor.md
@@ -11,7 +11,7 @@ title: TupleAccessor
 type TupleAccessor<TParent, TKey> = `${TParent["key"] extends never ? "" : TParent["key"]}[${TKey}]`;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:51](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L51)
+Defined in: [packages/form-core/src/util-types.ts:51](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L51)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/unknownaccessor.md
+++ b/docs/reference/type-aliases/unknownaccessor.md
@@ -11,7 +11,7 @@ title: UnknownAccessor
 type UnknownAccessor<TParent> = TParent["key"] extends never ? string : `${TParent["key"]}.${string}`;
 ```
 
-Defined in: [packages/form-core/src/util-types.ts:119](https://github.com/TanStack/form/blob/main/packages/form-core/src/util-types.ts#L119)
+Defined in: [packages/form-core/src/util-types.ts:119](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/util-types.ts#L119)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/unwrapfieldasyncvalidateorfn.md
+++ b/docs/reference/type-aliases/unwrapfieldasyncvalidateorfn.md
@@ -14,7 +14,7 @@ type UnwrapFieldAsyncValidateOrFn<TName, TValidateOrFn, TFormValidateOrFn> =
   | [TValidateOrFn] extends [FieldValidateAsyncFn<any, any, any>] ? Awaited<ReturnType<TValidateOrFn>> : [TValidateOrFn] extends [StandardSchemaV1<any, any>] ? StandardSchemaV1Issue[] : undefined;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:210](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L210)
+Defined in: [packages/form-core/src/FieldApi.ts:210](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L210)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/unwrapfieldvalidateorfn.md
+++ b/docs/reference/type-aliases/unwrapfieldvalidateorfn.md
@@ -14,7 +14,7 @@ type UnwrapFieldValidateOrFn<TName, TValidateOrFn, TFormValidateOrFn> =
   | [TValidateOrFn] extends [FieldValidateFn<any, any, any>] ? ReturnType<TValidateOrFn> : [TValidateOrFn] extends [StandardSchemaV1<any, any>] ? StandardSchemaV1Issue[] : undefined;
 ```
 
-Defined in: [packages/form-core/src/FieldApi.ts:128](https://github.com/TanStack/form/blob/main/packages/form-core/src/FieldApi.ts#L128)
+Defined in: [packages/form-core/src/FieldApi.ts:128](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FieldApi.ts#L128)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/unwrapformasyncvalidateorfn.md
+++ b/docs/reference/type-aliases/unwrapformasyncvalidateorfn.md
@@ -11,7 +11,7 @@ title: UnwrapFormAsyncValidateOrFn
 type UnwrapFormAsyncValidateOrFn<TValidateOrFn> = [TValidateOrFn] extends [FormValidateAsyncFn<any>] ? Awaited<ReturnType<TValidateOrFn>> : [TValidateOrFn] extends [StandardSchemaV1<any, any>] ? Record<string, StandardSchemaV1Issue[]> : undefined;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:148](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L148)
+Defined in: [packages/form-core/src/FormApi.ts:148](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L148)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/unwrapformvalidateorfn.md
+++ b/docs/reference/type-aliases/unwrapformvalidateorfn.md
@@ -11,7 +11,7 @@ title: UnwrapFormValidateOrFn
 type UnwrapFormValidateOrFn<TValidateOrFn> = [TValidateOrFn] extends [FormValidateFn<any>] ? ReturnType<TValidateOrFn> : [TValidateOrFn] extends [StandardSchemaV1<any, any>] ? Record<string, StandardSchemaV1Issue[]> : undefined;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:96](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L96)
+Defined in: [packages/form-core/src/FormApi.ts:96](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L96)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/updater.md
+++ b/docs/reference/type-aliases/updater.md
@@ -11,7 +11,7 @@ title: Updater
 type Updater<TInput, TOutput> = TOutput | UpdaterFn<TInput, TOutput>;
 ```
 
-Defined in: [packages/form-core/src/utils.ts:12](https://github.com/TanStack/form/blob/main/packages/form-core/src/utils.ts#L12)
+Defined in: [packages/form-core/src/utils.ts:12](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/utils.ts#L12)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/updaterfn.md
+++ b/docs/reference/type-aliases/updaterfn.md
@@ -11,7 +11,7 @@ title: UpdaterFn
 type UpdaterFn<TInput, TOutput> = (input) => TOutput;
 ```
 
-Defined in: [packages/form-core/src/utils.ts:10](https://github.com/TanStack/form/blob/main/packages/form-core/src/utils.ts#L10)
+Defined in: [packages/form-core/src/utils.ts:10](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/utils.ts#L10)
 
 ## Type Parameters
 

--- a/docs/reference/type-aliases/validationerror.md
+++ b/docs/reference/type-aliases/validationerror.md
@@ -11,4 +11,4 @@ title: ValidationError
 type ValidationError = unknown;
 ```
 
-Defined in: [packages/form-core/src/types.ts:3](https://github.com/TanStack/form/blob/main/packages/form-core/src/types.ts#L3)
+Defined in: [packages/form-core/src/types.ts:3](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/types.ts#L3)

--- a/docs/reference/type-aliases/validationmeta.md
+++ b/docs/reference/type-aliases/validationmeta.md
@@ -11,7 +11,7 @@ title: ValidationMeta
 type ValidationMeta = object;
 ```
 
-Defined in: [packages/form-core/src/FormApi.ts:454](https://github.com/TanStack/form/blob/main/packages/form-core/src/FormApi.ts#L454)
+Defined in: [packages/form-core/src/FormApi.ts:454](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/FormApi.ts#L454)
 
 An object representing the validation metadata for a field. Not intended for public usage.
 

--- a/docs/reference/type-aliases/validationsource.md
+++ b/docs/reference/type-aliases/validationsource.md
@@ -11,4 +11,4 @@ title: ValidationSource
 type ValidationSource = "form" | "field";
 ```
 
-Defined in: [packages/form-core/src/types.ts:5](https://github.com/TanStack/form/blob/main/packages/form-core/src/types.ts#L5)
+Defined in: [packages/form-core/src/types.ts:5](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/types.ts#L5)

--- a/docs/reference/variables/standardschemavalidators.md
+++ b/docs/reference/variables/standardschemavalidators.md
@@ -11,7 +11,7 @@ title: standardSchemaValidators
 const standardSchemaValidators: object;
 ```
 
-Defined in: [packages/form-core/src/standardSchemaValidator.ts:53](https://github.com/TanStack/form/blob/main/packages/form-core/src/standardSchemaValidator.ts#L53)
+Defined in: [packages/form-core/src/standardSchemaValidator.ts:53](https://github.com/Pascalmh/tanstack-form/blob/main/packages/form-core/src/standardSchemaValidator.ts#L53)
 
 ## Type declaration
 

--- a/packages/react-form/package.json
+++ b/packages/react-form/package.json
@@ -84,6 +84,7 @@
     "@tanstack/form-core": "workspace:*",
     "@tanstack/react-store": "^0.7.0",
     "decode-formdata": "^0.9.0",
+    "valibot": "^1.1.0",
     "devalue": "^5.1.1"
   },
   "devDependencies": {

--- a/packages/react-form/package.json
+++ b/packages/react-form/package.json
@@ -85,7 +85,8 @@
     "@tanstack/react-store": "^0.7.0",
     "decode-formdata": "^0.9.0",
     "valibot": "^1.1.0",
-    "devalue": "^5.1.1"
+    "devalue": "^5.1.1",
+    "zod": "^3.24.4"
   },
   "devDependencies": {
     "@tanstack/react-start": "^1.120.3",

--- a/packages/react-form/tests/standardSchema.test.tsx
+++ b/packages/react-form/tests/standardSchema.test.tsx
@@ -1,6 +1,7 @@
 import { expect, it } from 'vitest'
 import { render } from '@testing-library/react'
 import * as v from 'valibot'
+import * as z from 'zod'
 import userEvent from '@testing-library/user-event'
 import { useForm } from '../src/useForm'
 import type { JSX } from 'react'
@@ -128,13 +129,154 @@ it('should canSubmit with valibot variant schema', async () => {
   expect.soft(getInput('aOrB value').value).toBe('b')
   expect.soft(getInput('aOrB isValid').value).toBe('true')
   expect.soft(getInput('a value').value).toBe('')
-  expect.soft(getInput('a isValid').value).toBe('true') // as we chose "b" option, the value of "a" can be "any"thing
+  expect
+    .soft(getInput('a isValid').value, "expect field 'a' to be isValid")
+    .toBe('true') // as we chose "b" option, the value of "a" can be "any"thing
   expect.soft(getInput('b value').value).toBe('foobar')
   expect.soft(getInput('b isValid').value).toBe('true') // "b" is valid now, as it's not empty anymore
 
   // check the state on the Form-level
-  expect.soft(getInput('form isValid').value).toBe('true')
-  expect.soft(getInput('form canSubmit').value).toBe('true')
+  expect
+    .soft(getInput('form isValid').value, 'expect form.isValid to be true')
+    .toBe('true')
+  expect
+    .soft(getInput('form canSubmit').value, 'expect form.canSubmit to be true')
+    .toBe('true')
+})
+
+it('should canSubmit with zod variant schema', async () => {
+  const schema = z.discriminatedUnion('aOrB', [
+    z.object({
+      aOrB: z.literal('a'),
+      a: z.string().min(1),
+      b: z.any(),
+    }),
+    z.object({
+      aOrB: z.literal('b'),
+      b: z.string().min(1),
+      a: z.any(),
+    }),
+  ])
+
+  type Schema = z.input<typeof schema>
+
+  const Component = () => {
+    const form = useForm({
+      defaultValues: {
+        aOrB: 'a',
+        a: '', // invalid initial value
+        b: '', // invalid initial value
+      } as Schema,
+      validators: {
+        onMount: schema,
+        onChange: schema,
+      },
+    })
+
+    return (
+      <>
+        <form.Field name="aOrB">
+          {(field) => (
+            <>
+              <input
+                title={`${field.name} value`}
+                value={field.state.value}
+                // @ts-expect-error - only "a" or "b" are valid values, not any string
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              <input
+                title={`${field.name} isValid`}
+                value={field.state.meta.isValid ? 'true' : 'false'}
+                readOnly
+              />
+            </>
+          )}
+        </form.Field>
+        <form.Field name="a">
+          {(field) => (
+            <>
+              <input
+                title={`${field.name} value`}
+                value={field.state.value}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              <input
+                title={`${field.name} isValid`}
+                value={field.state.meta.isValid ? 'true' : 'false'}
+                readOnly
+              />
+            </>
+          )}
+        </form.Field>
+        <form.Field name="b">
+          {(field) => (
+            <>
+              <input
+                title={`${field.name} value`}
+                value={field.state.value}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              <input
+                title={`${field.name} isValid`}
+                value={field.state.meta.isValid ? 'true' : 'false'}
+                readOnly
+              />
+            </>
+          )}
+        </form.Field>
+        <form.Subscribe
+          selector={(state) => [state.isValid, state.canSubmit] as const}
+        >
+          {([isValid, canSubmit]) => (
+            <>
+              <input
+                title="form isValid"
+                value={isValid ? 'true' : 'false'}
+                readOnly
+              />
+              <input
+                title="form canSubmit"
+                value={canSubmit ? 'true' : 'false'}
+              />
+            </>
+          )}
+        </form.Subscribe>
+      </>
+    )
+  }
+
+  const { getByTitle, user } = setup(<Component />)
+
+  function getInput(name: string) {
+    return getByTitle(name) as HTMLInputElement
+  }
+
+  // check initial values
+  expect.soft(getInput('form isValid').value).toBe('false')
+  expect.soft(getInput('form canSubmit').value).toBe('false')
+
+  // choose option "b" and make "b" valid
+  await user.clear(getInput('aOrB value'))
+  await user.type(getInput('aOrB value'), 'b')
+  await user.type(getInput('b value'), 'foobar') // valid input for "b"
+
+  // check that values are as expected on the Field-level
+  expect.soft(getInput('aOrB value').value).toBe('b')
+  expect.soft(getInput('aOrB isValid').value).toBe('true')
+  expect.soft(getInput('a value').value).toBe('')
+  expect
+    .soft(getInput('a isValid').value, "expect field 'a' to be isValid")
+    .toBe('true') // as we chose "b" option, the value of "a" can be "any"thing
+  expect.soft(getInput('b value').value).toBe('foobar')
+  expect.soft(getInput('b isValid').value).toBe('true') // "b" is valid now, as it's not empty anymore
+
+  // check the state on the Form-level
+  expect
+    .soft(getInput('form isValid').value, 'expect form.isValid to be true')
+    .toBe('true')
+  expect
+    .soft(getInput('form canSubmit').value, 'expect form.canSubmit to be true')
+    .toBe('true')
 })
 
 function setup(jsx: JSX.Element) {

--- a/packages/react-form/tests/standardSchema.test.tsx
+++ b/packages/react-form/tests/standardSchema.test.tsx
@@ -1,0 +1,145 @@
+import { expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+import * as v from 'valibot'
+import userEvent from '@testing-library/user-event'
+import { useForm } from '../src/useForm'
+import type { JSX } from 'react'
+
+it('should canSubmit with valibot variant schema', async () => {
+  const schema = v.variant('aOrB', [
+    v.object({
+      aOrB: v.literal('a'),
+      a: v.pipe(v.string(), v.nonEmpty()),
+      b: v.pipe(
+        v.any(),
+        v.transform(() => undefined),
+      ),
+    }),
+    v.object({
+      aOrB: v.literal('b'),
+      b: v.pipe(v.string(), v.nonEmpty()),
+      a: v.pipe(
+        v.any(),
+        v.transform(() => undefined),
+      ),
+    }),
+  ])
+
+  const Component = () => {
+    const form = useForm({
+      defaultValues: {
+        aOrB: 'a',
+        a: '', // invalid initial value
+        b: '', // invalid initial value
+      },
+      validators: {
+        onMount: schema,
+        onChange: schema,
+      },
+    })
+
+    return (
+      <>
+        <form.Field name="aOrB">
+          {(field) => (
+            <>
+              <input
+                title={`${field.name} value`}
+                value={field.state.value}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              <input
+                title={`${field.name} isValid`}
+                value={field.state.meta.isValid ? 'true' : 'false'}
+                readOnly
+              />
+            </>
+          )}
+        </form.Field>
+        <form.Field name="a">
+          {(field) => (
+            <>
+              <input
+                title={`${field.name} value`}
+                value={field.state.value}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              <input
+                title={`${field.name} isValid`}
+                value={field.state.meta.isValid ? 'true' : 'false'}
+                readOnly
+              />
+            </>
+          )}
+        </form.Field>
+        <form.Field name="b">
+          {(field) => (
+            <>
+              <input
+                title={`${field.name} value`}
+                value={field.state.value}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              <input
+                title={`${field.name} isValid`}
+                value={field.state.meta.isValid ? 'true' : 'false'}
+                readOnly
+              />
+            </>
+          )}
+        </form.Field>
+        <form.Subscribe
+          selector={(state) => [state.isValid, state.canSubmit] as const}
+        >
+          {([isValid, canSubmit]) => (
+            <>
+              <input
+                title="form isValid"
+                value={isValid ? 'true' : 'false'}
+                readOnly
+              />
+              <input
+                title="form canSubmit"
+                value={canSubmit ? 'true' : 'false'}
+              />
+            </>
+          )}
+        </form.Subscribe>
+      </>
+    )
+  }
+
+  const { getByTitle, user } = setup(<Component />)
+
+  function getInput(name: string) {
+    return getByTitle(name) as HTMLInputElement
+  }
+
+  // check initial values
+  expect.soft(getInput('form isValid').value).toBe('false')
+  expect.soft(getInput('form canSubmit').value).toBe('false')
+
+  // choose option "b" and make "b" valid
+  await user.clear(getInput('aOrB value'))
+  await user.type(getInput('aOrB value'), 'b')
+  await user.type(getInput('b value'), 'foobar') // valid input for "b"
+
+  // check that values are as expected on the Field-level
+  expect.soft(getInput('aOrB value').value).toBe('b')
+  expect.soft(getInput('aOrB isValid').value).toBe('true')
+  expect.soft(getInput('a value').value).toBe('')
+  expect.soft(getInput('a isValid').value).toBe('true') // as we chose "b" option, the value of "a" can be "any"thing
+  expect.soft(getInput('b value').value).toBe('foobar')
+  expect.soft(getInput('b isValid').value).toBe('true') // "b" is valid now, as it's not empty anymore
+
+  // check the state on the Form-level
+  expect.soft(getInput('form isValid').value).toBe('true')
+  expect.soft(getInput('form canSubmit').value).toBe('true')
+})
+
+function setup(jsx: JSX.Element) {
+  return {
+    user: userEvent.setup(),
+    ...render(jsx),
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -809,6 +809,9 @@ importers:
       devalue:
         specifier: ^5.1.1
         version: 5.1.1
+      valibot:
+        specifier: ^1.1.0
+        version: 1.1.0(typescript@5.8.3)
     devDependencies:
       '@tanstack/react-start':
         specifier: ^1.120.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -812,6 +812,9 @@ importers:
       valibot:
         specifier: ^1.1.0
         version: 1.1.0(typescript@5.8.3)
+      zod:
+        specifier: ^3.24.4
+        version: 3.24.4
     devDependencies:
       '@tanstack/react-start':
         specifier: ^1.120.3


### PR DESCRIPTION
I have a issue with `onMount` validation when using a [v.variant](https://valibot.dev/api/variant/) Schema

The thing is that this is valid:

```ts
const values = useStore(form.store, (state) => state.values);
console.log('values', v.safeParse(ValibotSchema, values)); // { success: true, … }
```

While `form.canSubmit` remains `false`

- Open the Stackblitz https://stackblitz.com/edit/tanstack-form-cjr4wwda?file=src%2Findex.tsx
- Open Devtools/Console
- Select the "Cat"-Radio Button

_Observe_: `canSubmit` remains `false`.

- Select the "Dog"-Radio Button
- Give the Dog a cool name
- Select the "Cat"-Radio Button

_Observe_: `canSubmit` is `true`