### PR TITLE
fix(form-core): respect dontValidate option in formApi array modifiers

### DIFF
--- a/.changeset/fresh-bikes-clap.md
+++ b/.changeset/fresh-bikes-clap.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/form-core': minor
+---
+
+respect dontValidate option in formApi array modifiers

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -2301,13 +2301,18 @@ export class FormApi<
       mergeOpts(options, { dontValidate: true }),
     )
 
-    // Validate the whole array + all fields that have shifted
-    await this.validateField(field, 'change')
-
+    const dontValidate = options?.dontValidate ?? false
+    if (!dontValidate) {
+      // Validate the whole array + all fields that have shifted
+      await this.validateField(field, 'change')
+    }
+  
     // Shift down all meta after validating to make sure the new field has been mounted
     metaHelper(this).handleArrayFieldMetaShift(field, index, 'insert')
 
-    await this.validateArrayFieldsStartingFrom(field, index, 'change')
+    if (!dontValidate) {
+      await this.validateArrayFieldsStartingFrom(field, index, 'change')
+    }
   }
 
   /**
@@ -2331,9 +2336,12 @@ export class FormApi<
       mergeOpts(options, { dontValidate: true }),
     )
 
-    // Validate the whole array + all fields that have shifted
-    await this.validateField(field, 'change')
-    await this.validateArrayFieldsStartingFrom(field, index, 'change')
+    const dontValidate = options?.dontValidate ?? false
+    if (!dontValidate) {
+      // Validate the whole array + all fields that have shifted
+      await this.validateField(field, 'change')
+      await this.validateArrayFieldsStartingFrom(field, index, 'change')
+    }
   }
 
   /**
@@ -2368,9 +2376,12 @@ export class FormApi<
       this.deleteField(start as never)
     }
 
-    // Validate the whole array + all fields that have shifted
-    await this.validateField(field, 'change')
-    await this.validateArrayFieldsStartingFrom(field, index, 'change')
+    const dontValidate = options?.dontValidate ?? false
+    if (!dontValidate) {
+      // Validate the whole array + all fields that have shifted
+      await this.validateField(field, 'change')
+      await this.validateArrayFieldsStartingFrom(field, index, 'change')
+    }
   }
 
   /**
@@ -2395,11 +2406,14 @@ export class FormApi<
     // Swap meta
     metaHelper(this).handleArrayFieldMetaShift(field, index1, 'swap', index2)
 
-    // Validate the whole array
-    this.validateField(field, 'change')
-    // Validate the swapped fields
-    this.validateField(`${field}[${index1}]` as DeepKeys<TFormData>, 'change')
-    this.validateField(`${field}[${index2}]` as DeepKeys<TFormData>, 'change')
+    const dontValidate = options?.dontValidate ?? false
+    if (!dontValidate) {
+      // Validate the whole array
+      this.validateField(field, 'change')
+      // Validate the swapped fields
+      this.validateField(`${field}[${index1}]` as DeepKeys<TFormData>, 'change')
+      this.validateField(`${field}[${index2}]` as DeepKeys<TFormData>, 'change')
+    }
   }
 
   /**
@@ -2424,11 +2438,14 @@ export class FormApi<
     // Move meta between index1 and index2
     metaHelper(this).handleArrayFieldMetaShift(field, index1, 'move', index2)
 
-    // Validate the whole array
-    this.validateField(field, 'change')
-    // Validate the moved fields
-    this.validateField(`${field}[${index1}]` as DeepKeys<TFormData>, 'change')
-    this.validateField(`${field}[${index2}]` as DeepKeys<TFormData>, 'change')
+    const dontValidate = options?.dontValidate ?? false
+    if (!dontValidate) {
+      // Validate the whole array
+      this.validateField(field, 'change')
+      // Validate the moved fields
+      this.validateField(`${field}[${index1}]` as DeepKeys<TFormData>, 'change')
+      this.validateField(`${field}[${index2}]` as DeepKeys<TFormData>, 'change')
+    }
   }
 
   /**
@@ -2457,8 +2474,11 @@ export class FormApi<
       }
     }
 
-    // validate array change
-    this.validateField(field, 'change')
+    const dontValidate = options?.dontValidate ?? false
+    if (!dontValidate) {
+      // validate array change
+      this.validateField(field, 'change')
+    }
   }
 
   /**


### PR DESCRIPTION


fix #1764

## 🎯 Changes

check the `dontValidate` option in array modifiers before applying validation

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
