### PR TITLE
Fix typo in generics explanation

### DIFF
--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -39,7 +39,7 @@ This comes with a number of advantages:
 
 ## Generics are grim
 
-You should never need to pass a generic or use an internal type when leveraging TanStack Form. This is because we've designed the library to inference everything from runtime defaults.
+You should never need to pass a generic or use an internal type when leveraging TanStack Form. This is because we've designed the library to infer everything from runtime defaults.
 
 When writing sufficiently correct TanStack Form code, you should not be able to distinguish between JavaScript usage and TypeScript usage, with the exception of any type casts you might do of runtime values.
 


### PR DESCRIPTION
This pull request makes a small documentation fix by correcting a typo in the `docs/philosophy.md` file. The word "inference" was changed to "infer" for grammatical accuracy.Corrected a typo in the documentation regarding generics.

