### PR TITLE
fix(react-form): allow interfaces to be assigned to `withFieldGroup`'s `props`

### DIFF
--- a/.changeset/cruel-clocks-obey.md
+++ b/.changeset/cruel-clocks-obey.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-form': patch
+---
+
+Allow interfaces to be assigned to `withFieldGroup`'s `props`.

--- a/packages/react-form/src/createFormHook.tsx
+++ b/packages/react-form/src/createFormHook.tsx
@@ -249,7 +249,7 @@ export interface WithFieldGroupProps<
   TFieldComponents extends Record<string, ComponentType<any>>,
   TFormComponents extends Record<string, ComponentType<any>>,
   TSubmitMeta,
-  TRenderProps extends Record<string, unknown> = Record<string, never>,
+  TRenderProps extends object = Record<string, never>,
 > extends BaseFormOptions<TFieldGroupData, TSubmitMeta> {
   // Optional, but adds props to the `render` function outside of `form`
   props?: TRenderProps
@@ -445,7 +445,7 @@ export function createFormHook<
   function withFieldGroup<
     TFieldGroupData,
     TSubmitMeta,
-    TRenderProps extends Record<string, unknown> = {},
+    TRenderProps extends object = {},
   >({
     render,
     props,

--- a/packages/react-form/tests/createFormHook.test-d.tsx
+++ b/packages/react-form/tests/createFormHook.test-d.tsx
@@ -820,7 +820,7 @@ describe('createFormHook', () => {
     const Component5 = <FieldGroup form={form} fields="nope2" />
   })
 
-  it('should allow interfaces without index signatures to be assigned to `props` in withForm', () => {
+  it('should allow interfaces without index signatures to be assigned to `props` in withForm and withFormGroup', () => {
     interface TestNoSignature {
       title: string
     }
@@ -842,20 +842,55 @@ describe('createFormHook', () => {
       render: () => <></>,
     })
 
+    const WithFieldGroupComponent1 = withFieldGroup({
+      defaultValues: { name: '' },
+      props: {} as TestNoSignature,
+      render: () => <></>,
+    })
+
+    const WithFieldGroupComponent2 = withFieldGroup({
+      defaultValues: { name: '' },
+      props: {} as TestWithSignature,
+      render: () => <></>,
+    })
+
     const appForm = useAppForm({ defaultValues: { name: '' } })
 
     const Component1 = <WithFormComponent1 title="" form={appForm} />
     const Component2 = (
       <WithFormComponent2 title="" something="else" form={appForm} />
     )
+
+    const FieldGroupComponent1 = (
+      <WithFieldGroupComponent1
+        title=""
+        form={appForm}
+        fields={{ name: 'name' }}
+      />
+    )
+    const FieldGroupComponent2 = (
+      <WithFieldGroupComponent2
+        title=""
+        something="else"
+        form={appForm}
+        fields={{ name: 'name' }}
+      />
+    )
   })
 
-  it('should not allow null as prop in withForm', () => {
+  it('should not allow null as prop in withForm and withFormGroup', () => {
     const WithFormComponent = withForm({
       defaultValues: { name: '' },
       // @ts-expect-error
       props: null,
       render: () => <></>,
     })
+  })
+
+  const WithFieldGroupComponent = withFieldGroup({
+    defaultValues: { name: '' },
+    // @ts-expect-error
+    props: null,
+    render: () => <></>,
   })
 })


### PR DESCRIPTION
Fixes: #1703

## 🎯 Changes

This PR fixes an issue that the previous generic had for interfaces in TypeScript similarly to #1601.

The purpose and the implementation is exactly the same, but now for `withFieldGroup` instead of `withForm`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
