### PR TITLE
fix(form-core): Trigger listeners and validation on `setFieldValue`

### DIFF
--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -9,6 +9,7 @@ import {
   getAsyncValidatorArray,
   getBy,
   getSyncValidatorArray,
+  mergeOpts,
 } from './utils'
 import { defaultValidationLogic } from './ValidationLogic'
 import type { DeepKeys, DeepValue, UnwrapOneLevelOfArray } from './util-types'
@@ -1350,11 +1351,19 @@ export class FieldApi<
    * Sets the field value and run the `change` validator.
    */
   setValue = (updater: Updater<TData>, options?: UpdateMetaOptions) => {
-    this.form.setFieldValue(this.name, updater as never, options)
+    this.form.setFieldValue(
+      this.name,
+      updater as never,
+      mergeOpts(options, { dontRunListeners: true, dontValidate: true }),
+    )
 
-    this.triggerOnChangeListener()
+    if (!options?.dontRunListeners) {
+      this.triggerOnChangeListener()
+    }
 
-    this.validate('change')
+    if (!options?.dontValidate) {
+      this.validate('change')
+    }
   }
 
   getMeta = () => this.store.state.meta
@@ -1400,11 +1409,17 @@ export class FieldApi<
    */
   pushValue = (
     value: TData extends any[] ? TData[number] : never,
-    opts?: UpdateMetaOptions,
+    options?: UpdateMetaOptions,
   ) => {
-    this.form.pushFieldValue(this.name, value as any, opts)
+    this.form.pushFieldValue(
+      this.name,
+      value as any,
+      mergeOpts(options, { dontRunListeners: true }),
+    )
 
-    this.triggerOnChangeListener()
+    if (!options?.dontRunListeners) {
+      this.triggerOnChangeListener()
+    }
   }
 
   /**
@@ -1413,11 +1428,18 @@ export class FieldApi<
   insertValue = (
     index: number,
     value: TData extends any[] ? TData[number] : never,
-    opts?: UpdateMetaOptions,
+    options?: UpdateMetaOptions,
   ) => {
-    this.form.insertFieldValue(this.name, index, value as any, opts)
+    this.form.insertFieldValue(
+      this.name,
+      index,
+      value as any,
+      mergeOpts(options, { dontRunListeners: true }),
+    )
 
-    this.triggerOnChangeListener()
+    if (!options?.dontRunListeners) {
+      this.triggerOnChangeListener()
+    }
   }
 
   /**
@@ -1426,47 +1448,83 @@ export class FieldApi<
   replaceValue = (
     index: number,
     value: TData extends any[] ? TData[number] : never,
-    opts?: UpdateMetaOptions,
+    options?: UpdateMetaOptions,
   ) => {
-    this.form.replaceFieldValue(this.name, index, value as any, opts)
+    this.form.replaceFieldValue(
+      this.name,
+      index,
+      value as any,
+      mergeOpts(options, { dontRunListeners: true }),
+    )
 
-    this.triggerOnChangeListener()
+    if (!options?.dontRunListeners) {
+      this.triggerOnChangeListener()
+    }
   }
 
   /**
    * Removes a value at the specified index.
    */
-  removeValue = (index: number, opts?: UpdateMetaOptions) => {
-    this.form.removeFieldValue(this.name, index, opts)
+  removeValue = (index: number, options?: UpdateMetaOptions) => {
+    this.form.removeFieldValue(
+      this.name,
+      index,
+      mergeOpts(options, { dontRunListeners: true }),
+    )
 
-    this.triggerOnChangeListener()
+    if (!options?.dontRunListeners) {
+      this.triggerOnChangeListener()
+    }
   }
 
   /**
    * Swaps the values at the specified indices.
    */
-  swapValues = (aIndex: number, bIndex: number, opts?: UpdateMetaOptions) => {
-    this.form.swapFieldValues(this.name, aIndex, bIndex, opts)
+  swapValues = (
+    aIndex: number,
+    bIndex: number,
+    options?: UpdateMetaOptions,
+  ) => {
+    this.form.swapFieldValues(
+      this.name,
+      aIndex,
+      bIndex,
+      mergeOpts(options, { dontRunListeners: true }),
+    )
 
-    this.triggerOnChangeListener()
+    if (!options?.dontRunListeners) {
+      this.triggerOnChangeListener()
+    }
   }
 
   /**
    * Moves the value at the first specified index to the second specified index.
    */
-  moveValue = (aIndex: number, bIndex: number, opts?: UpdateMetaOptions) => {
-    this.form.moveFieldValues(this.name, aIndex, bIndex, opts)
+  moveValue = (aIndex: number, bIndex: number, options?: UpdateMetaOptions) => {
+    this.form.moveFieldValues(
+      this.name,
+      aIndex,
+      bIndex,
+      mergeOpts(options, { dontRunListeners: true }),
+    )
 
-    this.triggerOnChangeListener()
+    if (!options?.dontRunListeners) {
+      this.triggerOnChangeListener()
+    }
   }
 
   /**
    * Clear all values from the array.
    */
-  clearValues = (opts?: UpdateMetaOptions) => {
-    this.form.clearFieldValues(this.name, opts)
+  clearValues = (options?: UpdateMetaOptions) => {
+    this.form.clearFieldValues(
+      this.name,
+      mergeOpts(options, { dontRunListeners: true }),
+    )
 
-    this.triggerOnChangeListener()
+    if (!options?.dontRunListeners) {
+      this.triggerOnChangeListener()
+    }
   }
 
   /**
@@ -1936,7 +1994,10 @@ export class FieldApi<
     }
   }
 
-  private triggerOnChangeListener() {
+  /**
+   * @private
+   */
+  triggerOnChangeListener() {
     const formDebounceMs = this.form.options.listeners?.onChangeDebounceMs
     if (formDebounceMs && formDebounceMs > 0) {
       if (this.timeoutIds.formListeners.change) {

--- a/packages/form-core/src/types.ts
+++ b/packages/form-core/src/types.ts
@@ -134,6 +134,14 @@ export interface UpdateMetaOptions {
    * @default false
    */
   dontUpdateMeta?: boolean
+  /**
+   * @default false
+   */
+  dontValidate?: boolean
+  /**
+   * @default false
+   */
+  dontRunListeners?: boolean
 }
 
 /**

--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -539,3 +539,18 @@ export function createFieldMap<T>(values: Readonly<T>): { [K in keyof T]: K } {
 
   return output
 }
+
+/**
+ * Merge the first parameter with the given overrides.
+ * @private
+ */
+export function mergeOpts<T extends Record<string, unknown>>(
+  originalOpts: T | undefined | null,
+  overrides: T,
+): T {
+  if (originalOpts === undefined || originalOpts === null) {
+    return overrides
+  }
+
+  return { ...originalOpts, ...overrides }
+}

--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -544,7 +544,7 @@ export function createFieldMap<T>(values: Readonly<T>): { [K in keyof T]: K } {
  * Merge the first parameter with the given overrides.
  * @private
  */
-export function mergeOpts<T extends Record<string, unknown>>(
+export function mergeOpts<T>(
   originalOpts: T | undefined | null,
   overrides: T,
 ): T {

--- a/packages/form-core/tests/utils.spec.ts
+++ b/packages/form-core/tests/utils.spec.ts
@@ -8,6 +8,7 @@ import {
   evaluate,
   getBy,
   makePathArray,
+  mergeOpts,
   setBy,
 } from '../src/index'
 
@@ -723,5 +724,30 @@ describe('createFieldMap', () => {
     const copy = { ...input }
     createFieldMap(input)
     expect(input).toEqual(copy)
+  })
+})
+
+describe('mergeOpts', () => {
+  type SomeOpts = {
+    foo?: string
+    bar?: boolean
+  }
+
+  it('should return the overrides if original object is undefined', () => {
+    expect(mergeOpts<SomeOpts>(undefined, { foo: 'test' })).toEqual({
+      foo: 'test',
+    })
+    expect(mergeOpts<SomeOpts>(null, { foo: 'test' })).toEqual({ foo: 'test' })
+  })
+
+  it('should preserve properties that were not overwritten', () => {
+    const original: SomeOpts = {
+      foo: 'test',
+    }
+    expect(mergeOpts(original, { bar: true })).toEqual({
+      foo: 'test',
+      bar: true,
+    })
+    expect(mergeOpts(original, {})).toEqual({ foo: 'test' })
   })
 })


### PR DESCRIPTION
Also adds two meta properties, `dontValidate` and `dontRunListeners`. Should help in case someone wants extreme control, but it's more for our sake.