### PR TITLE
fix(react-form): Allow interfaces to be assigned to `withForm`'s `props`

### DIFF
--- a/packages/react-form/src/createFormHook.tsx
+++ b/packages/react-form/src/createFormHook.tsx
@@ -183,7 +183,7 @@ export interface WithFormProps<
   TSubmitMeta,
   TFieldComponents extends Record<string, ComponentType<any>>,
   TFormComponents extends Record<string, ComponentType<any>>,
-  TRenderProps extends Record<string, unknown> = Record<string, never>,
+  TRenderProps extends object = Record<string, never>,
 > extends FormOptions<
     TFormData,
     TOnMount,
@@ -326,7 +326,7 @@ export function createFormHook<
     TOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
     TOnServer extends undefined | FormAsyncValidateOrFn<TFormData>,
     TSubmitMeta,
-    TRenderProps extends Record<string, unknown> = {},
+    TRenderProps extends object = {},
   >({
     render,
     props,

--- a/packages/react-form/tests/createFormHook.test-d.tsx
+++ b/packages/react-form/tests/createFormHook.test-d.tsx
@@ -249,4 +249,43 @@ describe('createFormHook', () => {
       <WithFormComponent form={incorrectAppForm} prop1="test" prop2={10} />
     )
   })
+
+  it('should allow interfaces without index signatures to be assigned to `props` in withForm', () => {
+    interface TestNoSignature {
+      title: string
+    }
+
+    interface TestWithSignature {
+      title: string
+      [key: string]: unknown
+    }
+
+    const WithFormComponent1 = withForm({
+      defaultValues: { name: '' },
+      props: {} as TestNoSignature,
+      render: () => <></>,
+    })
+
+    const WithFormComponent2 = withForm({
+      defaultValues: { name: '' },
+      props: {} as TestWithSignature,
+      render: () => <></>,
+    })
+
+    const appForm = useAppForm({ defaultValues: { name: '' } })
+
+    const Component1 = <WithFormComponent1 title="" form={appForm} />
+    const Component2 = (
+      <WithFormComponent2 title="" something="else" form={appForm} />
+    )
+  })
+
+  it('should not allow null as prop in withForm', () => {
+    const WithFormComponent = withForm({
+      defaultValues: { name: '' },
+      // @ts-expect-error
+      props: null,
+      render: () => <></>,
+    })
+  })
 })


### PR DESCRIPTION
This PR fixes an issue that the previous generic had for interfaces in TypeScript.

`Record<string, unknown>` requires that any lookup must be possible using `obj[key]`, and since the generic extends it, it just means anything with an index signature.

Object literals obviously have an index signature already. And according to [this issue in the TypeScript repo](https://github.com/Microsoft/TypeScript/issues/15300), types also have an implicit type signature. However, interfaces can be extended at multiple locations, and therefore are not considered to have implicit signatures.

To put it simply, the code attempts to fix the following problem:

```tsx
// okay
withForm({
  // ...
  props: {  title: '' }
})

// okay
type FormProps = { title: string }
withForm({
 // ...
 props: {} as FormProps
})

// okay
interface FormProps {
  title: string;
}
const props: FormProps = {
  title: ''
}
withForm({
  // ...
  props
})

// Interface is not assignable to Record<string, unknown>
interface FormProps {
  title: string
}

withForm({
  // ...
  // Doesn't work!
  props: {} as FormProps
})
```

This PR widens the generic type to `object` to allow interfaces.

Note that `null` is not considered an `object` type for TypeScript, as it's a primitive value.
In case this gets tinkered with in the future, I added a test case to ensure it won't pass.