### PR TITLE
fix(react-form): retain field and form context during Hot Module Replacement

### DIFF
--- a/packages/react-form/src/createFormHook.tsx
+++ b/packages/react-form/src/createFormHook.tsx
@@ -18,6 +18,10 @@ import type { FieldComponent } from './useField'
 import type { ReactFormExtendedApi } from './useForm'
 import type { AppFieldExtendedReactFieldGroupApi } from './useFieldGroup'
 
+// We should never hit the `null` case here
+const fieldContext = createContext<AnyFieldApi>(null as never)
+const formContext = createContext<AnyFormApi>(null as never)
+
 /**
  * TypeScript inferencing is weird.
  *
@@ -56,9 +60,6 @@ type UnwrapDefaultOrAny<DefaultT, T> = [DefaultT] extends [T]
   : T
 
 export function createFormHookContexts() {
-  // We should never hit the `null` case here
-  const fieldContext = createContext<AnyFieldApi>(null as never)
-
   function useFieldContext<TData>() {
     const field = useContext(fieldContext)
 
@@ -91,9 +92,6 @@ export function createFormHookContexts() {
       any
     >
   }
-
-  // We should never hit the `null` case here
-  const formContext = createContext<AnyFormApi>(null as never)
 
   function useFormContext() {
     const form = useContext(formContext)


### PR DESCRIPTION
This PR moves the field and form context to module scope and exports them through the context creation. It avoids Vite's HMR creating new context and breaking the connection by accident.

This will need testing to confirm that it fixed the problems. Until that is confirmed, it's marked as draft.