### PR TITLE
docs(react-form): add type=submit in form-composition.md subscribe button

### DIFF
--- a/docs/framework/react/guides/form-composition.md
+++ b/docs/framework/react/guides/form-composition.md
@@ -124,7 +124,7 @@ function SubscribeButton({ label }: { label: string }) {
   const form = useFormContext()
   return (
     <form.Subscribe selector={(state) => state.isSubmitting}>
-      {(isSubmitting) => <button onClick={() => form.handleSubmit()} disabled={isSubmitting}>{label}</button>}
+      {(isSubmitting) => <button type="submit" disabled={isSubmitting}>{label}</button>}
     </form.Subscribe>
   )
 }

--- a/docs/framework/react/guides/form-composition.md
+++ b/docs/framework/react/guides/form-composition.md
@@ -124,7 +124,11 @@ function SubscribeButton({ label }: { label: string }) {
   const form = useFormContext()
   return (
     <form.Subscribe selector={(state) => state.isSubmitting}>
-      {(isSubmitting) => <button type="submit" disabled={isSubmitting}>{label}</button>}
+      {(isSubmitting) => (
+        <button type="submit" disabled={isSubmitting}>
+          {label}
+        </button>
+      )}
     </form.Subscribe>
   )
 }

--- a/docs/framework/react/guides/form-composition.md
+++ b/docs/framework/react/guides/form-composition.md
@@ -124,7 +124,7 @@ function SubscribeButton({ label }: { label: string }) {
   const form = useFormContext()
   return (
     <form.Subscribe selector={(state) => state.isSubmitting}>
-      {(isSubmitting) => <button disabled={isSubmitting}>{label}</button>}
+      {(isSubmitting) => <button onClick={() => form.handleSubmit()} disabled={isSubmitting}>{label}</button>}
     </form.Subscribe>
   )
 }


### PR DESCRIPTION
the docs does not clearly states that form.handleSubmit must be present in the subscribe button in form composition and will confuse many developers (and I did get confused). So with this it is clearly stated.