### PR TITLE
fix(form-core): remove `crypto` package

### DIFF
--- a/.changeset/chatty-readers-ask.md
+++ b/.changeset/chatty-readers-ask.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/form-core': patch
+---
+
+fixes partial prerendering in NextJS using cache components

--- a/packages/form-core/package.json
+++ b/packages/form-core/package.json
@@ -52,7 +52,6 @@
   ],
   "dependencies": {
     "@tanstack/devtools-event-client": "^0.3.5",
-    "@tanstack/pacer": "^0.15.3",
     "@tanstack/store": "^0.7.7"
   },
   "devDependencies": {

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -1,5 +1,4 @@
 import { Derived, Store, batch } from '@tanstack/store'
-import { throttle } from '@tanstack/pacer'
 import {
   deleteBy,
   determineFormLevelErrorSourceAndValue,
@@ -12,6 +11,7 @@ import {
   isNonEmptyArray,
   mergeOpts,
   setBy,
+  throttle,
   uuid,
 } from './utils'
 import { defaultValidationLogic } from './ValidationLogic'
@@ -1316,9 +1316,7 @@ export class FormApi<
           id: this._formId,
           state: state,
         }),
-      {
-        wait: 300,
-      },
+      300,
     )
 
     // devtool broadcasts

--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -603,3 +603,12 @@ export function uuid(): string {
   IDX++
   return out
 }
+
+export function throttle<TFn extends (...args: Array<any>) => any>(fn: TFn, delay: number) {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  return function (...args: Parameters<TFn>) {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), delay);
+  };
+}

--- a/packages/form-core/tests/utils.spec.ts
+++ b/packages/form-core/tests/utils.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, expectTypeOf, it } from 'vitest'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 import {
   concatenatePaths,
   createFieldMap,
@@ -10,6 +10,7 @@ import {
   makePathArray,
   mergeOpts,
   setBy,
+  throttle,
   uuid,
 } from '../src/index'
 
@@ -823,5 +824,18 @@ describe('uuid', () => {
     const parts = id.split('-')
     expect(parts[2]?.[0]).toBe('4')
     expect(['8', '9', 'a', 'b']).toContain(parts[3]?.[0])
+  })
+})
+
+describe('throttle', () => {
+  it('should throttle a function', async () => {
+    const fn = vi.fn()
+    vi.useFakeTimers()
+    const throttledFn = throttle(fn, 100)
+    throttledFn()
+    throttledFn()
+    await vi.runAllTimersAsync()
+    vi.useRealTimers()
+    expect(fn).toHaveBeenCalledTimes(1)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1233,9 +1233,6 @@ importers:
       '@tanstack/devtools-event-client':
         specifier: ^0.3.5
         version: 0.3.5
-      '@tanstack/pacer':
-        specifier: ^0.15.3
-        version: 0.15.4
       '@tanstack/store':
         specifier: ^0.7.7
         version: 0.7.7
@@ -4787,10 +4784,6 @@ packages:
   '@tanstack/history@1.133.28':
     resolution: {integrity: sha512-B7+x7eP2FFvi3fgd3rNH9o/Eixt+pp0zCIdGhnQbAJjFrlwIKGjGnwyJjhWJ5fMQlGks/E2LdDTqEV4W9Plx7g==}
     engines: {node: '>=12'}
-
-  '@tanstack/pacer@0.15.4':
-    resolution: {integrity: sha512-vGY+CWsFZeac3dELgB6UZ4c7OacwsLb8hvL2gLS6hTgy8Fl0Bm/aLokHaeDIP+q9F9HUZTnp360z9uv78eg8pg==}
-    engines: {node: '>=18'}
 
   '@tanstack/query-core@5.90.5':
     resolution: {integrity: sha512-wLamYp7FaDq6ZnNehypKI5fNvxHPfTYylE0m/ZpuuzJfJqhR5Pxg9gvGBHZx4n7J+V5Rg5mZxHHTlv25Zt5u+w==}
@@ -14254,11 +14247,6 @@ snapshots:
       - typescript
 
   '@tanstack/history@1.133.28': {}
-
-  '@tanstack/pacer@0.15.4':
-    dependencies:
-      '@tanstack/devtools-event-client': 0.3.5
-      '@tanstack/store': 0.7.7
 
   '@tanstack/query-core@5.90.5': {}
 


### PR DESCRIPTION
@tanstack/pacer seems to execute `crypto.randomUUID` at some point in `throttle`. This prevents partial pre-rendering of client-side forms in nextjs. As throttle is a very simple function this commit replaces it with a super simple implementation.

## 🎯 Changes

- Removes `@tanstack/pacer` dependency
- Adds local minimal `throttle` method that does not rely on `crypto`
- Adds unit tests for the new throttle method

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
