### PR TITLE
fix(react-core): nextjs `onServerValidate` decode options types

### DIFF
--- a/packages/react-form/src/nextjs/createServerValidate.ts
+++ b/packages/react-form/src/nextjs/createServerValidate.ts
@@ -44,6 +44,9 @@ interface CreateServerValidateOptions<
   onServerValidate: TOnServer
 }
 
+type Tail<T extends unknown[]> = T extends [unknown, ...infer R] ? R : never;
+
+
 export const createServerValidate =
   <
     TFormData,
@@ -74,7 +77,7 @@ export const createServerValidate =
       TSubmitMeta
     >,
   ) =>
-  async (formData: FormData, info?: Parameters<typeof decode>[1]) => {
+  async (formData: FormData, ...decodeOptions: Tail<Parameters<typeof decode>>) => {
     const { onServerValidate } = defaultOpts
 
     const runValidator = async ({
@@ -97,7 +100,7 @@ export const createServerValidate =
       })
     }
 
-    const values = decode(formData, info) as never as TFormData
+    const values = decode(formData, ...decodeOptions) as never as TFormData
 
     const onServerError = (await runValidator({
       value: values,


### PR DESCRIPTION
The `decode` function from `decode-formdata` [is overloaded](https://github.com/fabian-hiller/decode-formdata/blob/e8b6689734ad14df7f4248ce066512ef84bc596f/src/decode.ts#L35), leading to some type quirks when trying to pass in `FormDataInfo` to `serverValidate`