### PR TITLE
feat(solid-form): add withFieldGroup API

### DIFF
--- a/docs/framework/solid/guides/form-composition.md
+++ b/docs/framework/solid/guides/form-composition.md
@@ -159,7 +159,7 @@ Sometimes forms get very large; it's just how it goes sometimes. While TanStack 
 To solve this, we support breaking forms into smaller pieces using the `withForm` higher-order component.
 
 ```tsx
-const { useAppForm, withForm } = createFormHook({
+const { useAppForm, withForm, withFieldGroup } = createFormHook({
   fieldComponents: {
     TextField,
   },
@@ -213,8 +213,243 @@ function App() {
 ### `withForm` FAQ
 
 > Why a higher-order component instead of a hook?
+>
+> While hooks are the future of Solid, higher-order components are still a powerful tool for composition. In particular, the API of `withForm` enables us to have strong type-safety without requiring users to pass generics.
 
-While hooks are the future of Solid, higher-order components are still a powerful tool for composition. In particular, the API of `withForm` enables us to have strong type-safety without requiring users to pass generics.
+## Reusing groups of fields in multiple forms
+
+Sometimes, a pair of fields are so closely related that it makes sense to group and reuse them — like the password example listed in the [linked fields guide](../linked-fields.md). Instead of repeating this logic across multiple forms, you can utilize the `withFieldGroup` higher-order component.
+
+> Unlike `withForm`, validators cannot be specified and could be any value.
+> Ensure that your fields can accept unknown error types.
+
+Rewriting the passwords example using `withFieldGroup` would look like this:
+
+```tsx
+const { useAppForm, withForm, withFieldGroup } = createFormHook({
+  fieldComponents: {
+    TextField,
+    ErrorInfo,
+  },
+  formComponents: {
+    SubscribeButton,
+  },
+  fieldContext,
+  formContext,
+})
+
+type PasswordFields = {
+  password: string
+  confirm_password: string
+}
+
+// These default values are not used at runtime, but the keys are needed for mapping purposes.
+// This allows you to spread `formOptions` without needing to redeclare it.
+const defaultValues: PasswordFields = {
+  password: '',
+  confirm_password: '',
+}
+
+const FieldGroupPasswordFields = withFieldGroup({
+  defaultValues,
+  // You may also restrict the group to only use forms that implement this submit meta.
+  // If none is provided, any form with the right defaultValues may use it.
+  // onSubmitMeta: { action: '' }
+
+  // Optional, but adds props to the `render` function in addition to `form`
+  props: {
+    // These default values are also for type-checking and are not used at runtime
+    title: 'Password',
+  },
+  // Internally, you will have access to a `group` instead of a `form`
+  render: function Render(props) {
+    // access reactive values using the group store
+    const password = useStore(
+      props.group.store,
+      (state) => state.values.password,
+    )
+    // or the form itself
+    const isSubmitting = useStore(
+      props.group.form.store,
+      (state) => state.isSubmitting,
+    )
+
+    return (
+      <div>
+        <h2>{props.title}</h2>
+        {/* Groups also have access to Field, Subscribe, Field, AppField and AppForm */}
+        <props.group.AppField name="password">
+          {(field) => <field.TextField label="Password" />}
+        </props.group.AppField>
+        <props.group.AppField
+          name="confirm_password"
+          validators={{
+            onChangeListenTo: ['password'],
+            onChange: ({ value, fieldApi }) => {
+              // The form could be any values, so it is typed as 'unknown'
+              const values: unknown = fieldApi.form.state.values
+              // use the group methods instead
+              if (value !== props.group.getFieldValue('password')) {
+                return 'Passwords do not match'
+              }
+              return undefined
+            },
+          }}
+        >
+          {(field) => (
+            <div>
+              <field.TextField label="Confirm Password" />
+              <field.ErrorInfo />
+            </div>
+          )}
+        </props.group.AppField>
+      </div>
+    )
+  },
+})
+```
+
+We can now use these grouped fields in any form that implements the default values:
+
+```tsx
+// You are allowed to extend the group fields as long as the
+// existing properties remain unchanged
+type Account = PasswordFields & {
+  provider: string
+  username: string
+}
+
+// You may nest the group fields wherever you want
+type FormValues = {
+  name: string
+  age: number
+  account_data: PasswordFields
+  linked_accounts: Account[]
+}
+
+const defaultValues: FormValues = {
+  name: '',
+  age: 0,
+  account_data: {
+    password: '',
+    confirm_password: '',
+  },
+  linked_accounts: [
+    {
+      provider: 'TanStack',
+      username: '',
+      password: '',
+      confirm_password: '',
+    },
+  ],
+}
+
+function App() {
+  const form = useAppForm(() => ({
+    defaultValues,
+    // If the group didn't specify an `onSubmitMeta` property,
+    // the form may implement any meta it wants.
+    // Otherwise, the meta must be defined and match.
+    onSubmitMeta: { action: '' },
+  }))
+
+  return (
+    <form.AppForm>
+      <FieldGroupPasswordFields
+        form={form}
+        // You must specify where the fields can be found
+        fields="account_data"
+        title="Passwords"
+      />
+      <form.Field name="linked_accounts" mode="array">
+        {(field) =>
+          field().state.value.map((account, i) => (
+            <FieldGroupPasswordFields
+              key={account.provider}
+              form={form}
+              // The fields may be in nested fields
+              fields={`linked_accounts[${i}]`}
+              title={account.provider}
+            />
+          ))
+        }
+      </form.Field>
+    </form.AppForm>
+  )
+}
+```
+
+### Mapping field group values to a different field
+
+You may want to keep the password fields on the top level of your form, or rename the properties for clarity. You can map field group values
+to their true location by changing the `field` property:
+
+> [!IMPORTANT]
+> Due to TypeScript limitations, field mapping is only allowed for objects. You can use records or arrays at the top level of a field group, but you will not be able to map the fields.
+
+```tsx
+// To have an easier form, you can keep the fields on the top level
+type FormValues = {
+  name: string
+  age: number
+  password: string
+  confirm_password: string
+}
+
+const defaultValues: FormValues = {
+  name: '',
+  age: 0,
+  password: '',
+  confirm_password: '',
+}
+
+function App() {
+  const form = useAppForm(() => ({
+    defaultValues,
+  }))
+
+  return (
+    <form.AppForm>
+      <FieldGroupPasswordFields
+        form={form}
+        // You can map the fields to their equivalent deep key
+        fields={{
+          password: 'password',
+          confirm_password: 'confirm_password',
+          // or map them to differently named keys entirely
+          // 'password': 'name'
+        }}
+        title="Passwords"
+      />
+    </form.AppForm>
+  )
+}
+```
+
+If you expect your fields to always be at the top level of your form, you can create a quick map
+of your field groups using a helper function:
+
+```tsx
+const defaultValues: PasswordFields = {
+  password: '',
+  confirm_password: '',
+}
+
+const passwordFields = createFieldMap(defaultValues)
+/* This generates the following map:
+ {
+    'password': 'password',
+    'confirm_password': 'confirm_password'
+ }
+*/
+
+// Usage:
+<FieldGroupPasswordFields
+  form={form}
+  fields={passwordFields}
+  title="Passwords"
+/>
+```
 
 ## Tree-shaking form and field components
 
@@ -316,7 +551,7 @@ function SubscribeButton(props: { label: string }) {
   )
 }
 
-const { useAppForm, withForm } = createFormHook({
+const { useAppForm, withForm, withFieldGroup } = createFormHook({
   fieldComponents: {
     TextField,
   },
@@ -345,7 +580,7 @@ const ChildForm = withForm({
   render: (props) => {
     return (
       <div>
-        <p>{title}</p>
+        <p>{props.title}</p>
         <props.form.AppField
           name="firstName"
           children={(field) => <field.TextField label="First Name" />}
@@ -360,9 +595,9 @@ const ChildForm = withForm({
 
 // /src/features/people/page.ts
 const Parent = () => {
-  const form = useAppForm({
+  const form = useAppForm(() => ({
     ...formOpts,
-  })
+  }))
 
   return <ChildForm form={form} title={'Testing'} />
 }

--- a/examples/solid/large-form/src/features/people/emergency-contact.tsx
+++ b/examples/solid/large-form/src/features/people/emergency-contact.tsx
@@ -1,0 +1,22 @@
+import { withFieldGroup } from '../../hooks/form'
+
+export const FieldGroupEmergencyContact = withFieldGroup({
+  defaultValues: {
+    phone: '',
+    fullName: '',
+  },
+  render: function Render({ group }) {
+    return (
+      <>
+        <group.AppField
+          name="fullName"
+          children={(field) => <field.TextField label="Full Name" />}
+        />
+        <group.AppField
+          name="phone"
+          children={(field) => <field.TextField label="Phone" />}
+        />
+      </>
+    )
+  },
+})

--- a/examples/solid/large-form/src/features/people/page.tsx
+++ b/examples/solid/large-form/src/features/people/page.tsx
@@ -1,5 +1,6 @@
 import { useAppForm } from '../../hooks/form.tsx'
 import { AddressFields } from './address-fields.tsx'
+import { FieldGroupEmergencyContact } from './emergency-contact.tsx'
 import { peopleFormOpts } from './shared-form.tsx'
 
 export const PeoplePage = () => {
@@ -57,14 +58,7 @@ export const PeoplePage = () => {
       />
       <AddressFields form={form} />
       <h2>Emergency Contact</h2>
-      <form.AppField
-        name="emergencyContact.fullName"
-        children={(field) => <field.TextField label="Full Name" />}
-      />
-      <form.AppField
-        name="emergencyContact.phone"
-        children={(field) => <field.TextField label="Phone" />}
-      />
+      <FieldGroupEmergencyContact form={form} fields="emergencyContact" />
       <form.AppForm>
         <form.SubscribeButton label="Submit" />
       </form.AppForm>

--- a/examples/solid/large-form/src/hooks/form.tsx
+++ b/examples/solid/large-form/src/hooks/form.tsx
@@ -15,7 +15,7 @@ function SubscribeButton(props: { label: string }) {
   )
 }
 
-export const { useAppForm, withForm } = createFormHook({
+export const { useAppForm, withForm, withFieldGroup } = createFormHook({
   fieldComponents: {
     TextField,
   },

--- a/packages/solid-form/src/createField.tsx
+++ b/packages/solid-form/src/createField.tsx
@@ -11,12 +11,13 @@ import type {
   DeepValue,
   FieldAsyncValidateOrFn,
   FieldValidateOrFn,
+  FieldValidators,
   FormAsyncValidateOrFn,
   FormValidateOrFn,
   Narrow,
 } from '@tanstack/form-core'
 
-import type { Accessor, Component, JSX, JSXElement } from 'solid-js'
+import type { Accessor, JSX, JSXElement } from 'solid-js'
 import type { CreateFieldOptions, CreateFieldOptionsBound } from './types'
 
 interface SolidFieldApi<
@@ -624,6 +625,95 @@ interface FieldComponentProps<
     >,
   ) => JSXElement
 }
+
+
+/**
+ * A type alias representing a field component for a form lens data type.
+ */
+export type LensFieldComponent<
+  in out TLensData,
+  in out TParentSubmitMeta,
+  in out ExtendedApi = {},
+> = <
+  const TName extends DeepKeys<TLensData>,
+  TData extends DeepValue<TLensData, TName>,
+  TOnMount extends undefined | FieldValidateOrFn<unknown, string, TData>,
+  TOnChange extends undefined | FieldValidateOrFn<unknown, string, TData>,
+  TOnChangeAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<unknown, string, TData>,
+  TOnBlur extends undefined | FieldValidateOrFn<unknown, string, TData>,
+  TOnBlurAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<unknown, string, TData>,
+  TOnSubmit extends undefined | FieldValidateOrFn<unknown, string, TData>,
+  TOnSubmitAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<unknown, string, TData>,
+  TOnDynamic extends undefined | FieldValidateOrFn<unknown, string, TData>,
+  TOnDynamicAsync extends
+    | undefined
+    | FieldAsyncValidateOrFn<unknown, string, TData>,
+>({
+  children,
+  ...fieldOptions
+}: Omit<
+  FieldComponentBoundProps<
+    unknown,
+    string,
+    TData,
+    TOnMount,
+    TOnChange,
+    TOnChangeAsync,
+    TOnBlur,
+    TOnBlurAsync,
+    TOnSubmit,
+    TOnSubmitAsync,
+    TOnDynamic,
+    TOnDynamicAsync,
+    undefined | FormValidateOrFn<unknown>,
+    undefined | FormValidateOrFn<unknown>,
+    undefined | FormAsyncValidateOrFn<unknown>,
+    undefined | FormValidateOrFn<unknown>,
+    undefined | FormAsyncValidateOrFn<unknown>,
+    undefined | FormValidateOrFn<unknown>,
+    undefined | FormAsyncValidateOrFn<unknown>,
+    undefined | FormValidateOrFn<unknown>,
+    undefined | FormAsyncValidateOrFn<unknown>,
+    undefined | FormAsyncValidateOrFn<unknown>,
+    TParentSubmitMeta,
+    ExtendedApi
+  >,
+  'name' | 'validators'
+> & {
+  name: TName
+  validators?: Omit<
+    FieldValidators<
+      unknown,
+      string,
+      TData,
+      TOnMount,
+      TOnChange,
+      TOnChangeAsync,
+      TOnBlur,
+      TOnBlurAsync,
+      TOnSubmit,
+      TOnSubmitAsync,
+      TOnDynamic,
+      TOnDynamicAsync
+    >,
+    'onChangeListenTo' | 'onBlurListenTo'
+  > & {
+    /**
+     * An optional list of field names that should trigger this field's `onChange` and `onChangeAsync` events when its value changes
+     */
+    onChangeListenTo?: DeepKeys<TLensData>[]
+    /**
+     * An optional list of field names that should trigger this field's `onBlur` and `onBlurAsync` events when its value changes
+     */
+    onBlurListenTo?: DeepKeys<TLensData>[]
+  }
+}) => JSX.Element
 
 export function Field<
   TParentData,

--- a/packages/solid-form/src/createFieldGroup.tsx
+++ b/packages/solid-form/src/createFieldGroup.tsx
@@ -1,0 +1,237 @@
+import { FieldGroupApi, functionalUpdate } from '@tanstack/form-core'
+import { useStore } from '@tanstack/solid-store'
+import { onCleanup, onMount } from 'solid-js'
+import type { Component, JSX, ParentProps } from 'solid-js';
+import type {
+  DeepKeysOfType,
+  FieldGroupState,
+  FieldsMap,
+  FormAsyncValidateOrFn,
+  FormValidateOrFn
+} from '@tanstack/form-core'
+import type { LensFieldComponent } from './createField'
+import type { AppFieldExtendedSolidFormApi } from './createFormHook'
+
+
+/**
+ * @private
+ */
+export type AppFieldExtendedSolidFieldGroupApi<
+  TFormData,
+  TFieldGroupData,
+  TFields extends
+    | DeepKeysOfType<TFormData, TFieldGroupData | null | undefined>
+    | FieldsMap<TFormData, TFieldGroupData>,
+  TOnMount extends undefined | FormValidateOrFn<TFormData>,
+  TOnChange extends undefined | FormValidateOrFn<TFormData>,
+  TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnBlur extends undefined | FormValidateOrFn<TFormData>,
+  TOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnSubmit extends undefined | FormValidateOrFn<TFormData>,
+  TOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnDynamic extends undefined | FormValidateOrFn<TFormData>,
+  TOnDynamicAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnServer extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TSubmitMeta,
+  TFieldComponents extends Record<string, Component<any>>,
+  TFormComponents extends Record<string, Component<any>>,
+> = FieldGroupApi<
+  TFormData,
+  TFieldGroupData,
+  TFields,
+  TOnMount,
+  TOnChange,
+  TOnChangeAsync,
+  TOnBlur,
+  TOnBlurAsync,
+  TOnSubmit,
+  TOnSubmitAsync,
+  TOnDynamic,
+  TOnDynamicAsync,
+  TOnServer,
+  TSubmitMeta
+> &
+  NoInfer<TFormComponents> & {
+    AppField: LensFieldComponent<
+      TFieldGroupData,
+      TSubmitMeta,
+      NoInfer<TFieldComponents>
+    >
+    AppForm: Component<ParentProps>
+    /**
+     * A solid component to render form fields. With this, you can render and manage individual form fields.
+     */
+    Field: LensFieldComponent<TFieldGroupData, TSubmitMeta>
+
+    /**
+     * A `Subscribe` function that allows you to listen and solid to changes in the form's state. It's especially useful when you need to execute side effects or render specific components in response to state updates.
+     */
+    Subscribe: <TSelected = NoInfer<FieldGroupState<TFieldGroupData>>>(props: {
+      selector?: (state: NoInfer<FieldGroupState<TFieldGroupData>>) => TSelected
+      children: ((state: NoInfer<TSelected>) => JSX.Element) | JSX.Element
+    }) => JSX.Element
+  }
+
+export function createFieldGroup<
+  TFormData,
+  TFieldGroupData,
+  TFields extends
+    | DeepKeysOfType<TFormData, TFieldGroupData | null | undefined>
+    | FieldsMap<TFormData, TFieldGroupData>,
+  TOnMount extends undefined | FormValidateOrFn<TFormData>,
+  TOnChange extends undefined | FormValidateOrFn<TFormData>,
+  TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnBlur extends undefined | FormValidateOrFn<TFormData>,
+  TOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnSubmit extends undefined | FormValidateOrFn<TFormData>,
+  TOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnDynamic extends undefined | FormValidateOrFn<TFormData>,
+  TOnDynamicAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnServer extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TComponents extends Record<string, Component<any>>,
+  TFormComponents extends Record<string, Component<any>>,
+  TSubmitMeta = never,
+>(opts: () => {
+  form:
+    | AppFieldExtendedSolidFormApi<
+        TFormData,
+        TOnMount,
+        TOnChange,
+        TOnChangeAsync,
+        TOnBlur,
+        TOnBlurAsync,
+        TOnSubmit,
+        TOnSubmitAsync,
+        TOnDynamic,
+        TOnDynamicAsync,
+        TOnServer,
+        TSubmitMeta,
+        TComponents,
+        TFormComponents
+      >
+    | AppFieldExtendedSolidFieldGroupApi<
+        // Since this only occurs if you nest it within other form lenses, it can be more
+        // lenient with the types.
+        unknown,
+        TFormData,
+        string | FieldsMap<unknown, TFormData>,
+        any,
+        any,
+        any,
+        any,
+        any,
+        any,
+        any,
+        any,
+        any,
+        any,
+        TSubmitMeta,
+        TComponents,
+        TFormComponents
+      >
+  fields: TFields
+  defaultValues?: TFieldGroupData
+  onSubmitMeta?: TSubmitMeta
+  formComponents: TFormComponents
+}): AppFieldExtendedSolidFieldGroupApi<
+  TFormData,
+  TFieldGroupData,
+  TFields,
+  TOnMount,
+  TOnChange,
+  TOnChangeAsync,
+  TOnBlur,
+  TOnBlurAsync,
+  TOnSubmit,
+  TOnSubmitAsync,
+  TOnDynamic,
+  TOnDynamicAsync,
+  TOnServer,
+  TSubmitMeta,
+  TComponents,
+  TFormComponents
+> {
+  const options = opts()
+  const api = new FieldGroupApi(options)
+  const form = options.form instanceof FieldGroupApi
+    ? (options.form.form as AppFieldExtendedSolidFormApi<
+        TFormData,
+        TOnMount,
+        TOnChange,
+        TOnChangeAsync,
+        TOnBlur,
+        TOnBlurAsync,
+        TOnSubmit,
+        TOnSubmitAsync,
+        TOnDynamic,
+        TOnDynamicAsync,
+        TOnServer,
+        TSubmitMeta,
+        TComponents,
+        TFormComponents
+      >)
+    : options.form
+  
+  const extendedApi: AppFieldExtendedSolidFieldGroupApi<
+    TFormData,
+    TFieldGroupData,
+    TFields,
+    TOnMount,
+    TOnChange,
+    TOnChangeAsync,
+    TOnBlur,
+    TOnBlurAsync,
+    TOnSubmit,
+    TOnSubmitAsync,
+    TOnDynamic,
+    TOnDynamicAsync,
+    TOnServer,
+    TSubmitMeta,
+    TComponents,
+    TFormComponents
+  > = api as never
+
+  extendedApi.AppForm = (appFormProps) => <form.AppForm {...appFormProps} />
+  extendedApi.AppField = (props) => (
+    <form.AppField {...(api.getFormFieldOptions(props) as any)} />
+  )
+  extendedApi.Field = (props) => (
+    <form.Field {...(api.getFormFieldOptions(props) as any)} />
+  )
+  extendedApi.Subscribe = (props) => {
+    const data = useStore(api.store, props.selector)
+
+    return functionalUpdate(props.children, data()) as Element
+  }
+
+  let mounted = false
+  onMount(() => {
+    const cleanupFn = api.mount()
+    mounted = true
+    onCleanup(() => {
+      cleanupFn()
+      mounted = false
+    })
+  })
+
+  return Object.assign(extendedApi, {
+    ...options.formComponents,
+  }) as AppFieldExtendedSolidFieldGroupApi<
+    TFormData,
+    TFieldGroupData,
+    TFields,
+    TOnMount,
+    TOnChange,
+    TOnChangeAsync,
+    TOnBlur,
+    TOnBlurAsync,
+    TOnSubmit,
+    TOnSubmitAsync,
+    TOnDynamic,
+    TOnDynamicAsync,
+    TOnServer,
+    TSubmitMeta,
+    TComponents,
+    TFormComponents
+  >
+}

--- a/packages/solid-form/src/createFormHook.tsx
+++ b/packages/solid-form/src/createFormHook.tsx
@@ -3,7 +3,10 @@ import { createForm } from './createForm'
 import type {
   AnyFieldApi,
   AnyFormApi,
+  BaseFormOptions,
+  DeepKeysOfType,
   FieldApi,
+  FieldsMap,
   FormAsyncValidateOrFn,
   FormOptions,
   FormValidateOrFn,
@@ -17,6 +20,7 @@ import type {
 } from 'solid-js'
 import type { FieldComponent } from './createField'
 import type { SolidFormExtendedApi } from './createForm'
+import { createFieldGroup, type AppFieldExtendedSolidFieldGroupApi } from './createFieldGroup'
 
 /**
  * TypeScript inferencing is weird.
@@ -142,8 +146,10 @@ interface CreateFormHookProps<
   formComponents: TFormComponents
   formContext: Context<AnyFormApi>
 }
-
-type AppFieldExtendedSolidFormApi<
+/**
+ * @private
+ */
+export type AppFieldExtendedSolidFormApi<
   TFormData,
   TOnMount extends undefined | FormValidateOrFn<TFormData>,
   TOnChange extends undefined | FormValidateOrFn<TFormData>,
@@ -246,6 +252,45 @@ export interface WithFormProps<
     >,
   ) => JSXElement
 }
+
+
+export interface WithFieldGroupProps<
+  TFieldGroupData,
+  TFieldComponents extends Record<string, Component<any>>,
+  TFormComponents extends Record<string, Component<any>>,
+  TSubmitMeta,
+  TRenderProps extends Record<string, unknown> = Record<string, never>,
+> extends BaseFormOptions<TFieldGroupData, TSubmitMeta> {
+  // Optional, but adds props to the `render` function outside of `form`
+  props?: TRenderProps
+  render: (
+    props: ParentProps<
+      NoInfer<TRenderProps> & {
+        group: AppFieldExtendedSolidFieldGroupApi<
+          unknown,
+          TFieldGroupData,
+          string | FieldsMap<unknown, TFieldGroupData>,
+          undefined | FormValidateOrFn<unknown>,
+          undefined | FormValidateOrFn<unknown>,
+          undefined | FormAsyncValidateOrFn<unknown>,
+          undefined | FormValidateOrFn<unknown>,
+          undefined | FormAsyncValidateOrFn<unknown>,
+          undefined | FormValidateOrFn<unknown>,
+          undefined | FormAsyncValidateOrFn<unknown>,
+          undefined | FormValidateOrFn<unknown>,
+          undefined | FormAsyncValidateOrFn<unknown>,
+          undefined | FormAsyncValidateOrFn<unknown>,
+          // this types it as 'never' in the render prop. It should prevent any
+          // untyped meta passed to the handleSubmit by accident.
+          unknown extends TSubmitMeta ? never : TSubmitMeta,
+          TFieldComponents,
+          TFormComponents
+        >
+      }
+    >,
+  ) => JSXElement
+}
+
 
 export function createFormHook<
   const TComponents extends Record<string, Component<any>>,
@@ -416,8 +461,96 @@ export function createFormHook<
     return (innerProps) => render({ ...props, ...innerProps })
   }
 
+  function withFieldGroup<
+    TFieldGroupData,
+    TSubmitMeta,
+    TRenderProps extends Record<string, unknown> = {},
+  >({
+    render,
+    props,
+    defaultValues,
+  }: WithFieldGroupProps<
+    TFieldGroupData,
+    TComponents,
+    TFormComponents,
+    TSubmitMeta,
+    TRenderProps
+  >): <
+    TFormData,
+    TFields extends
+      | DeepKeysOfType<TFormData, TFieldGroupData | null | undefined>
+      | FieldsMap<TFormData, TFieldGroupData>,
+    TOnMount extends undefined | FormValidateOrFn<TFormData>,
+    TOnChange extends undefined | FormValidateOrFn<TFormData>,
+    TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+    TOnBlur extends undefined | FormValidateOrFn<TFormData>,
+    TOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+    TOnSubmit extends undefined | FormValidateOrFn<TFormData>,
+    TOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+    TOnDynamic extends undefined | FormValidateOrFn<TFormData>,
+    TOnDynamicAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+    TOnServer extends undefined | FormAsyncValidateOrFn<TFormData>,
+    TFormSubmitMeta,
+  >(
+    params: ParentProps<
+      NoInfer<TRenderProps> & {
+        form:
+          | AppFieldExtendedSolidFormApi<
+              TFormData,
+              TOnMount,
+              TOnChange,
+              TOnChangeAsync,
+              TOnBlur,
+              TOnBlurAsync,
+              TOnSubmit,
+              TOnSubmitAsync,
+              TOnDynamic,
+              TOnDynamicAsync,
+              TOnServer,
+              unknown extends TSubmitMeta ? TFormSubmitMeta : TSubmitMeta,
+              TComponents,
+              TFormComponents
+            >
+          | AppFieldExtendedSolidFieldGroupApi<
+              // Since this only occurs if you nest it within other field groups, it can be more
+              // lenient with the types.
+              unknown,
+              TFormData,
+              string | FieldsMap<unknown, TFormData>,
+              any,
+              any,
+              any,
+              any,
+              any,
+              any,
+              any,
+              any,
+              any,
+              any,
+              unknown extends TSubmitMeta ? TFormSubmitMeta : TSubmitMeta,
+              TComponents,
+              TFormComponents
+            >
+        fields: TFields
+      }
+    >,
+  ) => JSXElement {
+    return function Render(innerProps) {
+      const fieldGroupProps = {
+          form: innerProps.form,
+          fields: innerProps.fields,
+          defaultValues,
+          formComponents: opts.formComponents,
+        }
+      const fieldGroupApi = createFieldGroup(() => fieldGroupProps)
+
+      return render({ ...props, ...innerProps, group: fieldGroupApi as any })
+    }
+  }
+
   return {
     useAppForm,
     withForm,
+    withFieldGroup,
   }
 }

--- a/packages/solid-form/src/index.tsx
+++ b/packages/solid-form/src/index.tsx
@@ -4,5 +4,6 @@ export { useStore } from '@tanstack/solid-store'
 
 export * from './createField'
 export * from './createForm'
+export * from './createFieldGroup'
 export * from './createFormHook'
 export * from './types'

--- a/packages/solid-form/tests/createFormHook.test.tsx
+++ b/packages/solid-form/tests/createFormHook.test.tsx
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { render } from '@solidjs/testing-library'
 import { formOptions } from '@tanstack/form-core'
-import { createFormHook, createFormHookContexts } from '../src'
+import userEvent from '@testing-library/user-event'
+import { createFormHook, createFormHookContexts, useStore } from '../src'
+
+const user = userEvent.setup()
 
 const { fieldContext, useFieldContext, formContext, useFormContext } =
   createFormHookContexts()
@@ -28,7 +31,7 @@ function SubscribeButton({ label }: { label: string }) {
   )
 }
 
-const { useAppForm, withForm } = createFormHook({
+const { useAppForm, withForm, withFieldGroup } = createFormHook({
   fieldComponents: {
     TextField,
   },
@@ -111,5 +114,470 @@ describe('createFormHook', () => {
     const input = getByLabelText('First Name')
     expect(input).toHaveValue('John')
     expect(getByText('Testing')).toBeInTheDocument()
+  })
+
+  it('should handle withFieldGroup types properly', () => {
+    const formOpts = formOptions({
+      defaultValues: {
+        person: {
+          firstName: 'John',
+          lastName: 'Doe',
+        },
+      },
+    })
+
+    const ChildForm = withFieldGroup({
+      defaultValues: formOpts.defaultValues.person,
+      // Optional, but adds props to the `render` function outside of `form`
+      props: {
+        title: 'Child Form',
+      },
+      render: ({ group, title }) => {
+        return (
+          <div>
+            <p>{title}</p>
+            <group.AppField
+              name="firstName"
+              children={(field) => <field.TextField label="First Name" />}
+            />
+            <group.AppForm>
+              <group.SubscribeButton label="Submit" />
+            </group.AppForm>
+          </div>
+        )
+      },
+    })
+
+    const Parent = () => {
+      const form = useAppForm(() => ({
+        ...formOpts,
+      }))
+
+      return <ChildForm form={form} fields="person" title={'Testing'} />
+    }
+
+    const { getByLabelText, getByText } = render(() => <Parent />)
+    const input = getByLabelText('First Name')
+    expect(input).toHaveValue('John')
+    expect(getByText('Testing')).toBeInTheDocument()
+  })
+
+  it('should use the correct field name in Field with withFieldGroup', () => {
+    const formOpts = formOptions({
+      defaultValues: {
+        person: {
+          firstName: 'John',
+          lastName: 'Doe',
+        },
+        people: [
+          {
+            firstName: 'Jane',
+            lastName: 'Doe',
+          },
+          {
+            firstName: 'Robert',
+            lastName: 'Doe',
+          },
+        ],
+      },
+    })
+
+    const ChildFormAsField = withFieldGroup({
+      defaultValues: formOpts.defaultValues.person,
+      render: ({ group }) => {
+        return (
+          <div>
+            <group.AppField
+              name="firstName"
+              children={(field) => <field.TextField label={field().name} />}
+            />
+            <group.AppForm>
+              <group.SubscribeButton label="Submit" />
+            </group.AppForm>
+          </div>
+        )
+      },
+    })
+    const ChildFormAsArray = withFieldGroup({
+      defaultValues: [formOpts.defaultValues.person],
+      props: {
+        title: '',
+      },
+      render: ({ group, title }) => {
+        return (
+          <div>
+            <p>{title}</p>
+            <group.AppField
+              name="[0].firstName"
+              children={(field) => <field.TextField label={field().name} />}
+            />
+            <group.AppForm>
+              <group.SubscribeButton label="Submit" />
+            </group.AppForm>
+          </div>
+        )
+      },
+    })
+
+    const Parent = () => {
+      const form = useAppForm(() => ({
+        ...formOpts,
+      }))
+
+      return (
+        <>
+          <ChildFormAsField form={form} fields="person" />
+          <ChildFormAsArray form={form} fields="people" title="Testing" />
+          <ChildFormAsField form={form} fields="people[1]" />
+        </>
+      )
+    }
+
+    const { getByLabelText, getByText } = render(() => <Parent />)
+    const inputField1 = getByLabelText('person.firstName')
+    const inputArray = getByLabelText('people[0].firstName')
+    const inputField2 = getByLabelText('people[1].firstName')
+    expect(inputField1).toHaveValue('John')
+    expect(inputArray).toHaveValue('Jane')
+    expect(inputField2).toHaveValue('Robert')
+    expect(getByText('Testing')).toBeInTheDocument()
+  })
+
+  it('should forward Field and Subscribe to the form', () => {
+    const formOpts = formOptions({
+      defaultValues: {
+        person: {
+          firstName: 'John',
+          lastName: 'Doe',
+        },
+      },
+    })
+
+    const ChildFormAsField = withFieldGroup({
+      defaultValues: formOpts.defaultValues.person,
+      render: ({ group }) => {
+        return (
+          <div>
+            <group.Field
+              name="firstName"
+              children={(field) => (
+                <label>
+                  <div>{field().name}</div>
+                  <input
+                    value={field().state.value}
+                    onChange={(e) => field().handleChange(e.target.value)}
+                  />
+                </label>
+              )}
+            />
+            <group.Subscribe selector={(state) => state.values.lastName}>
+              {(lastName) => <p>{lastName}</p>}
+            </group.Subscribe>
+          </div>
+        )
+      },
+    })
+
+    const Parent = () => {
+      const form = useAppForm(() => ({
+        ...formOpts,
+      }))
+      return <ChildFormAsField form={form} fields="person" />
+    }
+
+    const { getByLabelText, getByText } = render(() => <Parent />)
+    const input = getByLabelText('person.firstName')
+    expect(input).toHaveValue('John')
+    expect(getByText('Doe')).toBeInTheDocument()
+  })
+
+  it('should not lose focus on update with withFieldGroup', async () => {
+    const formOpts = formOptions({
+      defaultValues: {
+        person: {
+          firstName: 'John',
+          lastName: 'Doe',
+        },
+      },
+    })
+
+    const ChildForm = withFieldGroup({
+      defaultValues: formOpts.defaultValues.person,
+      render: function Render({ group }) {
+        const firstName = useStore(
+          group.store,
+          (state) => state.values.firstName,
+        )
+        return (
+          <div>
+            <p>{firstName()}</p>
+            <group.Field
+              name="firstName"
+              children={(field) => (
+                <label>
+                  <div>{field().name}</div>
+                  <input
+                    value={field().state.value}
+                    onChange={(e) => field().handleChange(e.target.value)}
+                  />
+                </label>
+              )}
+            />
+            <group.Subscribe selector={(state) => state.values.lastName}>
+              {(lastName) => <p>{lastName}</p>}
+            </group.Subscribe>
+          </div>
+        )
+      },
+    })
+
+    const Parent = () => {
+      const form = useAppForm(() => ({
+        ...formOpts,
+      }))
+      return <ChildForm form={form} fields="person" />
+    }
+
+    const { getByLabelText } = render(() => <Parent />)
+
+    const input = getByLabelText('person.firstName')
+    input.focus()
+    expect(input).toHaveFocus()
+
+    await user.clear(input)
+    await user.type(input, 'Something')
+
+    expect(input).toHaveFocus()
+  })
+
+  it('should allow nesting withFieldGroup in other withFieldGroups', () => {
+    type Nested = {
+      firstName: string
+    }
+    type Wrapper = {
+      field: Nested
+    }
+    type FormValues = {
+      form: Wrapper
+      unrelated: { something: { lastName: string } }
+    }
+
+    const defaultValues: FormValues = {
+      form: {
+        field: {
+          firstName: 'Test',
+        },
+      },
+      unrelated: {
+        something: {
+          lastName: '',
+        },
+      },
+    }
+
+    const LensNested = withFieldGroup({
+      defaultValues: defaultValues.form.field,
+      render: function Render({ group }) {
+        return (
+          <group.Field name="firstName">
+            {(field) => <p>{field().name}</p>}
+          </group.Field>
+        )
+      },
+    })
+    const LensWrapper = withFieldGroup({
+      defaultValues: defaultValues.form,
+      render: function Render({ group }) {
+        return (
+          <div>
+            <LensNested form={group} fields="field" />
+          </div>
+        )
+      },
+    })
+
+    const Parent = () => {
+      const form = useAppForm(() => ({
+        defaultValues,
+      }))
+      return <LensWrapper form={form} fields="form" />
+    }
+
+    const { getByText } = render(() => <Parent />)
+
+    expect(getByText('form.field.firstName')).toBeInTheDocument()
+  })
+
+  it('should allow mapping withFieldGroup to different values', () => {
+    const formOpts = formOptions({
+      defaultValues: {
+        unrelated: 'John',
+        values: '',
+      },
+    })
+
+    const ChildFormAsField = withFieldGroup({
+      defaultValues: { firstName: '', lastName: '' },
+      render: ({ group }) => {
+        return (
+          <div>
+            <group.AppField
+              name="firstName"
+              children={(field) => <field.TextField label={field().name} />}
+            />
+          </div>
+        )
+      },
+    })
+
+    const Parent = () => {
+      const form = useAppForm(() => ({
+        ...formOpts,
+      }))
+
+      return (
+        <ChildFormAsField
+          form={form}
+          fields={{
+            firstName: 'unrelated',
+            lastName: 'values',
+          }}
+        />
+      )
+    }
+
+    const { getByLabelText } = render(() => <Parent />)
+    const inputField1 = getByLabelText('unrelated')
+    expect(inputField1).toHaveValue('John')
+  })
+
+  it('should remap FieldGroupApi.Field validators to the correct names', () => {
+    const FieldGroupString = withFieldGroup({
+      defaultValues: { password: '', confirmPassword: '' },
+      render: function Render({ group }) {
+        return (
+          <group.Field
+            name="password"
+            validators={{
+              onChange: () => null,
+              onChangeListenTo: ['password'],
+              onBlur: () => null,
+              onBlurListenTo: ['confirmPassword'],
+            }}
+          >
+            {(field) => {
+              expect(
+                field().options.validators?.onChangeListenTo,
+              ).toStrictEqual(['account.password'])
+              expect(field().options.validators?.onBlurListenTo).toStrictEqual([
+                'account.confirmPassword',
+              ])
+              return <></>
+            }}
+          </group.Field>
+        )
+      },
+    })
+
+    const FieldGroupObject = withFieldGroup({
+      defaultValues: { password: '', confirmPassword: '' },
+      render: function Render({ group }) {
+        return (
+          <group.Field
+            name="password"
+            validators={{
+              onChange: () => null,
+              onChangeListenTo: ['password'],
+              onBlur: () => null,
+              onBlurListenTo: ['confirmPassword'],
+            }}
+          >
+            {(field) => {
+              expect(
+                field().options.validators?.onChangeListenTo,
+              ).toStrictEqual(['userPassword'])
+              expect(field().options.validators?.onBlurListenTo).toStrictEqual([
+                'userConfirmPassword',
+              ])
+              return <></>
+            }}
+          </group.Field>
+        )
+      },
+    })
+
+    const Parent = () => {
+      const form = useAppForm(() => ({
+        defaultValues: {
+          account: {
+            password: '',
+            confirmPassword: '',
+          },
+          userPassword: '',
+          userConfirmPassword: '',
+        },
+      }))
+
+      return (
+        <>
+          <FieldGroupString form={form} fields="account" />
+          <FieldGroupObject
+            form={form}
+            fields={{
+              password: 'userPassword',
+              confirmPassword: 'userConfirmPassword',
+            }}
+          />
+        </>
+      )
+    }
+
+    render(() => <Parent />)
+  })
+
+  it('should accept formId and return it', async () => {
+    function Submit() {
+      const form = useFormContext()
+
+      return (
+        <button type="submit" form={form.formId} data-testid="formId-target">
+          {form.formId}
+        </button>
+      )
+    }
+
+    function Comp() {
+      const form = useAppForm(() => ({
+        formId: 'test',
+      }))
+
+      return (
+        <form.AppForm>
+          <form
+            id={form.formId}
+            onSubmit={(e) => {
+              e.preventDefault()
+              form.handleSubmit()
+            }}
+          ></form>
+
+          <form.Subscribe
+            selector={(state) => state.submissionAttempts}
+            children={(submissionAttempts) => (
+              <span data-testid="formId-result">{submissionAttempts()}</span>
+            )}
+          />
+
+          <Submit />
+        </form.AppForm>
+      )
+    }
+
+    const { getByTestId } = render(() => <Comp />)
+    const target = getByTestId('formId-target')
+    const result = getByTestId('formId-result')
+
+    await user.click(target)
+    expect(result).toHaveTextContent('1')
   })
 })


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
Add the `withFieldGroup` API for Form Composition in Solid Form

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
