### PR TITLE
Fix: typo in importing TanStackDevtools

### DIFF
--- a/docs/framework/react/guides/devtools.md
+++ b/docs/framework/react/guides/devtools.md
@@ -17,7 +17,7 @@ npm i @tanstack/react-form-devtools
 Next in the root of your application import the `TanstackDevtools`.
 
 ```tsx
-import { TanstackDevtools } from '@tanstack/react-devtools'
+import { TanStackDevtools } from '@tanstack/react-devtools'
 
 import App from './App'
 
@@ -25,7 +25,7 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
 
-    <TanstackDevtools />
+    <TanStackDevtools />
   </StrictMode>,
 )
 ```
@@ -33,7 +33,7 @@ createRoot(document.getElementById('root')!).render(
 Import the `FormDevtoolsPlugin` from **TanStack Form** and provide it to the `TanstackDevtools` component.
 
 ```tsx
-import { TanstackDevtools } from '@tanstack/react-devtools'
+import { TanStackDevtools } from '@tanstack/react-devtools'
 import { FormDevtoolsPlugin } from '@tanstack/react-form-devtools'
 
 import App from './App'
@@ -42,7 +42,7 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
 
-    <TanstackDevtools plugins={[FormDevtoolsPlugin()]} />
+    <TanStackDevtools plugins={[FormDevtoolsPlugin()]} />
   </StrictMode>,
 )
 ```

--- a/docs/framework/react/guides/devtools.md
+++ b/docs/framework/react/guides/devtools.md
@@ -14,7 +14,7 @@ npm i @tanstack/react-devtools
 npm i @tanstack/react-form-devtools
 ```
 
-Next in the root of your application import the `TanstackDevtools`.
+Next in the root of your application import the `TanStackDevtools`.
 
 ```tsx
 import { TanStackDevtools } from '@tanstack/react-devtools'
@@ -30,7 +30,7 @@ createRoot(document.getElementById('root')!).render(
 )
 ```
 
-Import the `FormDevtoolsPlugin` from **TanStack Form** and provide it to the `TanstackDevtools` component.
+Import the `FormDevtoolsPlugin` from **TanStack Form** and provide it to the `TanStackDevtools` component.
 
 ```tsx
 import { TanStackDevtools } from '@tanstack/react-devtools'
@@ -47,6 +47,6 @@ createRoot(document.getElementById('root')!).render(
 )
 ```
 
-Finally add any additional configuration you desire to the `TanstackDevtools` component, more information can be found under the [TanStack Devtools Configuration](https://tanstack.com/devtools/) section.
+Finally add any additional configuration you desire to the `TanStackDevtools` component, more information can be found under the [TanStack Devtools Configuration](https://tanstack.com/devtools/) section.
 
 A complete working example can be found in our [examples section](https://tanstack.com/form/latest/docs/framework/react/examples/devtools).


### PR DESCRIPTION
There was a typo while importing TanStackDevtools. It is suppose to be TanStackDevtools instead of TanstackDevtools

## 🎯 Changes
Changd text from TanstackDevtools to TanStackDevtools
<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

i think no test run is required since its just a documentation typo. (could be wrong)

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
