### PR TITLE
fix(form-core): infer `formOptions` parameter's type correctly

### DIFF
--- a/packages/form-core/src/formOptions.ts
+++ b/packages/form-core/src/formOptions.ts
@@ -4,35 +4,59 @@ import type {
   FormValidateOrFn,
 } from './FormApi'
 
+/*
+
+These types need to do two things:
+
+1. Validator generics need to depend on the TFormData generic
+2. The resulting needs to allow overriding values
+
+The generics from formOptions almost work, except that it loses information
+about how to infer TFormData.
+If you pass a validator function, it tries to resolve the `formApi` or `value`
+inside of it, meaning that TFormData changes to `unknown`.
+
+To bypass this, the intersection for defaultOpts gives TypeScript that information again,
+without losing the benefits from the TOptions generic.
+*/
+
 export function formOptions<
   TOptions extends Partial<
     FormOptions<
       TFormData,
-      TOnMount,
-      TOnChange,
-      TOnChangeAsync,
-      TOnBlur,
-      TOnBlurAsync,
-      TOnSubmit,
-      TOnSubmitAsync,
-      TOnDynamic,
-      TOnDynamicAsync,
-      TOnServer,
+      undefined | FormValidateOrFn<TFormData>,
+      undefined | FormValidateOrFn<TFormData>,
+      undefined | FormAsyncValidateOrFn<TFormData>,
+      undefined | FormValidateOrFn<TFormData>,
+      undefined | FormAsyncValidateOrFn<TFormData>,
+      undefined | FormValidateOrFn<TFormData>,
+      undefined | FormAsyncValidateOrFn<TFormData>,
+      undefined | FormValidateOrFn<TFormData>,
+      undefined | FormAsyncValidateOrFn<TFormData>,
+      undefined | FormAsyncValidateOrFn<TFormData>,
       TSubmitMeta
     >
   >,
-  TFormData,
-  TOnMount extends undefined | FormValidateOrFn<TFormData>,
-  TOnChange extends undefined | FormValidateOrFn<TFormData>,
-  TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
-  TOnBlur extends undefined | FormValidateOrFn<TFormData>,
-  TOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
-  TOnSubmit extends undefined | FormValidateOrFn<TFormData>,
-  TOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
-  TOnDynamic extends undefined | FormValidateOrFn<TFormData>,
-  TOnDynamicAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
-  TOnServer extends undefined | FormAsyncValidateOrFn<TFormData>,
-  TSubmitMeta = never,
->(defaultOpts: TOptions): TOptions {
+  TFormData = TOptions['defaultValues'],
+  TSubmitMeta = TOptions['onSubmitMeta'],
+>(
+  defaultOpts: Partial<
+    FormOptions<
+      TFormData,
+      undefined | FormValidateOrFn<TFormData>,
+      undefined | FormValidateOrFn<TFormData>,
+      undefined | FormAsyncValidateOrFn<TFormData>,
+      undefined | FormValidateOrFn<TFormData>,
+      undefined | FormAsyncValidateOrFn<TFormData>,
+      undefined | FormValidateOrFn<TFormData>,
+      undefined | FormAsyncValidateOrFn<TFormData>,
+      undefined | FormValidateOrFn<TFormData>,
+      undefined | FormAsyncValidateOrFn<TFormData>,
+      undefined | FormAsyncValidateOrFn<TFormData>,
+      TSubmitMeta
+    >
+  > &
+    TOptions,
+): TOptions {
   return defaultOpts
 }

--- a/packages/form-core/src/formOptions.ts
+++ b/packages/form-core/src/formOptions.ts
@@ -5,20 +5,7 @@ import type {
 } from './FormApi'
 
 export function formOptions<
-  TFormData,
-  TOnMount extends undefined | FormValidateOrFn<TFormData>,
-  TOnChange extends undefined | FormValidateOrFn<TFormData>,
-  TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
-  TOnBlur extends undefined | FormValidateOrFn<TFormData>,
-  TOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
-  TOnSubmit extends undefined | FormValidateOrFn<TFormData>,
-  TOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
-  TOnDynamic extends undefined | FormValidateOrFn<TFormData>,
-  TOnDynamicAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
-  TOnServer extends undefined | FormAsyncValidateOrFn<TFormData>,
-  TSubmitMeta = never,
->(
-  defaultOpts: Partial<
+  TOptions extends Partial<
     FormOptions<
       TFormData,
       TOnMount,
@@ -34,21 +21,21 @@ export function formOptions<
       TSubmitMeta
     >
   >,
-): Partial<
-  FormOptions<
-    TFormData,
-    TOnMount,
-    TOnChange,
-    TOnChangeAsync,
-    TOnBlur,
-    TOnBlurAsync,
-    TOnSubmit,
-    TOnSubmitAsync,
-    TOnDynamic,
-    TOnDynamicAsync,
-    TOnServer,
-    TSubmitMeta
-  >
-> {
+  TFormData,
+  TOnMount extends undefined | FormValidateOrFn<TFormData>,
+  TOnChange extends undefined | FormValidateOrFn<TFormData>,
+  TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnBlur extends undefined | FormValidateOrFn<TFormData>,
+  TOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnSubmit extends undefined | FormValidateOrFn<TFormData>,
+  TOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnDynamic extends undefined | FormValidateOrFn<TFormData>,
+  TOnDynamicAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnServer extends undefined | FormAsyncValidateOrFn<TFormData>,
+
+  TSubmitMeta = never,
+>(
+  defaultOpts: TOptions,
+): TOptions {
   return defaultOpts
 }

--- a/packages/form-core/src/formOptions.ts
+++ b/packages/form-core/src/formOptions.ts
@@ -1,4 +1,8 @@
-import type { FormOptions } from './FormApi'
+import type {
+  FormAsyncValidateOrFn,
+  FormOptions,
+  FormValidateOrFn,
+} from './FormApi'
 
 export function formOptions<
   TFormData,

--- a/packages/form-core/src/formOptions.ts
+++ b/packages/form-core/src/formOptions.ts
@@ -1,9 +1,50 @@
 import type { FormOptions } from './FormApi'
 
 export function formOptions<
-  T extends Partial<
-    FormOptions<any, any, any, any, any, any, any, any, any, any, any, any>
+  TFormData,
+  TOnMount extends undefined | FormValidateOrFn<TFormData>,
+  TOnChange extends undefined | FormValidateOrFn<TFormData>,
+  TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnBlur extends undefined | FormValidateOrFn<TFormData>,
+  TOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnSubmit extends undefined | FormValidateOrFn<TFormData>,
+  TOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnDynamic extends undefined | FormValidateOrFn<TFormData>,
+  TOnDynamicAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnServer extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TSubmitMeta = never,
+>(
+  defaultOpts: Partial<
+    FormOptions<
+      TFormData,
+      TOnMount,
+      TOnChange,
+      TOnChangeAsync,
+      TOnBlur,
+      TOnBlurAsync,
+      TOnSubmit,
+      TOnSubmitAsync,
+      TOnDynamic,
+      TOnDynamicAsync,
+      TOnServer,
+      TSubmitMeta
+    >
   >,
->(defaultOpts: T) {
+): Partial<
+  FormOptions<
+    TFormData,
+    TOnMount,
+    TOnChange,
+    TOnChangeAsync,
+    TOnBlur,
+    TOnBlurAsync,
+    TOnSubmit,
+    TOnSubmitAsync,
+    TOnDynamic,
+    TOnDynamicAsync,
+    TOnServer,
+    TSubmitMeta
+  >
+> {
   return defaultOpts
 }

--- a/packages/form-core/src/formOptions.ts
+++ b/packages/form-core/src/formOptions.ts
@@ -32,10 +32,7 @@ export function formOptions<
   TOnDynamic extends undefined | FormValidateOrFn<TFormData>,
   TOnDynamicAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
   TOnServer extends undefined | FormAsyncValidateOrFn<TFormData>,
-
   TSubmitMeta = never,
->(
-  defaultOpts: TOptions,
-): TOptions {
+>(defaultOpts: TOptions): TOptions {
   return defaultOpts
 }

--- a/packages/form-core/tests/FormApi.test-d.ts
+++ b/packages/form-core/tests/FormApi.test-d.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf, it } from 'vitest'
 import { z } from 'zod'
-import { FormApi } from '../src'
+import { FormApi, formOptions } from '../src'
 import type {
   DeepKeys,
   GlobalFormValidationError,
@@ -374,4 +374,72 @@ it('should extract the form error type from a global form error', () => {
       | undefined
     )[]
   >
+})
+
+it('listeners should be typed correctly', () => {
+  type FormData = {
+    firstName: string
+    lastName: string
+  }
+
+  const form = new FormApi({
+    defaultValues: {
+      firstName: '',
+      lastName: '',
+    } as FormData,
+    listeners: {
+      onSubmit: ({ formApi }) => {
+        expectTypeOf(formApi.state.values).toEqualTypeOf<FormData>()
+      },
+    },
+  })
+
+  form.handleSubmit()
+})
+
+it('listeners sholud be types when using formOptions', () => {
+  type FormData = {
+    firstName: string
+    lastName: string
+  }
+
+  const formOpts = formOptions({
+    defaultValues: {
+      firstName: 'FirstName',
+      lastName: 'LastName',
+    } as FormData,
+    validators: {
+      onSubmit: () => {
+        return {
+          test: 'test',
+        }
+      },
+    },
+    listeners: {
+      onSubmit: ({ formApi }) => {
+        expectTypeOf(formApi.state.values).toEqualTypeOf<FormData>()
+      },
+    },
+  })
+
+  const form = new FormApi({
+    ...formOpts,
+    listeners: {
+      // this doesn't error since listeners return void
+      onSubmit: ({ formApi }) => {
+        console.log(formApi.state.values)
+      },
+    },
+    validators: {
+      // this errors becuase the return type is not the same as the validator return type
+      // onSubmit: () => 'custom on submit',
+      onSubmit: () => {
+        return {
+          test: 'can change the value!',
+        }
+      },
+    },
+  })
+
+  form.handleSubmit()
 })

--- a/packages/form-core/tests/FormApi.test-d.ts
+++ b/packages/form-core/tests/FormApi.test-d.ts
@@ -397,7 +397,7 @@ it('listeners should be typed correctly', () => {
   form.handleSubmit()
 })
 
-it('listeners sholud be types when using formOptions', () => {
+it('listeners should be typed correctly when using formOptions', () => {
   type FormData = {
     firstName: string
     lastName: string
@@ -433,10 +433,14 @@ it('listeners sholud be types when using formOptions', () => {
     validators: {
       // this errors becuase the return type is not the same as the validator return type
       // onSubmit: () => 'custom on submit',
+
       onSubmit: () => {
         return {
           test: 'can change the value!',
         }
+      },
+      onChange: () => {
+        return 'onChange'
       },
     },
   })


### PR DESCRIPTION
- Add TFormData generic parameter to formOptions function
- Add test to verify listener type preservation with formOptions
- Current implementation has intentional type issues for investigation