### PR TITLE
chore(typescript): use moduleResolution bundler

### DIFF
--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "moduleResolution": "Bundler"
-  },
-  "include": ["**/*"]
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "isolatedModules": true,
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "module": "ES2022",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "noEmit": true,
     "noImplicitReturns": true,
     "noUncheckedIndexedAccess": true,
@@ -23,5 +23,5 @@
     "strict": true,
     "target": "ES2020"
   },
-  "include": ["eslint.config.js", "prettier.config.js"]
+  "include": ["eslint.config.js", "prettier.config.js", "scripts"]
 }


### PR DESCRIPTION
## 🎯 Changes

This project previously didn't work without moduleResolution node in the root-level tsconfig. I can't remember why (maybe TS versions?), but I think it will work now.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
