### PR TITLE
fix(react-form): widen return type of render prop

### DIFF
--- a/.changeset/cuddly-planets-dig.md
+++ b/.changeset/cuddly-planets-dig.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-form': patch
+---
+
+Allow returning all other `ReactNode`s not just `JSX.Element` in the `render` function of `withForm` and `withFieldGroup`.

--- a/packages/react-form/src/createFormHook.tsx
+++ b/packages/react-form/src/createFormHook.tsx
@@ -13,7 +13,12 @@ import type {
   FormOptions,
   FormValidateOrFn,
 } from '@tanstack/form-core'
-import type { ComponentType, Context, JSX, PropsWithChildren } from 'react'
+import type {
+  ComponentType,
+  Context,
+  PropsWithChildren,
+  ReactNode,
+} from 'react'
 import type { FieldComponent } from './useField'
 import type { ReactFormExtendedApi } from './useForm'
 import type { AppFieldExtendedReactFieldGroupApi } from './useFieldGroup'
@@ -241,7 +246,7 @@ export interface WithFormProps<
         >
       }
     >,
-  ) => JSX.Element
+  ) => ReactNode
 }
 
 export interface WithFieldGroupProps<
@@ -278,7 +283,7 @@ export interface WithFieldGroupProps<
         >
       }
     >,
-  ) => JSX.Element
+  ) => ReactNode
 }
 
 export function createFormHook<
@@ -515,7 +520,7 @@ export function createFormHook<
         fields: TFields
       }
     >,
-  ) => JSX.Element {
+  ) => ReactNode {
     return function Render(innerProps) {
       const fieldGroupProps = useMemo(() => {
         return {


### PR DESCRIPTION
Fixes: #1815 

## 🎯 Changes

In React `JSX.Element` is only a subset of the valid children described by `ReactNode`. By widening this type we allow returning all valid React children now in a non-breaking fashion allowing

```tsx
withForm({
  // Type 'null' is not assignable to type 'Element'.
  render: function Render() {
    return null
  },
})

withFieldGroup({
  // Type 'null' is not assignable to type 'Element'.
  render: function Render() {
    return null
  },
})
```

to work without TypeScript errors.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).