### PR TITLE
fix(solid-form): fix AppField rerender when calling field function

### DIFF
--- a/packages/solid-form/src/createFormHook.tsx
+++ b/packages/solid-form/src/createFormHook.tsx
@@ -1,7 +1,3 @@
-import { createContext, splitProps, useContext } from 'solid-js'
-import { createForm } from './createForm'
-import { createFieldGroup } from './createFieldGroup'
-import type { AppFieldExtendedSolidFieldGroupApi } from './createFieldGroup'
 import type {
   AnyFieldApi,
   AnyFormApi,
@@ -20,9 +16,17 @@ import type {
   JSXElement,
   ParentProps,
 } from 'solid-js'
+import {
+  createComponent,
+  createContext,
+  splitProps,
+  useContext,
+} from 'solid-js'
 import type { FieldComponent } from './createField'
+import type { AppFieldExtendedSolidFieldGroupApi } from './createFieldGroup'
+import { createFieldGroup } from './createFieldGroup'
 import type { SolidFormExtendedApi } from './createForm'
-import { Dynamic } from 'solid-js/web'
+import { createForm } from './createForm'
 
 /**
  * TypeScript inferencing is weird.
@@ -358,13 +362,13 @@ export function createFormHook<
         <form.Field {...fieldProps}>
           {(field) => (
             <opts.fieldContext.Provider value={field}>
-              <Dynamic
-                component={() =>
+              {createComponent(
+                () =>
                   childProps.children(
                     Object.assign(field, opts.fieldComponents),
-                  )
-                }
-              />
+                  ),
+                {},
+              )}
             </opts.fieldContext.Provider>
           )}
         </form.Field>


### PR DESCRIPTION
## Problem

Using any Signal inside the `Form.AppField` render function causes the entire component to re-run whenever that Signal changes.

Below is an example:
```tsx
<Form.AppField name="username">
  {(field) => {
    const value = useStore(
      field().store,
      (s) => s.value,
    );
    onMount(() => {
      console.log("Mount"); // This runs every time value changes
    });
    console.log(value()); // This runs every time value changes
    
    return <field.TextField label={t`Username`} />;
  }}
</Form
```

## Fix
By wrapping it with a `<Dynamic>` this no longer happens.

```tsx
<Form.AppField name="username">
  {(field) => (
    <Dynamic
      component={() => {
        const value = useStore(field().store, (s) => s.value);
        onMount(() => {
          console.log("Mount");
        });
        console.log(value());
        
        return <field.TextField label={t`Username`} />;
      }}
    />
  )}
</Form.AppField>
```


`<Dynamic>` is basically doing this here

```tsx
export function InlineComponent(props: { e: () => JSXElement }) {
  return props.e();
}
```
