### PR TITLE
feat(form-core): add validateArrayFields for validating nested fields

### DIFF
--- a/packages/form-core/src/FieldGroupApi.ts
+++ b/packages/form-core/src/FieldGroupApi.ts
@@ -327,6 +327,23 @@ export class FieldGroupApi<
   }
 
   /**
+   * Validates the children of a specified array in the form using the correct handlers for a given validation type.
+   */
+  validateArrayFields = async <
+    TField extends DeepKeysOfType<TFieldGroupData, any[]>,
+  >(
+    field: TField,
+    index: number,
+    cause: ValidationCause,
+  ) => {
+    return this.form.validateArrayFields(
+      this.getFormFieldName(field),
+      index,
+      cause,
+    )
+  }
+
+  /**
    * Validates a specified field in the form using the correct handlers for a given validation type.
    */
   validateField = <TField extends DeepKeys<TFieldGroupData>>(

--- a/packages/form-core/src/types.ts
+++ b/packages/form-core/src/types.ts
@@ -166,6 +166,15 @@ export interface FieldManipulator<TFormData, TSubmitMeta> {
   ) => Promise<unknown[]>
 
   /**
+   * Validates the children of a specified array in the form using the correct handlers for a given validation type.
+   */
+  validateArrayFields: <TField extends DeepKeysOfType<TFormData, any[]>>(
+    field: TField,
+    index: number,
+    cause: ValidationCause,
+  ) => Promise<unknown[]>
+
+  /**
    * Validates a specified field in the form using the correct handlers for a given validation type.
    */
   validateField: <TField extends DeepKeys<TFormData>>(

--- a/packages/form-core/tests/FieldGroupApi.spec.ts
+++ b/packages/form-core/tests/FieldGroupApi.spec.ts
@@ -213,6 +213,96 @@ describe('field group api', () => {
     expect(field3.state.meta.errors).toEqual(['Field 3'])
   })
 
+  it('should forward validateArrayFields to form', async () => {
+    vi.useFakeTimers()
+
+    const defaultValues = {
+      people: {
+        names: [
+          {
+            firstName: 'First one',
+            lastName: 'Last one',
+          },
+          {
+            firstName: 'Second one',
+            lastName: 'Last two',
+          },
+        ],
+      },
+    }
+
+    const form = new FormApi({
+      defaultValues,
+    })
+    form.mount()
+
+    const field1FirstName = new FieldApi({
+      form,
+      name: 'people.names[0].firstName',
+      validators: {
+        onChange: () => 'Field 1 - First Name',
+      },
+    })
+
+    const field1LastName = new FieldApi({
+      form,
+      name: 'people.names[0].lastName',
+      validators: {
+        onChange: () => 'Field 1 - Last Name',
+      },
+    })
+
+    const field2FirstName = new FieldApi({
+      form,
+      name: 'people.names[1].firstName',
+      validators: {
+        onChange: () => 'Field 2 - First Name',
+      },
+    })
+
+    const field2LastName = new FieldApi({
+      form,
+      name: 'people.names[1].lastName',
+      validators: {
+        onChange: () => 'Field 2 - Last Name',
+      },
+    })
+
+    field1FirstName.mount()
+    field1LastName.mount()
+    field2FirstName.mount()
+    field2LastName.mount()
+
+    const fieldGroup = new FieldGroupApi({
+      form,
+      defaultValues: {
+        names: [
+          {
+            firstName: '',
+            lastName: '',
+          },
+          {
+            firstName: '',
+            lastName: '',
+          },
+        ],
+      },
+      fields: 'people',
+    })
+
+    fieldGroup.mount()
+
+    fieldGroup.validateArrayFields('names', 0, 'change')
+
+    await vi.runAllTimersAsync()
+
+    expect(field1FirstName.state.meta.errors).toEqual(['Field 1 - First Name'])
+    expect(field1LastName.state.meta.errors).toEqual(['Field 1 - Last Name'])
+
+    expect(field2FirstName.state.meta.errors).toEqual([])
+    expect(field2LastName.state.meta.errors).toEqual([])
+  })
+
   it('should get the right field value from the nested field', () => {
     const defaultValues: FormValues = {
       name: '',

--- a/packages/form-core/tests/FormApi.test-d.ts
+++ b/packages/form-core/tests/FormApi.test-d.ts
@@ -281,6 +281,12 @@ it('should only allow array fields for array-specific methods', () => {
   const validate2 = form.validateArrayFieldsStartingFrom<AllKeys>
   // @ts-expect-error too wide!
   const validate3 = form.validateArrayFieldsStartingFrom<RandomKeys>
+
+  const validate4 = form.validateArrayFields<OnlyArrayKeys>
+  // @ts-expect-error too wide!
+  const validate5 = form.validateArrayFields<AllKeys>
+  // @ts-expect-error too wide!
+  const validate6 = form.validateArrayFields<RandomKeys>
 })
 
 it('should infer full field name union for form.resetField parameters', () => {


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
This PR introduces a new function `validateArrayFields` that is similar to `validateArrayFieldsStartingFrom` but it validates only nested fields for the given index.

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
