### PR TITLE
docs: update the large-form example to work with async validators

### DIFF
--- a/examples/react/large-form/src/features/people/page.tsx
+++ b/examples/react/large-form/src/features/people/page.tsx
@@ -6,31 +6,6 @@ import { peopleFormOpts } from './shared-form.tsx'
 export const PeoplePage = () => {
   const form = useAppForm({
     ...peopleFormOpts,
-    validators: {
-      onChange: ({ value }) => {
-        const errors = {
-          fields: {},
-        } as {
-          fields: Record<string, string>
-        }
-        if (!value.fullName) {
-          errors.fields.fullName = 'Full name is required'
-        }
-        if (!value.phone) {
-          errors.fields.phone = 'Phone is required'
-        }
-        if (!value.emergencyContact.fullName) {
-          errors.fields['emergencyContact.fullName'] =
-            'Emergency contact full name is required'
-        }
-        if (!value.emergencyContact.phone) {
-          errors.fields['emergencyContact.phone'] =
-            'Emergency contact phone is required'
-        }
-
-        return errors
-      },
-    },
     onSubmit: ({ value }) => {
       alert(JSON.stringify(value, null, 2))
     },

--- a/examples/react/large-form/src/features/people/shared-form.tsx
+++ b/examples/react/large-form/src/features/people/shared-form.tsx
@@ -17,4 +17,29 @@ export const peopleFormOpts = formOptions({
       phone: '',
     },
   },
+  validators: {
+    onChangeAsync: async ({ value }) => {
+      const errors = {
+        fields: {},
+      } as {
+        fields: Record<string, string>
+      }
+      if (!value.fullName) {
+        errors.fields.fullName = 'Full name is required'
+      }
+      if (!value.phone) {
+        errors.fields.phone = 'Phone is required'
+      }
+      if (!value.emergencyContact.fullName) {
+        errors.fields['emergencyContact.fullName'] =
+          'Emergency contact full name is required'
+      }
+      if (!value.emergencyContact.phone) {
+        errors.fields['emergencyContact.phone'] =
+          'Emergency contact phone is required'
+      }
+
+      return errors
+    },
+  },
 })


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

The form composition API (_React Large Form_) was confusing, because an `onChange` validator was defined in the main form, not in the `formOptions`, which was misleading, because if you try to add async validators there, TypeScript will complain about the form passed down through the child form's props (see [this StackBlitz box](https://stackblitz.com/edit/tanstack-form-wwwdyfov?file=src%2Ffeatures%2Fpeople%2Fpage.tsx)).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
