### PR TITLE
Add @tanstack/form-server Package

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -155,6 +155,10 @@
               "to": "framework/react/guides/ssr"
             },
             {
+              "label": "Server Errors & Success Flows",
+              "to": "framework/react/guides/server-errors-and-success"
+            },
+            {
               "label": "Debugging",
               "to": "framework/react/guides/debugging"
             }

--- a/docs/framework/react/guides/server-errors-and-success.md
+++ b/docs/framework/react/guides/server-errors-and-success.md
@@ -23,7 +23,6 @@ The `mapServerErrors` function converts different server error formats into a st
 ```tsx
 import { mapServerErrors } from '@tanstack/form-server'
 
-// Zod-like errors
 const zodError = {
   issues: [
     { path: ['name'], message: 'Name is required' },
@@ -32,7 +31,6 @@ const zodError = {
 }
 
 const mapped = mapServerErrors(zodError)
-// Result: { fields: { name: ['Name is required'], email: ['Invalid email format'] } }
 ```
 
 ### Supported Error Formats
@@ -46,7 +44,6 @@ const zodError = {
     { path: ['items', 0, 'price'], message: 'Price must be positive' }
   ]
 }
-// Maps to: { fields: { 'items.0.price': ['Price must be positive'] } }
 ```
 
 #### Rails-style Errors
@@ -57,7 +54,6 @@ const railsError = {
     email: ['Invalid email', 'Email already taken']
   }
 }
-// Maps to: { fields: { name: ['Name is required'], email: ['Invalid email', 'Email already taken'] } }
 ```
 
 #### Custom Field/Form Errors
@@ -68,7 +64,6 @@ const customError = {
   ],
   formError: { message: 'Form submission failed' }
 }
-// Maps to: { fields: { name: ['Name is required'] }, form: 'Form submission failed' }
 ```
 
 ### Path Mapping
@@ -139,18 +134,15 @@ const form = useForm({
       const result = await submitForm(value)
       
       await onServerSuccess(form, result, {
-        resetStrategy: 'values', // 'none' | 'values' | 'all'
         flash: {
           set: (message) => setFlashMessage(message),
           message: 'Form saved successfully!'
         },
         after: async () => {
-          // Navigate or perform other actions
           router.push('/success')
         }
       })
     } catch (error) {
-      // Handle errors...
     }
   }
 })
@@ -270,7 +262,6 @@ import { mapServerErrors, applyServerErrors, onServerSuccess } from '@tanstack/f
 async function createUser(formData: FormData) {
   'use server'
   
-  // Server action implementation
   try {
     const result = await db.user.create({
       data: Object.fromEntries(formData)
@@ -303,7 +294,6 @@ function UserForm() {
     }
   })
   
-  // Form JSX...
 }
 ```
 
@@ -329,11 +319,9 @@ function UserForm() {
   
   const form = useForm({
     onSubmit: ({ value }) => {
-      // Remix handles submission
     }
   })
 
-  // Apply server errors if present
   useEffect(() => {
     if (actionData?.error) {
       const mappedErrors = mapServerErrors(actionData.error)
@@ -341,6 +329,5 @@ function UserForm() {
     }
   }, [actionData])
   
-  // Form JSX...
 }
 ```

--- a/docs/framework/react/guides/server-errors-and-success.md
+++ b/docs/framework/react/guides/server-errors-and-success.md
@@ -1,0 +1,346 @@
+# Server Errors & Success Flows
+
+TanStack Form provides utilities for handling server-side validation errors and success responses through the `@tanstack/form-server` package.
+
+## Installation
+
+```bash
+npm install @tanstack/form-server
+```
+
+## Overview
+
+The form-server package provides three main utilities:
+
+- **`mapServerErrors`** - Normalizes various server error formats into a consistent structure
+- **`applyServerErrors`** - Applies mapped errors to form fields and form-level state
+- **`onServerSuccess`** - Handles successful responses with configurable reset and callback options
+
+## Mapping Server Errors
+
+The `mapServerErrors` function converts different server error formats into a standardized structure:
+
+```tsx
+import { mapServerErrors } from '@tanstack/form-server'
+
+// Zod-like errors
+const zodError = {
+  issues: [
+    { path: ['name'], message: 'Name is required' },
+    { path: ['email'], message: 'Invalid email format' }
+  ]
+}
+
+const mapped = mapServerErrors(zodError)
+// Result: { fields: { name: ['Name is required'], email: ['Invalid email format'] } }
+```
+
+### Supported Error Formats
+
+The function automatically detects and handles various server error formats:
+
+#### Zod-style Validation Errors
+```tsx
+const zodError = {
+  issues: [
+    { path: ['items', 0, 'price'], message: 'Price must be positive' }
+  ]
+}
+// Maps to: { fields: { 'items.0.price': ['Price must be positive'] } }
+```
+
+#### Rails-style Errors
+```tsx
+const railsError = {
+  errors: {
+    name: 'Name is required',
+    email: ['Invalid email', 'Email already taken']
+  }
+}
+// Maps to: { fields: { name: ['Name is required'], email: ['Invalid email', 'Email already taken'] } }
+```
+
+#### Custom Field/Form Errors
+```tsx
+const customError = {
+  fieldErrors: [
+    { path: 'name', message: 'Name is required' }
+  ],
+  formError: { message: 'Form submission failed' }
+}
+// Maps to: { fields: { name: ['Name is required'] }, form: 'Form submission failed' }
+```
+
+### Path Mapping
+
+Use custom path mappers to handle different naming conventions:
+
+```tsx
+const pathMapper = (path: string) => 
+  path.replace(/_attributes/g, '').replace(/\[(\w+)\]/g, '.$1')
+
+const mapped = mapServerErrors(railsError, { pathMapper })
+```
+
+## Applying Errors to Forms
+
+Use `applyServerErrors` to inject server errors into your form:
+
+```tsx
+import { useForm } from '@tanstack/react-form'
+import { mapServerErrors, applyServerErrors } from '@tanstack/form-server'
+
+function MyForm() {
+  const form = useForm({
+    defaultValues: { name: '', email: '' },
+    onSubmit: async ({ value }) => {
+      try {
+        await submitForm(value)
+      } catch (serverError) {
+        const mappedErrors = mapServerErrors(serverError)
+        applyServerErrors(form, mappedErrors)
+      }
+    }
+  })
+
+  return (
+    <form onSubmit={(e) => {
+      e.preventDefault()
+      form.handleSubmit()
+    }}>
+      <form.Field name="name">
+        {(field) => (
+          <div>
+            <input
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+            />
+            {field.state.meta.errors.map((error) => (
+              <p key={error}>{error}</p>
+            ))}
+          </div>
+        )}
+      </form.Field>
+    </form>
+  )
+}
+```
+
+## Handling Success Responses
+
+The `onServerSuccess` function provides configurable success handling:
+
+```tsx
+import { onServerSuccess } from '@tanstack/form-server'
+
+const form = useForm({
+  onSubmit: async ({ value }) => {
+    try {
+      const result = await submitForm(value)
+      
+      await onServerSuccess(form, result, {
+        resetStrategy: 'values', // 'none' | 'values' | 'all'
+        flash: {
+          set: (message) => setFlashMessage(message),
+          message: 'Form saved successfully!'
+        },
+        after: async () => {
+          // Navigate or perform other actions
+          router.push('/success')
+        }
+      })
+    } catch (error) {
+      // Handle errors...
+    }
+  }
+})
+```
+
+### Reset Strategies
+
+- **`'none'`** - Don't reset the form
+- **`'values'`** - Reset form values but keep validation state
+- **`'all'`** - Reset everything including validation state
+
+## Complete Example
+
+```tsx
+import { useForm } from '@tanstack/react-form'
+import { mapServerErrors, applyServerErrors, onServerSuccess } from '@tanstack/form-server'
+import { useState } from 'react'
+
+function UserForm() {
+  const [flashMessage, setFlashMessage] = useState('')
+
+  const form = useForm({
+    defaultValues: {
+      name: '',
+      email: '',
+      profile: { bio: '' }
+    },
+    onSubmit: async ({ value }) => {
+      try {
+        const result = await fetch('/api/users', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(value)
+        })
+
+        if (!result.ok) {
+          const error = await result.json()
+          const mappedErrors = mapServerErrors(error, {
+            fallbackFormMessage: 'Failed to create user'
+          })
+          applyServerErrors(form, mappedErrors)
+          return
+        }
+
+        const userData = await result.json()
+        await onServerSuccess(form, userData, {
+          resetStrategy: 'all',
+          flash: {
+            set: setFlashMessage,
+            message: 'User created successfully!'
+          }
+        })
+      } catch (error) {
+        const mappedErrors = mapServerErrors(error)
+        applyServerErrors(form, mappedErrors)
+      }
+    }
+  })
+
+  return (
+    <div>
+      {flashMessage && (
+        <div className="success-message">{flashMessage}</div>
+      )}
+      
+      <form onSubmit={(e) => {
+        e.preventDefault()
+        form.handleSubmit()
+      }}>
+        <form.Field name="name">
+          {(field) => (
+            <div>
+              <label>Name:</label>
+              <input
+                value={field.state.value}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              {field.state.meta.errors.map((error) => (
+                <p key={error} className="error">{error}</p>
+              ))}
+            </div>
+          )}
+        </form.Field>
+
+        <form.Field name="email">
+          {(field) => (
+            <div>
+              <label>Email:</label>
+              <input
+                type="email"
+                value={field.state.value}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              {field.state.meta.errors.map((error) => (
+                <p key={error} className="error">{error}</p>
+              ))}
+            </div>
+          )}
+        </form.Field>
+
+        <button type="submit" disabled={form.state.isSubmitting}>
+          {form.state.isSubmitting ? 'Creating...' : 'Create User'}
+        </button>
+      </form>
+    </div>
+  )
+}
+```
+
+## Framework Integration
+
+### Next.js App Router
+
+```tsx
+import { mapServerErrors, applyServerErrors, onServerSuccess } from '@tanstack/form-server'
+
+async function createUser(formData: FormData) {
+  'use server'
+  
+  // Server action implementation
+  try {
+    const result = await db.user.create({
+      data: Object.fromEntries(formData)
+    })
+    return { success: true, user: result }
+  } catch (error) {
+    return { success: false, error }
+  }
+}
+
+function UserForm() {
+  const form = useForm({
+    onSubmit: async ({ value }) => {
+      const formData = new FormData()
+      Object.entries(value).forEach(([key, val]) => {
+        formData.append(key, val as string)
+      })
+      
+      const result = await createUser(formData)
+      
+      if (result.success) {
+        await onServerSuccess(form, result.user, {
+          resetStrategy: 'all',
+          flash: { set: toast.success, message: 'User created!' }
+        })
+      } else {
+        const mappedErrors = mapServerErrors(result.error)
+        applyServerErrors(form, mappedErrors)
+      }
+    }
+  })
+  
+  // Form JSX...
+}
+```
+
+### Remix
+
+```tsx
+import { mapServerErrors, applyServerErrors } from '@tanstack/form-server'
+import { useActionData } from '@remix-run/react'
+
+export async function action({ request }: ActionFunctionArgs) {
+  const formData = await request.formData()
+  
+  try {
+    const user = await createUser(Object.fromEntries(formData))
+    return redirect('/users')
+  } catch (error) {
+    return json({ error }, { status: 400 })
+  }
+}
+
+function UserForm() {
+  const actionData = useActionData<typeof action>()
+  
+  const form = useForm({
+    onSubmit: ({ value }) => {
+      // Remix handles submission
+    }
+  })
+
+  // Apply server errors if present
+  useEffect(() => {
+    if (actionData?.error) {
+      const mappedErrors = mapServerErrors(actionData.error)
+      applyServerErrors(form, mappedErrors)
+    }
+  }, [actionData])
+  
+  // Form JSX...
+}
+```

--- a/packages/form-server/eslint.config.js
+++ b/packages/form-server/eslint.config.js
@@ -1,0 +1,5 @@
+// @ts-check
+
+import rootConfig from '../../eslint.config.js'
+
+export default [...rootConfig]

--- a/packages/form-server/package.json
+++ b/packages/form-server/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@tanstack/form-server",
+  "version": "1.20.0",
+  "description": "Server-side utilities for TanStack Form.",
+  "author": "tannerlinsley",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TanStack/form.git",
+    "directory": "packages/form-server"
+  },
+  "homepage": "https://tanstack.com/form",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/tannerlinsley"
+  },
+  "scripts": {
+    "clean": "premove ./dist ./coverage",
+    "test:eslint": "eslint ./src ./tests",
+    "test:types": "pnpm run \"/^test:types:ts[0-9]{2}$/\"",
+    "test:types:ts54": "node ../../node_modules/typescript54/lib/tsc.js",
+    "test:types:ts55": "node ../../node_modules/typescript55/lib/tsc.js",
+    "test:types:ts56": "node ../../node_modules/typescript56/lib/tsc.js",
+    "test:types:ts57": "node ../../node_modules/typescript57/lib/tsc.js",
+    "test:types:ts58": "tsc",
+    "test:lib": "vitest",
+    "test:lib:dev": "pnpm run test:lib --watch",
+    "test:build": "publint --strict",
+    "build": "vite build"
+  },
+  "type": "module",
+  "types": "dist/esm/index.d.ts",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "files": [
+    "dist",
+    "src"
+  ],
+  "dependencies": {
+    "@tanstack/form-core": "workspace:*"
+  }
+}

--- a/packages/form-server/src/index.ts
+++ b/packages/form-server/src/index.ts
@@ -1,0 +1,178 @@
+export type ServerFieldError = { 
+  path: string
+  message: string
+  code?: string 
+}
+
+export type ServerFormError = { 
+  message: string
+  code?: string 
+}
+
+export type MappedServerErrors = { 
+  fields: Record<string, string[]>
+  form?: string 
+}
+
+export type SuccessOptions = {
+  resetStrategy?: 'none' | 'values' | 'all'
+  flash?: { set: (msg: string) => void; message?: string }
+  after?: () => void | Promise<void>
+}
+
+export function mapServerErrors(
+  err: unknown,
+  opts?: { 
+    pathMapper?: (serverPath: string) => string
+    fallbackFormMessage?: string 
+  }
+): MappedServerErrors {
+  const pathMapper = opts?.pathMapper || defaultPathMapper
+  const fallbackFormMessage = opts?.fallbackFormMessage || 'An error occurred'
+  
+  if (!err || typeof err !== 'object') {
+    return { fields: {}, form: fallbackFormMessage }
+  }
+
+  const result: MappedServerErrors = { fields: {} }
+
+  if ('issues' in err && Array.isArray((err as Record<string, unknown>).issues)) {
+    const issues = (err as Record<string, unknown>).issues as Array<{ path: (string | number)[]; message: string }>
+    for (const issue of issues) {
+      const path = pathMapper(issue.path.join('.'))
+      if (!result.fields[path]) result.fields[path] = []
+      result.fields[path].push(issue.message)
+    }
+    return result
+  }
+
+  if ('errors' in err && typeof (err as Record<string, unknown>).errors === 'object') {
+    const errors = (err as Record<string, unknown>).errors as Record<string, string | string[]>
+    for (const [key, value] of Object.entries(errors)) {
+      const path = pathMapper(key)
+      const messages = Array.isArray(value) ? value : [value]
+      result.fields[path] = messages
+    }
+    return result
+  }
+
+  if ('message' in err && Array.isArray((err as Record<string, unknown>).message)) {
+    const messages = (err as Record<string, unknown>).message as Array<{ field: string; message: string }>
+    for (const item of messages) {
+      if (typeof item === 'object' && 'field' in item && 'message' in item) {
+        const path = pathMapper(item.field)
+        if (!result.fields[path]) result.fields[path] = []
+        result.fields[path].push(item.message)
+      }
+    }
+    return result
+  }
+
+  if ('fieldErrors' in err && Array.isArray((err as Record<string, unknown>).fieldErrors)) {
+    const fieldErrors = (err as Record<string, unknown>).fieldErrors as ServerFieldError[]
+    for (const fieldError of fieldErrors) {
+      const path = pathMapper(fieldError.path)
+      if (!result.fields[path]) result.fields[path] = []
+      result.fields[path].push(fieldError.message)
+    }
+  }
+
+  if ('formError' in err && typeof (err as Record<string, unknown>).formError === 'object') {
+    const formError = (err as Record<string, unknown>).formError as ServerFormError
+    result.form = formError.message
+  } else if ('message' in err && typeof (err as Record<string, unknown>).message === 'string') {
+    result.form = (err as Record<string, unknown>).message as string
+  }
+
+  if (Object.keys(result.fields).length === 0 && !result.form) {
+    result.form = fallbackFormMessage
+  }
+
+  return result
+}
+
+export function applyServerErrors<TFormApi extends { setFieldMeta: (path: string, updater: (prev: unknown) => unknown) => void; setFormMeta: (updater: (prev: unknown) => unknown) => void }>(
+  form: TFormApi,
+  mapped: MappedServerErrors
+): void {
+  for (const [fieldPath, messages] of Object.entries(mapped.fields)) {
+    if (messages.length > 0) {
+      form.setFieldMeta(fieldPath, (prev: unknown) => {
+        const prevMeta = (prev as Record<string, unknown>) || {}
+        return {
+          ...prevMeta,
+          errorMap: {
+            ...(prevMeta.errorMap as Record<string, unknown>),
+            onServer: messages[0],
+          },
+          errorSourceMap: {
+            ...(prevMeta.errorSourceMap as Record<string, unknown>),
+            onServer: 'server',
+          },
+        }
+      })
+    }
+  }
+
+  if (mapped.form) {
+    form.setFormMeta((prev: unknown) => {
+      const prevMeta = (prev as Record<string, unknown>) || {}
+      return {
+        ...prevMeta,
+        errorMap: {
+          ...(prevMeta.errorMap as Record<string, unknown>),
+          onServer: mapped.form,
+        },
+        errorSourceMap: {
+          ...(prevMeta.errorSourceMap as Record<string, unknown>),
+          onServer: 'server',
+        },
+      }
+    })
+  }
+}
+
+export async function onServerSuccess<TFormApi extends { reset?: (options?: { resetValidation?: boolean }) => void }>(
+  form: TFormApi,
+  _result: unknown,
+  opts?: SuccessOptions
+): Promise<void> {
+  const { resetStrategy = 'none', flash, after } = opts || {}
+
+  if (resetStrategy !== 'none' && form.reset) {
+    if (resetStrategy === 'values') {
+      form.reset({ resetValidation: false })
+    } else {
+      form.reset()
+    }
+  }
+
+  if (flash?.set && flash.message) {
+    flash.set(flash.message)
+  }
+
+  if (after) {
+    await after()
+  }
+}
+
+export const selectServerResponse = <T = unknown>(store: unknown): T | undefined => {
+  if (store && typeof store === 'object' && '_serverResponse' in store) {
+    return (store as Record<string, unknown>)._serverResponse as T
+  }
+  return undefined
+}
+
+export const selectServerFormError = (store: unknown): string | undefined => {
+  if (store && typeof store === 'object' && '_serverFormError' in store) {
+    return (store as Record<string, unknown>)._serverFormError as string
+  }
+  return undefined
+}
+
+function defaultPathMapper(serverPath: string): string {
+  return serverPath
+    .replace(/\[(\d+)\]/g, '.$1')
+    .replace(/\[([^\]]+)\]/g, '.$1')
+    .replace(/^\./, '')
+}

--- a/packages/form-server/tests/applyServerErrors.test.ts
+++ b/packages/form-server/tests/applyServerErrors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import { applyServerErrors, type MappedServerErrors } from '../src/index'
+import {  applyServerErrors } from '../src/index'
+import type {MappedServerErrors} from '../src/index';
 
 describe('applyServerErrors', () => {
   it('should apply field errors to form', () => {
@@ -21,7 +22,7 @@ describe('applyServerErrors', () => {
     expect(mockForm.setFieldMeta).toHaveBeenCalledWith('email', expect.any(Function))
     expect(mockForm.setFormMeta).not.toHaveBeenCalled()
 
-    // Test the callback function for field meta
+    
     const nameCallback = mockForm.setFieldMeta.mock.calls[0]?.[1]
     const prevMeta = { errorMap: {}, errorSourceMap: {} }
     const newMeta = nameCallback?.(prevMeta)
@@ -48,7 +49,7 @@ describe('applyServerErrors', () => {
     expect(mockForm.setFieldMeta).not.toHaveBeenCalled()
     expect(mockForm.setFormMeta).toHaveBeenCalledWith(expect.any(Function))
 
-    // Test the callback function for form meta
+    
     const formCallback = mockForm.setFormMeta.mock.calls[0]?.[0]
     const prevMeta = { errorMap: {}, errorSourceMap: {} }
     const newMeta = formCallback?.(prevMeta)
@@ -93,7 +94,7 @@ describe('applyServerErrors', () => {
 
     applyServerErrors(mockForm, mappedErrors)
 
-    // Test field meta preservation
+    
     const fieldCallback = mockForm.setFieldMeta.mock.calls[0]?.[1]
     const prevFieldMeta = {
       errorMap: { onChange: 'Client validation error' },
@@ -112,7 +113,7 @@ describe('applyServerErrors', () => {
       },
     })
 
-    // Test form meta preservation
+    
     const formCallback = mockForm.setFormMeta.mock.calls[0]?.[0]
     const prevFormMeta = {
       errorMap: { onSubmit: 'Client form error' },

--- a/packages/form-server/tests/applyServerErrors.test.ts
+++ b/packages/form-server/tests/applyServerErrors.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyServerErrors, type MappedServerErrors } from '../src/index'
+
+describe('applyServerErrors', () => {
+  it('should apply field errors to form', () => {
+    const mockForm = {
+      setFieldMeta: vi.fn(),
+      setFormMeta: vi.fn(),
+    }
+
+    const mappedErrors: MappedServerErrors = {
+      fields: {
+        name: ['Name is required'],
+        email: ['Invalid email format'],
+      },
+    }
+
+    applyServerErrors(mockForm, mappedErrors)
+
+    expect(mockForm.setFieldMeta).toHaveBeenCalledWith('name', expect.any(Function))
+    expect(mockForm.setFieldMeta).toHaveBeenCalledWith('email', expect.any(Function))
+    expect(mockForm.setFormMeta).not.toHaveBeenCalled()
+
+    // Test the callback function for field meta
+    const nameCallback = mockForm.setFieldMeta.mock.calls[0]?.[1]
+    const prevMeta = { errorMap: {}, errorSourceMap: {} }
+    const newMeta = nameCallback?.(prevMeta)
+
+    expect(newMeta).toEqual({
+      errorMap: { onServer: 'Name is required' },
+      errorSourceMap: { onServer: 'server' },
+    })
+  })
+
+  it('should apply form-level error', () => {
+    const mockForm = {
+      setFieldMeta: vi.fn(),
+      setFormMeta: vi.fn(),
+    }
+
+    const mappedErrors: MappedServerErrors = {
+      fields: {},
+      form: 'Form submission failed',
+    }
+
+    applyServerErrors(mockForm, mappedErrors)
+
+    expect(mockForm.setFieldMeta).not.toHaveBeenCalled()
+    expect(mockForm.setFormMeta).toHaveBeenCalledWith(expect.any(Function))
+
+    // Test the callback function for form meta
+    const formCallback = mockForm.setFormMeta.mock.calls[0]?.[0]
+    const prevMeta = { errorMap: {}, errorSourceMap: {} }
+    const newMeta = formCallback?.(prevMeta)
+
+    expect(newMeta).toEqual({
+      errorMap: { onServer: 'Form submission failed' },
+      errorSourceMap: { onServer: 'server' },
+    })
+  })
+
+  it('should apply both field and form errors', () => {
+    const mockForm = {
+      setFieldMeta: vi.fn(),
+      setFormMeta: vi.fn(),
+    }
+
+    const mappedErrors: MappedServerErrors = {
+      fields: {
+        name: ['Name is required'],
+      },
+      form: 'Form has errors',
+    }
+
+    applyServerErrors(mockForm, mappedErrors)
+
+    expect(mockForm.setFieldMeta).toHaveBeenCalledWith('name', expect.any(Function))
+    expect(mockForm.setFormMeta).toHaveBeenCalledWith(expect.any(Function))
+  })
+
+  it('should preserve existing error maps', () => {
+    const mockForm = {
+      setFieldMeta: vi.fn(),
+      setFormMeta: vi.fn(),
+    }
+
+    const mappedErrors: MappedServerErrors = {
+      fields: {
+        name: ['Server error'],
+      },
+      form: 'Server form error',
+    }
+
+    applyServerErrors(mockForm, mappedErrors)
+
+    // Test field meta preservation
+    const fieldCallback = mockForm.setFieldMeta.mock.calls[0]?.[1]
+    const prevFieldMeta = {
+      errorMap: { onChange: 'Client validation error' },
+      errorSourceMap: { onChange: 'client' },
+    }
+    const newFieldMeta = fieldCallback?.(prevFieldMeta)
+
+    expect(newFieldMeta).toEqual({
+      errorMap: { 
+        onChange: 'Client validation error',
+        onServer: 'Server error' 
+      },
+      errorSourceMap: { 
+        onChange: 'client',
+        onServer: 'server' 
+      },
+    })
+
+    // Test form meta preservation
+    const formCallback = mockForm.setFormMeta.mock.calls[0]?.[0]
+    const prevFormMeta = {
+      errorMap: { onSubmit: 'Client form error' },
+      errorSourceMap: { onSubmit: 'client' },
+    }
+    const newFormMeta = formCallback?.(prevFormMeta)
+
+    expect(newFormMeta).toEqual({
+      errorMap: { 
+        onSubmit: 'Client form error',
+        onServer: 'Server form error' 
+      },
+      errorSourceMap: { 
+        onSubmit: 'client',
+        onServer: 'server' 
+      },
+    })
+  })
+
+  it('should handle empty field arrays', () => {
+    const mockForm = {
+      setFieldMeta: vi.fn(),
+      setFormMeta: vi.fn(),
+    }
+
+    const mappedErrors: MappedServerErrors = {
+      fields: {
+        name: [],
+        email: ['Email error'],
+      },
+    }
+
+    applyServerErrors(mockForm, mappedErrors)
+
+    expect(mockForm.setFieldMeta).toHaveBeenCalledTimes(1)
+    expect(mockForm.setFieldMeta).toHaveBeenCalledWith('email', expect.any(Function))
+  })
+
+  it('should use first error message when multiple exist', () => {
+    const mockForm = {
+      setFieldMeta: vi.fn(),
+      setFormMeta: vi.fn(),
+    }
+
+    const mappedErrors: MappedServerErrors = {
+      fields: {
+        email: ['First error', 'Second error', 'Third error'],
+      },
+    }
+
+    applyServerErrors(mockForm, mappedErrors)
+
+    const callback = mockForm.setFieldMeta.mock.calls[0]?.[1]
+    const newMeta = callback?.({ errorMap: {}, errorSourceMap: {} })
+
+    expect(newMeta.errorMap.onServer).toBe('First error')
+  })
+})

--- a/packages/form-server/tests/integration.test.ts
+++ b/packages/form-server/tests/integration.test.ts
@@ -3,14 +3,12 @@ import { applyServerErrors, mapServerErrors, onServerSuccess } from '../src/inde
 
 describe('integration tests', () => {
   it('should handle complete error mapping and application flow', () => {
-    // Mock form instance
     const mockForm = {
       setFieldMeta: vi.fn(),
       setFormMeta: vi.fn(),
       reset: vi.fn(),
     }
 
-    // Simulate server error response
     const serverError = {
       issues: [
         { path: ['name'], message: 'Name is required' },
@@ -19,13 +17,10 @@ describe('integration tests', () => {
       ],
     }
 
-    // Map server errors
     const mappedErrors = mapServerErrors(serverError)
 
-    // Apply to form
     applyServerErrors(mockForm, mappedErrors)
 
-    // Verify field errors were applied
     expect(mockForm.setFieldMeta).toHaveBeenCalledTimes(3)
     expect(mockForm.setFieldMeta).toHaveBeenCalledWith('name', expect.any(Function))
     expect(mockForm.setFieldMeta).toHaveBeenCalledWith('email', expect.any(Function))
@@ -74,7 +69,6 @@ describe('integration tests', () => {
     expect(mockForm.setFieldMeta).toHaveBeenCalledWith('username', expect.any(Function))
     expect(mockForm.setFormMeta).toHaveBeenCalledWith(expect.any(Function))
 
-    // Verify error content
     const fieldCallback = mockForm.setFieldMeta.mock.calls[0]?.[1]
     const fieldMeta = fieldCallback?.({ errorMap: {}, errorSourceMap: {} })
     expect(fieldMeta?.errorMap.onServer).toBe('Username already taken')
@@ -103,7 +97,6 @@ describe('integration tests', () => {
   })
 
   it('should handle custom path mapper with real-world scenario', () => {
-    // Simulate a Rails-style error with bracket notation
     const railsError = {
       errors: {
         'user_attributes[profile_attributes][name]': 'Name is required',
@@ -112,7 +105,6 @@ describe('integration tests', () => {
       },
     }
 
-    // Custom mapper to handle Rails nested attributes
     const pathMapper = (path: string) => {
       return path
         .replace(/_attributes/g, '')

--- a/packages/form-server/tests/integration.test.ts
+++ b/packages/form-server/tests/integration.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyServerErrors, mapServerErrors, onServerSuccess } from '../src/index'
+
+describe('integration tests', () => {
+  it('should handle complete error mapping and application flow', () => {
+    // Mock form instance
+    const mockForm = {
+      setFieldMeta: vi.fn(),
+      setFormMeta: vi.fn(),
+      reset: vi.fn(),
+    }
+
+    // Simulate server error response
+    const serverError = {
+      issues: [
+        { path: ['name'], message: 'Name is required' },
+        { path: ['email'], message: 'Invalid email format' },
+        { path: ['items', 0, 'price'], message: 'Price must be positive' },
+      ],
+    }
+
+    // Map server errors
+    const mappedErrors = mapServerErrors(serverError)
+
+    // Apply to form
+    applyServerErrors(mockForm, mappedErrors)
+
+    // Verify field errors were applied
+    expect(mockForm.setFieldMeta).toHaveBeenCalledTimes(3)
+    expect(mockForm.setFieldMeta).toHaveBeenCalledWith('name', expect.any(Function))
+    expect(mockForm.setFieldMeta).toHaveBeenCalledWith('email', expect.any(Function))
+    expect(mockForm.setFieldMeta).toHaveBeenCalledWith('items.0.price', expect.any(Function))
+  })
+
+  it('should handle success flow with all options', async () => {
+    const mockForm = {
+      reset: vi.fn(),
+    }
+    const mockFlashSet = vi.fn()
+    const mockAfter = vi.fn()
+
+    const serverResponse = { id: 123, message: 'User created successfully' }
+
+    await onServerSuccess(mockForm, serverResponse, {
+      resetStrategy: 'all',
+      flash: {
+        set: mockFlashSet,
+        message: 'User created successfully!',
+      },
+      after: mockAfter,
+    })
+
+    expect(mockForm.reset).toHaveBeenCalledWith()
+    expect(mockFlashSet).toHaveBeenCalledWith('User created successfully!')
+    expect(mockAfter).toHaveBeenCalled()
+  })
+
+  it('should handle mixed field and form errors', () => {
+    const mockForm = {
+      setFieldMeta: vi.fn(),
+      setFormMeta: vi.fn(),
+    }
+
+    const serverError = {
+      fieldErrors: [
+        { path: 'username', message: 'Username already taken' },
+      ],
+      formError: { message: 'Account creation failed' },
+    }
+
+    const mappedErrors = mapServerErrors(serverError)
+    applyServerErrors(mockForm, mappedErrors)
+
+    expect(mockForm.setFieldMeta).toHaveBeenCalledWith('username', expect.any(Function))
+    expect(mockForm.setFormMeta).toHaveBeenCalledWith(expect.any(Function))
+
+    // Verify error content
+    const fieldCallback = mockForm.setFieldMeta.mock.calls[0]?.[1]
+    const fieldMeta = fieldCallback?.({ errorMap: {}, errorSourceMap: {} })
+    expect(fieldMeta?.errorMap.onServer).toBe('Username already taken')
+
+    const formCallback = mockForm.setFormMeta.mock.calls[0]?.[0]
+    const formMeta = formCallback?.({ errorMap: {}, errorSourceMap: {} })
+    expect(formMeta?.errorMap.onServer).toBe('Account creation failed')
+  })
+
+  it('should handle path mapping with complex nested structures', () => {
+    const serverError = {
+      errors: {
+        'user[profile][addresses][0][street]': 'Street is required',
+        'items[1][variants][0][price]': 'Price must be positive',
+      },
+    }
+
+    const mappedErrors = mapServerErrors(serverError)
+
+    expect(mappedErrors).toEqual({
+      fields: {
+        'user.profile.addresses.0.street': ['Street is required'],
+        'items.1.variants.0.price': ['Price must be positive'],
+      },
+    })
+  })
+
+  it('should handle custom path mapper with real-world scenario', () => {
+    // Simulate a Rails-style error with bracket notation
+    const railsError = {
+      errors: {
+        'user_attributes[profile_attributes][name]': 'Name is required',
+        'items_attributes[0][name]': 'Item name is required',
+        'items_attributes[0][price]': 'Price must be positive',
+      },
+    }
+
+    // Custom mapper to handle Rails nested attributes
+    const pathMapper = (path: string) => {
+      return path
+        .replace(/_attributes/g, '')
+        .replace(/\[(\d+)\]/g, '.$1')
+        .replace(/\[([^\]]+)\]/g, '.$1')
+        .replace(/^\./, '')
+    }
+
+    const mappedErrors = mapServerErrors(railsError, { pathMapper })
+
+    expect(mappedErrors).toEqual({
+      fields: {
+        'user.profile.name': ['Name is required'],
+        'items.0.name': ['Item name is required'],
+        'items.0.price': ['Price must be positive'],
+      },
+    })
+  })
+})

--- a/packages/form-server/tests/mapServerErrors.test.ts
+++ b/packages/form-server/tests/mapServerErrors.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest'
+import { mapServerErrors } from '../src/index'
+
+describe('mapServerErrors', () => {
+  describe('Zod-like errors', () => {
+    it('should map zod validation errors', () => {
+      const zodError = {
+        issues: [
+          { path: ['name'], message: 'Name is required' },
+          { path: ['email'], message: 'Invalid email format' },
+          { path: ['items', 0, 'price'], message: 'Price must be positive' },
+        ],
+      }
+
+      const result = mapServerErrors(zodError)
+
+      expect(result).toEqual({
+        fields: {
+          name: ['Name is required'],
+          email: ['Invalid email format'],
+          'items.0.price': ['Price must be positive'],
+        },
+      })
+    })
+
+    it('should handle nested array paths', () => {
+      const zodError = {
+        issues: [
+          { path: ['users', 1, 'addresses', 0, 'street'], message: 'Street is required' },
+        ],
+      }
+
+      const result = mapServerErrors(zodError)
+
+      expect(result).toEqual({
+        fields: {
+          'users.1.addresses.0.street': ['Street is required'],
+        },
+      })
+    })
+  })
+
+  describe('Rails-like errors', () => {
+    it('should map rails validation errors', () => {
+      const railsError = {
+        errors: {
+          name: 'Name is required',
+          email: ['Invalid email', 'Email already taken'],
+          'user.profile.bio': 'Bio is too long',
+        },
+      }
+
+      const result = mapServerErrors(railsError)
+
+      expect(result).toEqual({
+        fields: {
+          name: ['Name is required'],
+          email: ['Invalid email', 'Email already taken'],
+          'user.profile.bio': ['Bio is too long'],
+        },
+      })
+    })
+  })
+
+  describe('NestJS-like errors', () => {
+    it('should map nestjs validation errors', () => {
+      const nestError = {
+        message: [
+          { field: 'name', message: 'Name is required' },
+          { field: 'email', message: 'Invalid email' },
+        ],
+      }
+
+      const result = mapServerErrors(nestError)
+
+      expect(result).toEqual({
+        fields: {
+          name: ['Name is required'],
+          email: ['Invalid email'],
+        },
+      })
+    })
+  })
+
+  describe('Custom field/form error format', () => {
+    it('should map field and form errors', () => {
+      const customError = {
+        fieldErrors: [
+          { path: 'name', message: 'Name is required' },
+          { path: 'email', message: 'Invalid email' },
+        ],
+        formError: { message: 'Form submission failed' },
+      }
+
+      const result = mapServerErrors(customError)
+
+      expect(result).toEqual({
+        fields: {
+          name: ['Name is required'],
+          email: ['Invalid email'],
+        },
+        form: 'Form submission failed',
+      })
+    })
+  })
+
+  describe('Path mapping', () => {
+    it('should use custom path mapper', () => {
+      const error = {
+        issues: [
+          { path: ['items[0].price'], message: 'Price is required' },
+          { path: ['user[profile][name]'], message: 'Name is required' },
+        ],
+      }
+
+      const pathMapper = (path: string) => path.replace(/\[(\w+)\]/g, '.$1')
+      const result = mapServerErrors(error, { pathMapper })
+
+      expect(result).toEqual({
+        fields: {
+          'items.0.price': ['Price is required'],
+          'user.profile.name': ['Name is required'],
+        },
+      })
+    })
+
+    it('should handle bracket notation with default mapper', () => {
+      const error = {
+        errors: {
+          'items[0].name': 'Name is required',
+          'items[1][price]': 'Price is required',
+          'user[addresses][0][street]': 'Street is required',
+        },
+      }
+
+      const result = mapServerErrors(error)
+
+      expect(result).toEqual({
+        fields: {
+          'items.0.name': ['Name is required'],
+          'items.1.price': ['Price is required'],
+          'user.addresses.0.street': ['Street is required'],
+        },
+      })
+    })
+  })
+
+  describe('Fallback handling', () => {
+    it('should use fallback message for unknown error format', () => {
+      const unknownError = { someRandomProperty: 'value' }
+
+      const result = mapServerErrors(unknownError)
+
+      expect(result).toEqual({
+        fields: {},
+        form: 'An error occurred',
+      })
+    })
+
+    it('should use custom fallback message', () => {
+      const unknownError = { someRandomProperty: 'value' }
+
+      const result = mapServerErrors(unknownError, {
+        fallbackFormMessage: 'Custom error message',
+      })
+
+      expect(result).toEqual({
+        fields: {},
+        form: 'Custom error message',
+      })
+    })
+
+    it('should handle non-object errors', () => {
+      expect(mapServerErrors(null)).toEqual({
+        fields: {},
+        form: 'An error occurred',
+      })
+
+      expect(mapServerErrors('string error')).toEqual({
+        fields: {},
+        form: 'An error occurred',
+      })
+
+      expect(mapServerErrors(undefined)).toEqual({
+        fields: {},
+        form: 'An error occurred',
+      })
+    })
+
+    it('should extract message from generic error object', () => {
+      const error = { message: 'Something went wrong' }
+
+      const result = mapServerErrors(error)
+
+      expect(result).toEqual({
+        fields: {},
+        form: 'Something went wrong',
+      })
+    })
+  })
+})

--- a/packages/form-server/tests/onServerSuccess.test.ts
+++ b/packages/form-server/tests/onServerSuccess.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import { onServerSuccess, type SuccessOptions } from '../src/index'
+import {  onServerSuccess } from '../src/index'
+import type {SuccessOptions} from '../src/index';
 
 describe('onServerSuccess', () => {
   it('should handle success with no options', async () => {
@@ -129,12 +130,10 @@ describe('onServerSuccess', () => {
 
     await onServerSuccess(mockForm, { success: true }, options)
 
-    // Verify all operations were called
     expect(mockForm.reset).toHaveBeenCalled()
     expect(mockFlashSet).toHaveBeenCalledWith('Success!')
     expect(mockAfter).toHaveBeenCalled()
 
-    // Verify order: reset should be called first
     const resetCallOrder = mockForm.reset.mock.invocationCallOrder[0]!
     const flashCallOrder = mockFlashSet.mock.invocationCallOrder[0]!
     const afterCallOrder = mockAfter.mock.invocationCallOrder[0]!
@@ -150,7 +149,6 @@ describe('onServerSuccess', () => {
       resetStrategy: 'all',
     }
 
-    // Should not throw error
     await expect(onServerSuccess(mockForm, { success: true }, options)).resolves.toBeUndefined()
   })
 

--- a/packages/form-server/tests/onServerSuccess.test.ts
+++ b/packages/form-server/tests/onServerSuccess.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from 'vitest'
+import { onServerSuccess, type SuccessOptions } from '../src/index'
+
+describe('onServerSuccess', () => {
+  it('should handle success with no options', async () => {
+    const mockForm = {
+      reset: vi.fn(),
+    }
+
+    await onServerSuccess(mockForm, { success: true })
+
+    expect(mockForm.reset).not.toHaveBeenCalled()
+  })
+
+  it('should reset values only when resetStrategy is "values"', async () => {
+    const mockForm = {
+      reset: vi.fn(),
+    }
+
+    const options: SuccessOptions = {
+      resetStrategy: 'values',
+    }
+
+    await onServerSuccess(mockForm, { success: true }, options)
+
+    expect(mockForm.reset).toHaveBeenCalledWith({ resetValidation: false })
+  })
+
+  it('should reset all when resetStrategy is "all"', async () => {
+    const mockForm = {
+      reset: vi.fn(),
+    }
+
+    const options: SuccessOptions = {
+      resetStrategy: 'all',
+    }
+
+    await onServerSuccess(mockForm, { success: true }, options)
+
+    expect(mockForm.reset).toHaveBeenCalledWith()
+  })
+
+  it('should not reset when resetStrategy is "none"', async () => {
+    const mockForm = {
+      reset: vi.fn(),
+    }
+
+    const options: SuccessOptions = {
+      resetStrategy: 'none',
+    }
+
+    await onServerSuccess(mockForm, { success: true }, options)
+
+    expect(mockForm.reset).not.toHaveBeenCalled()
+  })
+
+  it('should set flash message when provided', async () => {
+    const mockForm = {}
+    const mockFlashSet = vi.fn()
+
+    const options: SuccessOptions = {
+      flash: {
+        set: mockFlashSet,
+        message: 'Success! Data saved.',
+      },
+    }
+
+    await onServerSuccess(mockForm, { success: true }, options)
+
+    expect(mockFlashSet).toHaveBeenCalledWith('Success! Data saved.')
+  })
+
+  it('should not set flash message when no message provided', async () => {
+    const mockForm = {}
+    const mockFlashSet = vi.fn()
+
+    const options: SuccessOptions = {
+      flash: {
+        set: mockFlashSet,
+      },
+    }
+
+    await onServerSuccess(mockForm, { success: true }, options)
+
+    expect(mockFlashSet).not.toHaveBeenCalled()
+  })
+
+  it('should execute after callback', async () => {
+    const mockForm = {}
+    const mockAfter = vi.fn()
+
+    const options: SuccessOptions = {
+      after: mockAfter,
+    }
+
+    await onServerSuccess(mockForm, { success: true }, options)
+
+    expect(mockAfter).toHaveBeenCalled()
+  })
+
+  it('should execute async after callback', async () => {
+    const mockForm = {}
+    const mockAfter = vi.fn().mockResolvedValue(undefined)
+
+    const options: SuccessOptions = {
+      after: mockAfter,
+    }
+
+    await onServerSuccess(mockForm, { success: true }, options)
+
+    expect(mockAfter).toHaveBeenCalled()
+  })
+
+  it('should execute operations in correct order', async () => {
+    const mockForm = {
+      reset: vi.fn(),
+    }
+    const mockFlashSet = vi.fn()
+    const mockAfter = vi.fn()
+
+    const options: SuccessOptions = {
+      resetStrategy: 'all',
+      flash: {
+        set: mockFlashSet,
+        message: 'Success!',
+      },
+      after: mockAfter,
+    }
+
+    await onServerSuccess(mockForm, { success: true }, options)
+
+    // Verify all operations were called
+    expect(mockForm.reset).toHaveBeenCalled()
+    expect(mockFlashSet).toHaveBeenCalledWith('Success!')
+    expect(mockAfter).toHaveBeenCalled()
+
+    // Verify order: reset should be called first
+    const resetCallOrder = mockForm.reset.mock.invocationCallOrder[0]!
+    const flashCallOrder = mockFlashSet.mock.invocationCallOrder[0]!
+    const afterCallOrder = mockAfter.mock.invocationCallOrder[0]!
+
+    expect(resetCallOrder).toBeLessThan(flashCallOrder)
+    expect(flashCallOrder).toBeLessThan(afterCallOrder)
+  })
+
+  it('should handle form without reset method', async () => {
+    const mockForm = {}
+
+    const options: SuccessOptions = {
+      resetStrategy: 'all',
+    }
+
+    // Should not throw error
+    await expect(onServerSuccess(mockForm, { success: true }, options)).resolves.toBeUndefined()
+  })
+
+  it('should handle all options together', async () => {
+    const mockForm = {
+      reset: vi.fn(),
+    }
+    const mockFlashSet = vi.fn()
+    const mockAfter = vi.fn()
+
+    const options: SuccessOptions = {
+      resetStrategy: 'values',
+      flash: {
+        set: mockFlashSet,
+        message: 'Data saved successfully!',
+      },
+      after: mockAfter,
+    }
+
+    await onServerSuccess(mockForm, { id: 123, name: 'Test' }, options)
+
+    expect(mockForm.reset).toHaveBeenCalledWith({ resetValidation: false })
+    expect(mockFlashSet).toHaveBeenCalledWith('Data saved successfully!')
+    expect(mockAfter).toHaveBeenCalled()
+  })
+})

--- a/packages/form-server/tests/selectors.test.ts
+++ b/packages/form-server/tests/selectors.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import { selectServerFormError, selectServerResponse } from '../src/index'
+
+describe('selectors', () => {
+  describe('selectServerResponse', () => {
+    it('should return server response when present', () => {
+      const store = {
+        _serverResponse: { id: 123, name: 'Test' },
+        otherData: 'value',
+      }
+
+      const result = selectServerResponse(store)
+
+      expect(result).toEqual({ id: 123, name: 'Test' })
+    })
+
+    it('should return undefined when server response not present', () => {
+      const store = {
+        otherData: 'value',
+      }
+
+      const result = selectServerResponse(store)
+
+      expect(result).toBeUndefined()
+    })
+
+    it('should return undefined for non-object store', () => {
+      expect(selectServerResponse(null)).toBeUndefined()
+      expect(selectServerResponse(undefined)).toBeUndefined()
+      expect(selectServerResponse('string')).toBeUndefined()
+      expect(selectServerResponse(123)).toBeUndefined()
+    })
+
+    it('should return typed response', () => {
+      interface UserResponse {
+        id: number
+        name: string
+      }
+
+      const store = {
+        _serverResponse: { id: 123, name: 'Test' },
+      }
+
+      const result = selectServerResponse<UserResponse>(store)
+
+      expect(result).toEqual({ id: 123, name: 'Test' })
+      // TypeScript should infer the correct type
+      if (result) {
+        expect(typeof result.id).toBe('number')
+        expect(typeof result.name).toBe('string')
+      }
+    })
+  })
+
+  describe('selectServerFormError', () => {
+    it('should return server form error when present', () => {
+      const store = {
+        _serverFormError: 'Form submission failed',
+        otherData: 'value',
+      }
+
+      const result = selectServerFormError(store)
+
+      expect(result).toBe('Form submission failed')
+    })
+
+    it('should return undefined when server form error not present', () => {
+      const store = {
+        otherData: 'value',
+      }
+
+      const result = selectServerFormError(store)
+
+      expect(result).toBeUndefined()
+    })
+
+    it('should return undefined for non-object store', () => {
+      expect(selectServerFormError(null)).toBeUndefined()
+      expect(selectServerFormError(undefined)).toBeUndefined()
+      expect(selectServerFormError('string')).toBeUndefined()
+      expect(selectServerFormError(123)).toBeUndefined()
+    })
+
+    it('should handle non-string server form error', () => {
+      const store = {
+        _serverFormError: 123,
+      }
+
+      const result = selectServerFormError(store)
+
+      expect(result).toBe(123)
+    })
+  })
+
+  describe('integration with complex store', () => {
+    it('should work with complex store structure', () => {
+      const store = {
+        form: {
+          values: { name: 'test' },
+          errors: {},
+        },
+        _serverResponse: { success: true, id: 456 },
+        _serverFormError: 'Server validation failed',
+        ui: {
+          loading: false,
+        },
+      }
+
+      expect(selectServerResponse(store)).toEqual({ success: true, id: 456 })
+      expect(selectServerFormError(store)).toBe('Server validation failed')
+    })
+  })
+})

--- a/packages/form-server/tests/selectors.test.ts
+++ b/packages/form-server/tests/selectors.test.ts
@@ -44,7 +44,7 @@ describe('selectors', () => {
       const result = selectServerResponse<UserResponse>(store)
 
       expect(result).toEqual({ id: 123, name: 'Test' })
-      // TypeScript should infer the correct type
+      
       if (result) {
         expect(typeof result.id).toBe('number')
         expect(typeof result.name).toBe('string')

--- a/packages/form-server/tsconfig.json
+++ b/packages/form-server/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "Bundler"
+  },
+  "include": ["src", "tests", "eslint.config.js", "vite.config.ts"]
+}

--- a/packages/form-server/vite.config.ts
+++ b/packages/form-server/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, mergeConfig } from 'vitest/config'
+import { tanstackViteConfig } from '@tanstack/config/vite'
+import packageJson from './package.json'
+
+const config = defineConfig({
+  test: {
+    name: packageJson.name,
+    dir: './tests',
+    watch: false,
+    environment: 'jsdom',
+    coverage: { enabled: true, provider: 'istanbul', include: ['src/**/*'] },
+    typecheck: { enabled: true },
+  },
+})
+
+export default mergeConfig(
+  config,
+  tanstackViteConfig({
+    entry: './src/index.ts',
+    srcDir: './src',
+  }),
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1103,6 +1103,12 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
 
+  packages/form-server:
+    dependencies:
+      '@tanstack/form-core':
+        specifier: workspace:*
+        version: link:../form-core
+
   packages/lit-form:
     dependencies:
       '@tanstack/form-core':


### PR DESCRIPTION
This PR introduces a new @tanstack/form-server package that provides utilities for handling server errors and success responses in TanStack Form applications.

### Key Features
- Error Normalization: mapServerErrors() standardizes various server error formats (Zod, Rails, NestJS, custom) into a consistent structure
- Error Injection: applyServerErrors() applies mapped errors to form instances with proper field and form-level error handling
- Success Handling: onServerSuccess() manages successful responses with configurable reset strategies, flash messages, and callbacks
- Store Selectors: Utility functions for extracting server data from application stores 

### Supported Error Formats

- Zod validation errors (issues array)
- Rails-style errors (errors object)
- NestJS validation errors (structured message array)
- Custom field/form error formats