### PR TITLE
Create useExternalFormApi hook

### DIFF
--- a/packages/react-form/src/index.ts
+++ b/packages/react-form/src/index.ts
@@ -2,7 +2,7 @@ export * from '@tanstack/form-core'
 
 export { useStore } from '@tanstack/react-store'
 
-export type { ReactFormApi, ReactFormExtendedApi } from './useForm'
+export type { ReactFormApi, ReactFormExtendedApi } from './useExternalFormApi'
 export { useForm } from './useForm'
 
 export type { UseField, FieldComponent } from './useField'

--- a/packages/react-form/src/useExternalFormApi.tsx
+++ b/packages/react-form/src/useExternalFormApi.tsx
@@ -1,0 +1,227 @@
+import { FormApi, functionalUpdate } from '@tanstack/form-core'
+import type {
+  AnyFormApi,
+  AnyFormState,
+  FormAsyncValidateOrFn,
+  FormOptions,
+  FormValidateOrFn,
+} from '@tanstack/form-core'
+import { Field } from './useField'
+import { useStore } from '@tanstack/react-store'
+import { useState } from 'react'
+import type { PropsWithChildren } from 'react'
+import { useEffect, useLayoutEffect } from 'react'
+import type { FieldComponent } from './useField'
+import type { FormState } from '@tanstack/form-core'
+import type { NoInfer } from '@tanstack/react-store'
+import type { ReactNode } from 'react'
+
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect
+
+function LocalSubscribe({
+  form,
+  selector,
+  children,
+}: PropsWithChildren<{
+  form: AnyFormApi
+  selector: (state: AnyFormState) => AnyFormState
+}>) {
+  const data = useStore(form.store, selector)
+  return functionalUpdate(children, data)
+}
+
+/**
+ * Fields that are added onto the `FormAPI` from `@tanstack/form-core` and returned from the form hooks.
+ */
+export interface ReactFormApi<
+  in out TFormData,
+  in out TOnMount extends undefined | FormValidateOrFn<TFormData>,
+  in out TOnChange extends undefined | FormValidateOrFn<TFormData>,
+  in out TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  in out TOnBlur extends undefined | FormValidateOrFn<TFormData>,
+  in out TOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  in out TOnSubmit extends undefined | FormValidateOrFn<TFormData>,
+  in out TOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  in out TOnServer extends undefined | FormAsyncValidateOrFn<TFormData>,
+  in out TSubmitMeta,
+> {
+  /**
+   * A React component to render form fields. With this, you can render and manage individual form fields.
+   */
+  Field: FieldComponent<
+    TFormData,
+    TOnMount,
+    TOnChange,
+    TOnChangeAsync,
+    TOnBlur,
+    TOnBlurAsync,
+    TOnSubmit,
+    TOnSubmitAsync,
+    TOnServer,
+    TSubmitMeta
+  >
+
+  /**
+   * Subscribe to the form state. Allows for reacting to changes in the form's state.
+   */
+  Subscribe: <
+    TSelected = NoInfer<
+      FormState<
+        TFormData,
+        TOnMount,
+        TOnChange,
+        TOnChangeAsync,
+        TOnBlur,
+        TOnBlurAsync,
+        TOnSubmit,
+        TOnSubmitAsync,
+        TOnServer
+      >
+    >,
+  >(props: {
+    selector?: (
+      state: NoInfer<
+        FormState<
+          TFormData,
+          TOnMount,
+          TOnChange,
+          TOnChangeAsync,
+          TOnBlur,
+          TOnBlurAsync,
+          TOnSubmit,
+          TOnSubmitAsync,
+          TOnServer
+        >
+      >,
+    ) => TSelected
+    children: ((state: NoInfer<TSelected>) => ReactNode) | ReactNode
+  }) => ReactNode
+}
+
+/**
+ * An extended version of the `FormApi` class that includes React-specific functionalities from `ReactFormApi`.
+ */
+export type ReactFormExtendedApi<
+  TFormData,
+  TOnMount extends undefined | FormValidateOrFn<TFormData>,
+  TOnChange extends undefined | FormValidateOrFn<TFormData>,
+  TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnBlur extends undefined | FormValidateOrFn<TFormData>,
+  TOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnSubmit extends undefined | FormValidateOrFn<TFormData>,
+  TOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnServer extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TSubmitMeta,
+> = FormApi<
+  TFormData,
+  TOnMount,
+  TOnChange,
+  TOnChangeAsync,
+  TOnBlur,
+  TOnBlurAsync,
+  TOnSubmit,
+  TOnSubmitAsync,
+  TOnServer,
+  TSubmitMeta
+> &
+  ReactFormApi<
+    TFormData,
+    TOnMount,
+    TOnChange,
+    TOnChangeAsync,
+    TOnBlur,
+    TOnBlurAsync,
+    TOnSubmit,
+    TOnSubmitAsync,
+    TOnServer,
+    TSubmitMeta
+  >
+
+/**
+ * A custom React Hook that attaches React helpers to an *already‑created*
+ * {@link FormApi} instance.  This mirrors TanStack's `useForm` API but lets
+ * callers supply their own `new FormApi()` so the same object can be shared
+ * across frameworks (e.g. React + Solid).
+ */
+export function useExternalFormApi<
+  TFormData,
+  TOnMount extends undefined | FormValidateOrFn<TFormData>,
+  TOnChange extends undefined | FormValidateOrFn<TFormData>,
+  TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnBlur extends undefined | FormValidateOrFn<TFormData>,
+  TOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnSubmit extends undefined | FormValidateOrFn<TFormData>,
+  TOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnServer extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TSubmitMeta,
+>(
+  /** An already‑constructed `FormApi` instance */
+  formApi: FormApi<
+    TFormData,
+    TOnMount,
+    TOnChange,
+    TOnChangeAsync,
+    TOnBlur,
+    TOnBlurAsync,
+    TOnSubmit,
+    TOnSubmitAsync,
+    TOnServer,
+    TSubmitMeta
+  >,
+  /** Optional runtime options to patch via `formApi.update()` */
+  opts?: FormOptions<
+    TFormData,
+    TOnMount,
+    TOnChange,
+    TOnChangeAsync,
+    TOnBlur,
+    TOnBlurAsync,
+    TOnSubmit,
+    TOnSubmitAsync,
+    TOnServer,
+    TSubmitMeta
+  >,
+) {
+  // Attach React helpers only once and preserve referential stability
+  const [extendedApi] = useState(() => {
+    const api = formApi ?? new FormApi() // use the external instance as-is
+    const ext = api as ReactFormExtendedApi<
+      TFormData,
+      TOnMount,
+      TOnChange,
+      TOnChangeAsync,
+      TOnBlur,
+      TOnBlurAsync,
+      TOnSubmit,
+      TOnSubmitAsync,
+      TOnServer,
+      TSubmitMeta
+    >
+
+    // Inject JSX helpers
+    ext.Field = (props) => <Field {...props} form={api} />
+    ext.Subscribe = (props: any) => (
+      <LocalSubscribe
+        form={api}
+        selector={props.selector}
+        children={props.children}
+      />
+    )
+
+    return ext
+  })
+
+  // Mount once on first render
+  useIsomorphicLayoutEffect(formApi.mount, [])
+
+  // Keep React in sync with `isSubmitting`
+  useStore(formApi.store, (s) => s.isSubmitting)
+
+  // Keep options fresh without triggering re-creation
+  useIsomorphicLayoutEffect(() => {
+    extendedApi.update(opts)
+  })
+
+  return extendedApi
+}

--- a/packages/react-form/src/useForm.tsx
+++ b/packages/react-form/src/useForm.tsx
@@ -1,143 +1,18 @@
-import { FormApi, functionalUpdate } from '@tanstack/form-core'
-import { useStore } from '@tanstack/react-store'
-import React, { useState } from 'react'
-import { Field } from './useField'
-import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
+import { FormApi } from '@tanstack/form-core'
+import { useState } from 'react'
+import { useExternalFormApi } from './useExternalFormApi'
 import type {
-  AnyFormApi,
-  AnyFormState,
   FormAsyncValidateOrFn,
   FormOptions,
-  FormState,
   FormValidateOrFn,
 } from '@tanstack/form-core'
-import type { PropsWithChildren, ReactNode } from 'react'
-import type { FieldComponent } from './useField'
-import type { NoInfer } from '@tanstack/react-store'
-
-/**
- * Fields that are added onto the `FormAPI` from `@tanstack/form-core` and returned from `useForm`
- */
-export interface ReactFormApi<
-  in out TFormData,
-  in out TOnMount extends undefined | FormValidateOrFn<TFormData>,
-  in out TOnChange extends undefined | FormValidateOrFn<TFormData>,
-  in out TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
-  in out TOnBlur extends undefined | FormValidateOrFn<TFormData>,
-  in out TOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
-  in out TOnSubmit extends undefined | FormValidateOrFn<TFormData>,
-  in out TOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
-  in out TOnServer extends undefined | FormAsyncValidateOrFn<TFormData>,
-  in out TSubmitMeta,
-> {
-  /**
-   * A React component to render form fields. With this, you can render and manage individual form fields.
-   */
-  Field: FieldComponent<
-    TFormData,
-    TOnMount,
-    TOnChange,
-    TOnChangeAsync,
-    TOnBlur,
-    TOnBlurAsync,
-    TOnSubmit,
-    TOnSubmitAsync,
-    TOnServer,
-    TSubmitMeta
-  >
-  /**
-   * A `Subscribe` function that allows you to listen and react to changes in the form's state. It's especially useful when you need to execute side effects or render specific components in response to state updates.
-   */
-  Subscribe: <
-    TSelected = NoInfer<
-      FormState<
-        TFormData,
-        TOnMount,
-        TOnChange,
-        TOnChangeAsync,
-        TOnBlur,
-        TOnBlurAsync,
-        TOnSubmit,
-        TOnSubmitAsync,
-        TOnServer
-      >
-    >,
-  >(props: {
-    selector?: (
-      state: NoInfer<
-        FormState<
-          TFormData,
-          TOnMount,
-          TOnChange,
-          TOnChangeAsync,
-          TOnBlur,
-          TOnBlurAsync,
-          TOnSubmit,
-          TOnSubmitAsync,
-          TOnServer
-        >
-      >,
-    ) => TSelected
-    children: ((state: NoInfer<TSelected>) => ReactNode) | ReactNode
-  }) => ReactNode
-}
-
-/**
- * An extended version of the `FormApi` class that includes React-specific functionalities from `ReactFormApi`
- */
-export type ReactFormExtendedApi<
-  TFormData,
-  TOnMount extends undefined | FormValidateOrFn<TFormData>,
-  TOnChange extends undefined | FormValidateOrFn<TFormData>,
-  TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
-  TOnBlur extends undefined | FormValidateOrFn<TFormData>,
-  TOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
-  TOnSubmit extends undefined | FormValidateOrFn<TFormData>,
-  TOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
-  TOnServer extends undefined | FormAsyncValidateOrFn<TFormData>,
-  TSubmitMeta,
-> = FormApi<
-  TFormData,
-  TOnMount,
-  TOnChange,
-  TOnChangeAsync,
-  TOnBlur,
-  TOnBlurAsync,
-  TOnSubmit,
-  TOnSubmitAsync,
-  TOnServer,
-  TSubmitMeta
-> &
-  ReactFormApi<
-    TFormData,
-    TOnMount,
-    TOnChange,
-    TOnChangeAsync,
-    TOnBlur,
-    TOnBlurAsync,
-    TOnSubmit,
-    TOnSubmitAsync,
-    TOnServer,
-    TSubmitMeta
-  >
-
-function LocalSubscribe({
-  form,
-  selector,
-  children,
-}: PropsWithChildren<{
-  form: AnyFormApi
-  selector: (state: AnyFormState) => AnyFormState
-}>) {
-  const data = useStore(form.store, selector)
-
-  return functionalUpdate(children, data)
-}
 
 /**
  * A custom React Hook that returns an extended instance of the `FormApi` class.
  *
- * This API encapsulates all the necessary functionalities related to the form. It allows you to manage form state, handle submissions, and interact with form fields
+ * Internally it delegates to `useFormApi`, which attaches React helpers to the
+ * underlying `FormApi` instance. This keeps the implementation in a single
+ * place so both hooks stay in sync.
  */
 export function useForm<
   TFormData,
@@ -164,59 +39,37 @@ export function useForm<
     TSubmitMeta
   >,
 ) {
-  const [formApi] = useState(() => {
-    const api = new FormApi<
-      TFormData,
-      TOnMount,
-      TOnChange,
-      TOnChangeAsync,
-      TOnBlur,
-      TOnBlurAsync,
-      TOnSubmit,
-      TOnSubmitAsync,
-      TOnServer,
-      TSubmitMeta
-    >(opts)
+  const [formApi] = useState(
+    () =>
+      new FormApi<
+        TFormData,
+        TOnMount,
+        TOnChange,
+        TOnChangeAsync,
+        TOnBlur,
+        TOnBlurAsync,
+        TOnSubmit,
+        TOnSubmitAsync,
+        TOnServer,
+        TSubmitMeta
+      >(opts),
+  )
 
-    const extendedApi: ReactFormExtendedApi<
-      TFormData,
-      TOnMount,
-      TOnChange,
-      TOnChangeAsync,
-      TOnBlur,
-      TOnBlurAsync,
-      TOnSubmit,
-      TOnSubmitAsync,
-      TOnServer,
-      TSubmitMeta
-    > = api as never
-    extendedApi.Field = function APIField(props) {
-      return <Field {...props} form={api} />
-    }
-    extendedApi.Subscribe = (props: any) => {
-      return (
-        <LocalSubscribe
-          form={api}
-          selector={props.selector}
-          children={props.children}
-        />
-      )
-    }
+  const extendedApi = useExternalFormApi<
+    TFormData,
+    TOnMount,
+    TOnChange,
+    TOnChangeAsync,
+    TOnBlur,
+    TOnBlurAsync,
+    TOnSubmit,
+    TOnSubmitAsync,
+    TOnServer,
+    TSubmitMeta
+  >(formApi, opts)
 
-    return extendedApi
-  })
-
-  useIsomorphicLayoutEffect(formApi.mount, [])
-
-  useStore(formApi.store, (state) => state.isSubmitting)
-
-  /**
-   * formApi.update should not have any side effects. Think of it like a `useRef`
-   * that we need to keep updated every render with the most up-to-date information.
-   */
-  useIsomorphicLayoutEffect(() => {
-    formApi.update(opts)
-  })
-
-  return formApi
+  return extendedApi
 }
+
+// Re-export types for compatibility with existing downstream imports
+export type { ReactFormApi, ReactFormExtendedApi } from './useExternalFormApi'

--- a/packages/react-form/tests/useExternalFormApi.test.tsx
+++ b/packages/react-form/tests/useExternalFormApi.test.tsx
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { useState } from 'react'
+import { FormApi } from '@tanstack/form-core'
+
+import { useExternalFormApi } from '../src/useExternalFormApi'
+
+const user = userEvent.setup()
+
+describe('useExternalFormApi', () => {
+  it('preserves field state', async () => {
+    function Comp() {
+      // Create a fresh FormApi instance once
+      const [formApi] = useState(
+        () => new FormApi({ defaultValues: { firstName: '', lastName: '' } }),
+      )
+      const form = useExternalFormApi(formApi)
+
+      return (
+        <form.Field
+          name="firstName"
+          defaultValue={''}
+          children={(field) => (
+            <input
+              data-testid="fieldinput"
+              value={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={(e) => field.handleChange(e.target.value)}
+            />
+          )}
+        />
+      )
+    }
+
+    const { getByTestId } = render(<Comp />)
+    const input = getByTestId('fieldinput') as HTMLInputElement
+    await user.type(input, 'FirstName')
+    expect(input).toHaveValue('FirstName')
+  })
+
+  it('should allow default values to be set', async () => {
+    function Comp() {
+      const [formApi] = useState(
+        () =>
+          new FormApi({
+            defaultValues: {
+              firstName: 'FirstName',
+              lastName: 'LastName',
+            },
+          }),
+      )
+      const form = useExternalFormApi(formApi)
+
+      return (
+        <form.Field
+          name="firstName"
+          children={(field) => <p>{field.state.value}</p>}
+        />
+      )
+    }
+
+    const { findByText, queryByText } = render(<Comp />)
+    expect(await findByText('FirstName')).toBeInTheDocument()
+    expect(queryByText('LastName')).not.toBeInTheDocument()
+  })
+
+  it('should handle submitting properly', async () => {
+    interface Person {
+      firstName: string
+    }
+
+    function Comp() {
+      const [submittedData, setSubmittedData] = useState<Person | null>(null)
+
+      const [formApi] = useState(
+        () =>
+          new FormApi({
+            defaultValues: { firstName: 'FirstName' },
+          }),
+      )
+
+      const form = useExternalFormApi(formApi, {
+        onSubmit: ({ value }) => {
+          setSubmittedData(value)
+        },
+      })
+
+      return (
+        <>
+          <form.Field
+            name="firstName"
+            children={(field) => (
+              <input
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+                placeholder={'First name'}
+              />
+            )}
+          />
+          <button onClick={form.handleSubmit}>Submit</button>
+          {submittedData && <p>Submitted data: {submittedData.firstName}</p>}
+        </>
+      )
+    }
+
+    const { findByPlaceholderText, getByText } = render(<Comp />)
+    const input = (await findByPlaceholderText(
+      'First name',
+    )) as HTMLInputElement
+    await user.clear(input)
+    await user.type(input, 'OtherName')
+    await user.click(getByText('Submit'))
+    await waitFor(() =>
+      expect(getByText('Submitted data: OtherName')).toBeInTheDocument(),
+    )
+  })
+
+  it('allows a FormApi created at module scope to be reused', async () => {
+    // Create the FormApi at the same scope as the component (module scope for this test)
+    const moduleFormApi = new FormApi({
+      defaultValues: { firstName: '' },
+    })
+
+    function Comp() {
+      const form = useExternalFormApi(moduleFormApi)
+
+      return (
+        <form.Field
+          name="firstName"
+          children={(field) => (
+            <input
+              data-testid="fieldinput-module"
+              value={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={(e) => field.handleChange(e.target.value)}
+            />
+          )}
+        />
+      )
+    }
+
+    const { getByTestId } = render(<Comp />)
+    const input = getByTestId('fieldinput-module') as HTMLInputElement
+
+    await user.type(input, 'ModuleName')
+    expect(input).toHaveValue('ModuleName')
+
+    // Reset for cleanliness – future tests could reuse same instance safely
+    moduleFormApi.reset({ firstName: '' })
+  })
+})


### PR DESCRIPTION
This PR addresses an issue I raised here, https://github.com/TanStack/form/discussions/1595. 

The new `useExternalFormApi` hook would make working with forms more ergonomic, as they are already external stores and there are many usecases for reading / writing to a store from outside of the react lifecycle. 