### PR TITLE
fix(react-form): export returned types from `createFormHook`

### DIFF
--- a/packages/react-form/src/createFormHook.tsx
+++ b/packages/react-form/src/createFormHook.tsx
@@ -133,9 +133,6 @@ interface CreateFormHookProps<
   formContext: Context<AnyFormApi>
 }
 
-/**
- * @private
- */
 export type AppFieldExtendedReactFormApi<
   TFormData,
   TOnMount extends undefined | FormValidateOrFn<TFormData>,

--- a/packages/react-form/src/createFormHook.tsx
+++ b/packages/react-form/src/createFormHook.tsx
@@ -133,6 +133,9 @@ interface CreateFormHookProps<
   formContext: Context<AnyFormApi>
 }
 
+/**
+ * @private
+ */
 export type AppFieldExtendedReactFormApi<
   TFormData,
   TOnMount extends undefined | FormValidateOrFn<TFormData>,

--- a/packages/react-form/src/index.ts
+++ b/packages/react-form/src/index.ts
@@ -2,16 +2,9 @@ export * from '@tanstack/form-core'
 
 export { useStore } from '@tanstack/react-store'
 
-export type { ReactFormApi, ReactFormExtendedApi } from './useForm'
-export { useForm } from './useForm'
-
-export type { UseField, FieldComponent } from './useField'
-export { useField, Field } from './useField'
-
-export { useTransform } from './useTransform'
-
-export type {
-  WithFormProps,
-  WithFieldGroupProps as WithFormLensProps,
-} from './createFormHook'
-export { createFormHook, createFormHookContexts } from './createFormHook'
+export * from './createFormHook'
+export * from './types'
+export * from './useField'
+export * from './useFieldGroup'
+export * from './useForm'
+export * from './useTransform'

--- a/packages/solid-form/src/index.tsx
+++ b/packages/solid-form/src/index.tsx
@@ -2,10 +2,7 @@ export * from '@tanstack/form-core'
 
 export { useStore } from '@tanstack/solid-store'
 
-export { createForm, type SolidFormApi } from './createForm'
-
-export type { CreateField, FieldComponent } from './createField'
-export { createField, Field } from './createField'
-
-export type { WithFormProps } from './createFormHook'
-export { createFormHook, createFormHookContexts } from './createFormHook'
+export * from './createField'
+export * from './createForm'
+export * from './createFormHook'
+export * from './types'


### PR DESCRIPTION
Close #1646 

This type export is required so that libraries with declaration file generation can create explicit types instead of non-portable references.


It's finnicky to trigger the warning or error, so feedback will be needed from users in the linked issue before this is safe to merge.

- [ ] Get feedback from affected users in #1646 
