### PR TITLE
docs: follow guidelines for reset in simple example

### DIFF
--- a/examples/react/simple/src/index.tsx
+++ b/examples/react/simple/src/index.tsx
@@ -98,7 +98,14 @@ export default function App() {
               <button type="submit" disabled={!canSubmit}>
                 {isSubmitting ? '...' : 'Submit'}
               </button>
-              <button type="reset" onClick={() => form.reset()}>
+              <button
+                type="reset"
+                onClick={(e) => {
+                  // Avoid unexpected resets of form elements (especially <select> elements)
+                  e.preventDefault();
+                  form.reset();
+                }}
+              >
                 Reset
               </button>
             </>

--- a/examples/react/simple/src/index.tsx
+++ b/examples/react/simple/src/index.tsx
@@ -102,8 +102,8 @@ export default function App() {
                 type="reset"
                 onClick={(e) => {
                   // Avoid unexpected resets of form elements (especially <select> elements)
-                  e.preventDefault();
-                  form.reset();
+                  e.preventDefault()
+                  form.reset()
                 }}
               >
                 Reset


### PR DESCRIPTION
I was playing with TanStack Form, starting from the simple example. I stumbled upon the annoying bug with `<select>` and form reset and found out that it's clearly documented here:

- https://tanstack.com/form/latest/docs/framework/react/guides/basic-concepts#reset-buttons

So this PR updates the simple example to follow the guidelines regarding form reset (which is to `event.preventDefault()`).