### PR TITLE
docs(react-form): fix incorrect error display in example

### DIFF
--- a/docs/framework/react/guides/custom-errors.md
+++ b/docs/framework/react/guides/custom-errors.md
@@ -69,10 +69,8 @@ Useful for representing quantities, thresholds, or magnitudes:
 Display in UI:
 
 ```tsx
-{
-  /* TypeScript knows the error is a number based on your validator */
-}
-;<div className="error">
+// TypeScript knows the error is a number based on your validator
+<div className="error">
   You need {field.state.meta.errors[0]} more years to be eligible
 </div>
 ```


### PR DESCRIPTION
## Summary

- removed a stray semicolon (;) that appeared after a JSX comment
- replaced comment with a regular line comment (// ...) for better readability


## Description

i think that semicolon was unnecessary and could confuse readers when copying or reading the example. 🤔