### PR TITLE
feat(form-core): add onDynamicListenTo validator option

### DIFF
--- a/docs/framework/react/guides/linked-fields.md
+++ b/docs/framework/react/guides/linked-fields.md
@@ -75,3 +75,95 @@ function App() {
 ```
 
 This similarly works with `onBlurListenTo` property, which will re-run the validation when the field is blurred.
+
+## Dynamic Validation with onDynamicListenTo
+
+For more advanced use cases where you need dynamic validation that responds to field changes but follows React Hook Form-like behavior, you can use `onDynamicListenTo` with `onDynamic` validators.
+
+The `onDynamicListenTo` property works similarly to `onChangeListenTo` and `onBlurListenTo`, but it's specifically designed for dynamic validation scenarios where you want more control over when validation occurs.
+
+```tsx
+function App() {
+  const form = useForm({
+    defaultValues: {
+      password: '',
+      confirm_password: '',
+    },
+    validationLogic: revalidateLogic(),
+  })
+
+  return (
+    <div>
+      <form.Field name="password">
+        {(field) => (
+          <label>
+            <div>Password</div>
+            <input
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+            />
+          </label>
+        )}
+      </form.Field>
+      <form.Field
+        name="confirm_password"
+        validators={{
+          onDynamicListenTo: ['password'],
+          onDynamic: ({ value, fieldApi }) => {
+            if (value !== fieldApi.form.getFieldValue('password')) {
+              return 'Passwords do not match'
+            }
+            return undefined
+          },
+        }}
+      >
+        {(field) => (
+          <div>
+            <label>
+              <div>Confirm Password</div>
+              <input
+                value={field.state.value}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+            </label>
+            {field.state.meta.errors.map((err) => (
+              <div key={err}>{err}</div>
+            ))}
+          </div>
+        )}
+      </form.Field>
+    </div>
+  )
+}
+```
+
+### Key Differences
+
+- **onChangeListenTo**: Runs validation immediately when the listened field changes
+- **onBlurListenTo**: Runs validation when the listened field is blurred  
+- **onDynamicListenTo**: Runs validation based on the form's validation logic (typically used with `revalidateLogic` for React Hook Form-like behavior)
+
+### Multiple Field Listening
+
+You can listen to multiple fields by providing an array
+
+```tsx
+<form.Field
+  name="dependent_field"
+  validators={{
+    onDynamicListenTo: ['field1', 'field2', 'field3'],
+    onDynamic: ({ value, fieldApi }) => {
+      // Validation logic that depends on multiple fields
+      const field1Value = fieldApi.form.getFieldValue('field1')
+      const field2Value = fieldApi.form.getFieldValue('field2')
+      const field3Value = fieldApi.form.getFieldValue('field3')
+      
+      if (field1Value && field2Value && field3Value && !value) {
+        return 'This field is required when all other fields have values'
+      }
+      return undefined
+    },
+  }}
+>
+</form.Field>
+```

--- a/packages/form-core/src/ValidationLogic.ts
+++ b/packages/form-core/src/ValidationLogic.ts
@@ -26,7 +26,7 @@ export interface ValidationLogicProps {
     | undefined
     | null
   event: {
-    type: 'blur' | 'change' | 'submit' | 'mount' | 'server'
+    type: 'blur' | 'change' | 'submit' | 'mount' | 'server' | 'dynamic'
     fieldName?: string
     async: boolean
   }
@@ -147,6 +147,11 @@ export const defaultValidationLogic: ValidationLogicFn = (props) => {
     cause: 'submit',
   } as const
 
+  const onDynamicValidator = {
+    fn: isAsync ? props.validators.onDynamicAsync : props.validators.onDynamic,
+    cause: 'dynamic',
+  } as const
+
   // Allows us to clear onServer errors
   const onServerValidator = isAsync
     ? undefined
@@ -190,6 +195,13 @@ export const defaultValidationLogic: ValidationLogicFn = (props) => {
       // Run change, server validation
       return props.runValidation({
         validators: [onChangeValidator, onServerValidator],
+        form: props.form,
+      })
+    }
+    case 'dynamic': {
+      // Run dynamic validation
+      return props.runValidation({
+        validators: [onDynamicValidator],
         form: props.form,
       })
     }


### PR DESCRIPTION
Adds `onDynamicListenTo` validator option to enable automatic dynamic validation when specified fields change, following the same pattern as existing `onChangeListenTo` and `onBlurListenTo` options.

## Changes

- **Type definitions**: Added `onDynamicListenTo?: DeepKeys<TParentData>[]` to [FieldValidators](cci:2://file:///Users/leejihoon/Documents/open-source/form/packages/form-core/src/FieldApi.ts:284:0-374:1)
- **Core logic**: Extended `getLinkedFields()` to support `dynamic` validation cause
- **Auto-trigger**: Modified `setValue()` to automatically trigger dynamic validation on linked fields
- **Validation logic**: Added `dynamic` case support in [defaultValidationLogic](cci:1://file:///Users/leejihoon/Documents/open-source/form/packages/form-core/src/ValidationLogic.ts:119:0-211:1)
- **Tests**: Comprehensive test coverage for sync/async scenarios and multiple field listening
- **Documentation**: Added usage guide and examples in React linked fields documentation

## Usage

```tsx
<form.Field
  name="confirmPassword"
  validators={{
    onDynamicListenTo: ['password'],
    onDynamic: ({ value, fieldApi }) => {
      if (value !== fieldApi.form.getFieldValue('password')) {
        return 'Passwords do not match'
      }
    }
  }}
>
  {/* Field render */}
</form.Field>