### PR TITLE
fix(form-core): prevent stale reactivity when using Date objects

### DIFF
--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -431,6 +431,10 @@ export function evaluate<T>(objA: T, objB: T) {
     return false
   }
 
+  if (objA instanceof Date && objB instanceof Date) {
+    return objA.getTime() === objB.getTime()
+  }
+
   if (objA instanceof Map && objB instanceof Map) {
     if (objA.size !== objB.size) return false
     for (const [k, v] of objA) {
@@ -539,3 +543,4 @@ export function createFieldMap<T>(values: Readonly<T>): { [K in keyof T]: K } {
 
   return output
 }
+

--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -543,4 +543,3 @@ export function createFieldMap<T>(values: Readonly<T>): { [K in keyof T]: K } {
 
   return output
 }
-

--- a/packages/form-core/tests/utils.spec.ts
+++ b/packages/form-core/tests/utils.spec.ts
@@ -648,6 +648,24 @@ describe('evaluate', () => {
     )
     expect(objComplexTrue).toEqual(true)
   })
+
+  it('should test equality between Date objects', () => {
+    const date1 = new Date('2025-01-01T00:00:00.000Z')
+    const date2 = new Date('2025-01-01T00:00:00.000Z')
+    const date3 = new Date('2025-01-02T00:00:00.000Z')
+
+    const dateTrue = evaluate(date1, date2)
+    expect(dateTrue).toEqual(true)
+
+    const dateFalse = evaluate(date1, date3)
+    expect(dateFalse).toEqual(false)
+
+    const dateObjectTrue = evaluate({ date: date1 }, { date: date2 })
+    expect(dateObjectTrue).toEqual(true)
+
+    const dateObjectFalse = evaluate({ date: date1 }, { date: date3 })
+    expect(dateObjectFalse).toEqual(false)
+  })
 })
 
 describe('concatenatePaths', () => {


### PR DESCRIPTION
## Description
Fixes issue where `isDefaultValue` was not updating correctly when changing date fields.

## Problem
The `evaluate` function was treating Date objects as regular objects, causing incorrect equality comparisons for date values.

## Solution
- Added specific Date object comparison using `getTime()` method
- Added comprehensive tests for Date object comparison scenarios

## Fixes
Closes #1712
