### PR TITLE
docs(nextjs-ssr): clarify need for HTML name attribute in form submissions

### DIFF
--- a/docs/framework/react/guides/ssr.md
+++ b/docs/framework/react/guides/ssr.md
@@ -293,7 +293,7 @@ export const ClientComp = () => {
           return (
             <div>
               <input
-                name="age"
+                name="age" // must explicitly set the name attribute for the POST request
                 type="number"
                 value={field.state.value}
                 onChange={(e) => field.handleChange(e.target.valueAsNumber)}

--- a/examples/react/next-server-actions/src/app/client-component.tsx
+++ b/examples/react/next-server-actions/src/app/client-component.tsx
@@ -37,7 +37,7 @@ export const ClientComp = () => {
           return (
             <div>
               <input
-                name="age"
+                name="age" // must explicitly set the name attribute for the POST request
                 type="number"
                 value={field.state.value}
                 onChange={(e) => field.handleChange(e.target.valueAsNumber)}


### PR DESCRIPTION
add inline comments to client components in next.js server action examples highlighting the need to explicitly set the name attribute on input fields for native POST submissions (e.g. with Next.js Server Actions). This avoids confusion where inputs may otherwise be omitted from formData.

closes https://github.com/TanStack/form/issues/1565