### PR TITLE
fix(form-core): prevent `FormApi#moveFieldValues` from mutating `defaultValues`

### DIFF
--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -2110,8 +2110,9 @@ export class FormApi<
     this.setFieldValue(
       field,
       (prev: any) => {
-        prev.splice(index2, 0, prev.splice(index1, 1)[0])
-        return prev
+        const next: any = [...prev]
+        next.splice(index2, 0, next.splice(index1, 1)[0])
+        return next
       },
       opts,
     )

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -812,6 +812,11 @@ describe('form api', () => {
     form.mount()
     form.moveFieldValues('names', 1, 2)
 
+    expect(form.options.defaultValues?.names).toStrictEqual([
+      'one',
+      'two',
+      'three',
+    ])
     expect(form.getFieldValue('names')).toStrictEqual(['one', 'three', 'two'])
   })
 

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -1016,6 +1016,10 @@ describe('form api', () => {
     form.reset()
     form.moveFieldValues('names', 1, 2)
     expect(form.options.defaultValues?.names).toStrictEqual(defaultValues.names)
+
+    form.reset()
+    form.clearFieldValues('names')
+    expect(form.options.defaultValues?.names).toStrictEqual(defaultValues.names)
   })
 
   it('should handle fields inside an array', async () => {

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -812,11 +812,6 @@ describe('form api', () => {
     form.mount()
     form.moveFieldValues('names', 1, 2)
 
-    expect(form.options.defaultValues?.names).toStrictEqual([
-      'one',
-      'two',
-      'three',
-    ])
     expect(form.getFieldValue('names')).toStrictEqual(['one', 'three', 'two'])
   })
 
@@ -989,6 +984,38 @@ describe('form api', () => {
     expect(field1Surname.state.meta.isBlurred).toBe(false)
     expect(field2Name.state.meta.isBlurred).toBe(true)
     expect(field2Surname.state.meta.isBlurred).toBe(false)
+  })
+
+  it('should preserve array default values when manipulating array values', () => {
+    const defaultValues = {
+      names: ['one', 'two', 'three'],
+    }
+    const form = new FormApi({
+      defaultValues,
+    })
+    form.mount()
+    form.pushFieldValue('names', 'four')
+    expect(form.options.defaultValues?.names).toStrictEqual(defaultValues.names)
+
+    form.reset()
+    form.insertFieldValue('names', 0, 'other')
+    expect(form.options.defaultValues?.names).toStrictEqual(defaultValues.names)
+
+    form.reset()
+    form.replaceFieldValue('names', 1, 'other')
+    expect(form.options.defaultValues?.names).toStrictEqual(defaultValues.names)
+
+    form.reset()
+    form.removeFieldValue('names', 1)
+    expect(form.options.defaultValues?.names).toStrictEqual(defaultValues.names)
+
+    form.reset()
+    form.swapFieldValues('names', 1, 2)
+    expect(form.options.defaultValues?.names).toStrictEqual(defaultValues.names)
+
+    form.reset()
+    form.moveFieldValues('names', 1, 2)
+    expect(form.options.defaultValues?.names).toStrictEqual(defaultValues.names)
   })
 
   it('should handle fields inside an array', async () => {


### PR DESCRIPTION
This PR addesses the following issue: https://github.com/TanStack/form/issues/1559

💡 Open question: I don't know if other field array methods suffer from the same issue but, if some do, should we address those in this PR too?