### PR TITLE
fix(form-core): preserve leading zeros in numeric string field names

### DIFF
--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -171,8 +171,14 @@ export function makePathArray(str: string | Array<string | number>) {
       .replace(reMultipleDots, '.')
       .split('.')
       .map((d) => {
-        if (d.indexOf(intPrefix) === 0) {
-          return parseInt(d.substring(intPrefix.length), 10)
+        if (d.startsWith(intPrefix)) {
+          const numStr = d.substring(intPrefix.length)
+          const num = parseInt(numStr, 10)
+
+          if (String(num) === numStr) {
+            return num
+          }
+          return numStr
         }
         return d
       })

--- a/packages/form-core/tests/utils.spec.ts
+++ b/packages/form-core/tests/utils.spec.ts
@@ -133,6 +133,16 @@ describe('setBy', () => {
       ],
     ])
   })
+
+  it('should correctly set a value on a key with leading zeros', () => {
+    const initial = { name: 'test' }
+    const result = setBy(initial, '01234', 'some-value')
+
+    expect(result).toHaveProperty('01234')
+    expect(result['01234']).toBe('some-value')
+
+    expect(result).not.toHaveProperty('1234')
+  })
 })
 
 describe('deleteBy', () => {
@@ -222,6 +232,15 @@ describe('makePathArray', () => {
     expect(makePathArray('[0][1]')).toEqual([0, 1])
     expect(makePathArray('[2][3].a')).toEqual([2, 3, 'a'])
     expect(makePathArray('[4][5][6].b[7]')).toEqual([4, 5, 6, 'b', 7])
+  })
+
+  it('should preserve leading zeros on purely numeric strings', () => {
+    expect(makePathArray('01234')).toEqual(['01234'])
+    expect(makePathArray('007')).toEqual(['007'])
+  })
+
+  it('should still convert non-leading-zero numbers to number types', () => {
+    expect(makePathArray('12345')).toEqual([12345])
   })
 })
 


### PR DESCRIPTION
Closes #1617

A field name like '01234' was being incorrectly treated as the number 1234 inside the `makePathArray` utility. This caused the form to set values using the wrong key, leading to data mismatches and stale fields.

The logic in makePathArray has been updated to be more precise. It now checks if converting a numeric string to a number would change its value (e.g., by stripping leading zeros). If it would, the original string is kept. This resolves the bug without affecting how standard array indices are parsed.