### PR TITLE
docs(react): add shadcn/ui examples to React ui-libraries documentation

### DIFF
--- a/docs/framework/react/guides/ui-libraries.md
+++ b/docs/framework/react/guides/ui-libraries.md
@@ -134,7 +134,7 @@ The process for integrating shadcn/ui components is similar. Here's an example u
   name="name"
   children={({ state, handleChange, handleBlur }) => (
     <Input
-      defaultValue={state.value}
+      value={state.value}
       onChange={(e) => handleChange(e.target.value)}
       onBlur={handleBlur}
       placeholder="Enter your name"


### PR DESCRIPTION
## 🎯 Changes

Add shadcn/ui examples to React UI Libraries documentation.
Remove the "lastName" from the example and rename "firstName" to "name" to improve the consistency, since the "lastName" was not used in the Mantine example, and "firstName" was not used in Material UI examples.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
