### PR TITLE
fix: Upgrade devalue to fix security vulnerability

### DIFF
--- a/packages/react-form/package.json
+++ b/packages/react-form/package.json
@@ -84,7 +84,7 @@
     "@tanstack/form-core": "workspace:*",
     "@tanstack/react-store": "^0.7.4",
     "decode-formdata": "^0.9.0",
-    "devalue": "^5.1.1"
+    "devalue": "^5.3.2"
   },
   "devDependencies": {
     "@tanstack/react-start": "^1.131.27",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1125,8 +1125,8 @@ importers:
         specifier: ^0.9.0
         version: 0.9.0
       devalue:
-        specifier: ^5.1.1
-        version: 5.1.1
+        specifier: ^5.3.2
+        version: 5.3.2
     devDependencies:
       '@tanstack/react-start':
         specifier: ^1.131.27
@@ -6398,8 +6398,8 @@ packages:
     peerDependencies:
       typescript: ^5.4.4
 
-  devalue@5.1.1:
-    resolution: {integrity: sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==}
+  devalue@5.3.2:
+    resolution: {integrity: sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==}
 
   diff@5.2.0:
     resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
@@ -17114,7 +17114,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  devalue@5.1.1: {}
+  devalue@5.3.2: {}
 
   diff@5.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,15 @@ packages:
   - 'examples/vue/**'
   - 'examples/lit/**'
   - 'examples/svelte/**'
+catalog:
+  '@tanstack/react-start': ^1.131.27
+  '@tanstack/react-store': ^0.7.4
+  '@types/react': ^19.0.7
+  '@types/react-dom': ^19.0.3
+  '@vitejs/plugin-react': ^4.7.0
+  decode-formdata: ^0.9.0
+  devalue: ^5.3.2
+  eslint-plugin-react-compiler: 19.0.0-beta-ebf51a3-20250411
+  react: ^19.0.0
+  react-dom: ^19.0.0
+  vite: ^7.1.3


### PR DESCRIPTION
From this vulnerability report: https://github.com/sveltejs/devalue/security/advisories/GHSA-vj54-72f3-p5jv

Upgraded the `devalue` dependency to its latest version `^5.3.2` to include the fix in this version of Tanstack Form