### PR TITLE
feat(form-core): Add options to reset/replace/delete all fields [FieldGroupApi]

### DIFF
--- a/.changeset/upset-lemons-spend.md
+++ b/.changeset/upset-lemons-spend.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/form-core': patch
+---
+
+Added options to reset/replace/delete fields for FieldGroup

--- a/packages/form-core/src/FieldGroupApi.ts
+++ b/packages/form-core/src/FieldGroupApi.ts
@@ -110,6 +110,14 @@ export interface FieldGroupOptions<
   onSubmitMeta?: TSubmitMeta
 }
 
+function isFieldInStringGroup(fieldName: string, groupPath: string) {
+  return (
+    fieldName !== groupPath &&
+    fieldName.startsWith(groupPath) &&
+    (fieldName[groupPath.length] === '.' || fieldName[groupPath.length] === '[')
+  )
+}
+
 export class FieldGroupApi<
   in out TFormData,
   in out TFieldGroupData,
@@ -396,6 +404,36 @@ export class FieldGroupApi<
   }
 
   /**
+   * Delete all fields that belong to this field group.
+   */
+  deleteAllFields = () => {
+    if (typeof this.fieldsMap === 'string') {
+      const groupPath = this.fieldsMap.toString()
+      const currentValue = this.form.getFieldValue(groupPath)
+
+      const fieldsToDelete = Object.keys(this.form.fieldInfo).filter(
+        (fieldName) => isFieldInStringGroup(fieldName, groupPath),
+      )
+
+      fieldsToDelete.forEach((field) => {
+        this.form.deleteField(field)
+      })
+
+      const emptyValue = Array.isArray(currentValue) ? [] : {}
+      this.form.setFieldValue(groupPath, emptyValue as never, {
+        dontUpdateMeta: true,
+      })
+
+      return
+    }
+
+    const fieldsMap = this.fieldsMap as FieldsMap<TFormData, TFieldGroupData>
+    for (const key in fieldsMap) {
+      this.deleteField(key)
+    }
+  }
+
+  /**
    * Pushes a value into an array field.
    */
   pushFieldValue = <TField extends DeepKeysOfType<TFieldGroupData, any[]>>(
@@ -458,6 +496,20 @@ export class FieldGroupApi<
   }
 
   /**
+   * Replaces all field values in this field group with the provided values.
+   */
+  replaceAllFields = (fields: TFieldGroupData) => {
+    for (const fieldName of Object.keys(
+      fields as object,
+    ) as (keyof TFieldGroupData)[]) {
+      this.setFieldValue(
+        fieldName as unknown as DeepKeys<TFieldGroupData>,
+        fields[fieldName] as never,
+      )
+    }
+  }
+
+  /**
    * Removes a value from an array field at the specified index.
    */
   removeFieldValue = async <
@@ -512,10 +564,39 @@ export class FieldGroupApi<
   }
 
   /**
-   * Resets the field value and meta to default state
+   * Resets the field value and meta to default state.
    */
   resetField = <TField extends DeepKeys<TFieldGroupData>>(field: TField) => {
     return this.form.resetField(this.getFormFieldName(field))
+  }
+
+  /**
+   * Resets all field values and meta within this field group.
+   */
+  resetAllFields = () => {
+    if (typeof this.fieldsMap === 'string') {
+      const groupPath = this.fieldsMap.toString()
+
+      const fieldsToReset = Object.keys(this.form.fieldInfo).filter(
+        (fieldName) => isFieldInStringGroup(fieldName, groupPath),
+      )
+
+      fieldsToReset.forEach((field) => this.form.resetField(field))
+
+      if (this.form.options.defaultValues !== undefined) {
+        const resetValue = getBy(this.form.options.defaultValues, groupPath)
+        this.form.setFieldValue(groupPath, resetValue as never, {
+          dontUpdateMeta: true,
+        })
+      }
+      return
+    }
+
+    const fieldsMap = this.fieldsMap as FieldsMap<TFormData, TFieldGroupData>
+
+    for (const key in fieldsMap) {
+      this.resetField(key)
+    }
   }
 
   validateAllFields = (cause: ValidationCause) =>

--- a/packages/form-core/tests/FieldGroupApi.spec.ts
+++ b/packages/form-core/tests/FieldGroupApi.spec.ts
@@ -512,6 +512,395 @@ describe('field group api', () => {
     expect(form.state.values.nested.field.name).toBeUndefined()
   })
 
+  it('should deleteAllFields for string field groups', () => {
+    const defaultValues = {
+      nested: {
+        field: {
+          name: 'hello',
+        },
+      },
+    }
+
+    const form = new FormApi({
+      defaultValues,
+    })
+    form.mount()
+
+    const field = new FieldApi({
+      form,
+      name: 'nested.field.name',
+    })
+    field.mount()
+
+    const group = new FieldGroupApi({
+      defaultValues: { name: '' },
+      form,
+      fields: 'nested.field',
+    })
+    group.mount()
+
+    group.deleteAllFields()
+
+    expect(form.state.values.nested.field).toEqual({})
+  })
+
+  it('should deleteAllFields for mapped field groups', () => {
+    type FormVals = {
+      a: string
+      b: string
+    }
+
+    const defaultValues: FormVals = { a: 'A', b: 'B' }
+    const form = new FormApi({
+      defaultValues,
+    })
+    form.mount()
+
+    const group = new FieldGroupApi({
+      form,
+      fields: {
+        firstName: 'a',
+        lastName: 'b',
+      },
+      defaultValues: { firstName: '', lastName: '' },
+    })
+    group.mount()
+
+    group.deleteAllFields()
+
+    expect(form.state.values.a).toBeUndefined()
+    expect(form.state.values.b).toBeUndefined()
+  })
+
+  it('should not delete sibling fields with matching prefix', () => {
+    const defaultValues = {
+      people: {
+        name: 'A',
+      },
+      peopleCount: {
+        total: 2,
+      },
+    }
+
+    const form = new FormApi({
+      defaultValues,
+    })
+    form.mount()
+
+    const peopleField = new FieldApi({
+      form,
+      name: 'people.name',
+    })
+    const peopleCountField = new FieldApi({
+      form,
+      name: 'peopleCount.total',
+    })
+    peopleField.mount()
+    peopleCountField.mount()
+
+    const group = new FieldGroupApi({
+      defaultValues: { name: '' },
+      form,
+      fields: 'people',
+    })
+    group.mount()
+
+    group.deleteAllFields()
+
+    expect(form.state.values.people).toEqual({})
+    expect(form.state.values.peopleCount.total).toBe(2)
+  })
+
+  it('should deleteAllFields even when no child fields are mounted', () => {
+    const defaultValues = {
+      nested: {
+        field: {
+          name: 'hello',
+          age: 12,
+        },
+      },
+    }
+
+    const form = new FormApi({
+      defaultValues,
+    })
+    form.mount()
+
+    const group = new FieldGroupApi({
+      defaultValues: { name: '', age: 0 },
+      form,
+      fields: 'nested.field',
+    })
+    group.mount()
+
+    group.deleteAllFields()
+
+    expect(form.state.values.nested.field).toEqual({})
+  })
+
+  it('should replaceAllFields for string field groups', () => {
+    const defaultValues: FormValues = {
+      name: '',
+      age: 0,
+      people: [],
+      relatives: {
+        father: {
+          name: 'father',
+          age: 10,
+        },
+      },
+    }
+
+    const form = new FormApi({
+      defaultValues,
+    })
+    form.mount()
+
+    const group = new FieldGroupApi({
+      defaultValues: {} as Person,
+      form,
+      fields: 'relatives.father',
+    })
+    group.mount()
+
+    group.replaceAllFields({ name: 'New name', age: 99 })
+
+    expect(form.state.values.relatives.father).toEqual({
+      name: 'New name',
+      age: 99,
+    })
+  })
+
+  it('should replaceAllFields for mapped field groups', () => {
+    type FormVals = {
+      a: string
+      b: string
+    }
+
+    const defaultValues: FormVals = { a: 'A', b: 'B' }
+    const form = new FormApi({
+      defaultValues,
+    })
+    form.mount()
+
+    const group = new FieldGroupApi({
+      form,
+      fields: {
+        firstName: 'a',
+        lastName: 'b',
+      },
+      defaultValues: { firstName: '', lastName: '' },
+    })
+    group.mount()
+
+    group.replaceAllFields({ firstName: 'X', lastName: 'Y' })
+
+    expect(form.state.values.a).toBe('X')
+    expect(form.state.values.b).toBe('Y')
+  })
+
+  it('should resetAllFields for string field groups', () => {
+    const defaultValues = {
+      nested: {
+        field: {
+          name: 'Default',
+          age: 33,
+        },
+      },
+    }
+
+    const form = new FormApi({
+      defaultValues,
+    })
+    form.mount()
+
+    const nameField = new FieldApi({
+      form,
+      name: 'nested.field.name',
+    })
+    const ageField = new FieldApi({
+      form,
+      name: 'nested.field.age',
+    })
+    nameField.mount()
+    ageField.mount()
+
+    const group = new FieldGroupApi({
+      defaultValues: { name: '', age: 0 },
+      form,
+      fields: 'nested.field',
+    })
+    group.mount()
+
+    group.setFieldValue('name', 'Updated')
+    group.setFieldValue('age', 99)
+    expect(form.state.values.nested.field).toEqual({ name: 'Updated', age: 99 })
+    expect(form.getFieldMeta('nested.field.name')?.isTouched).toBe(true)
+    expect(form.getFieldMeta('nested.field.age')?.isDirty).toBe(true)
+
+    group.resetAllFields()
+
+    expect(form.state.values.nested.field).toEqual(defaultValues.nested.field)
+    expect(form.getFieldMeta('nested.field.name')?.isTouched).toBe(false)
+    expect(form.getFieldMeta('nested.field.name')?.isDirty).toBe(false)
+    expect(form.getFieldMeta('nested.field.age')?.isTouched).toBe(false)
+    expect(form.getFieldMeta('nested.field.age')?.isDirty).toBe(false)
+  })
+
+  it('should resetAllFields for mapped field groups', () => {
+    type FormVals = {
+      a: string
+      b: string
+    }
+
+    const defaultValues: FormVals = { a: 'A', b: 'B' }
+    const form = new FormApi({
+      defaultValues,
+    })
+    form.mount()
+
+    const fieldA = new FieldApi({
+      form,
+      name: 'a',
+    })
+    const fieldB = new FieldApi({
+      form,
+      name: 'b',
+    })
+    fieldA.mount()
+    fieldB.mount()
+
+    const group = new FieldGroupApi({
+      form,
+      fields: {
+        firstName: 'a',
+        lastName: 'b',
+      },
+      defaultValues: { firstName: '', lastName: '' },
+    })
+    group.mount()
+
+    group.replaceAllFields({ firstName: 'X', lastName: 'Y' })
+    expect(form.state.values).toEqual({ a: 'X', b: 'Y' })
+    expect(form.getFieldMeta('a')?.isTouched).toBe(true)
+    expect(form.getFieldMeta('b')?.isDirty).toBe(true)
+
+    group.resetAllFields()
+
+    expect(form.state.values).toEqual(defaultValues)
+    expect(form.getFieldMeta('a')?.isTouched).toBe(false)
+    expect(form.getFieldMeta('a')?.isDirty).toBe(false)
+    expect(form.getFieldMeta('b')?.isTouched).toBe(false)
+    expect(form.getFieldMeta('b')?.isDirty).toBe(false)
+  })
+
+  it('should not reset sibling fields with matching prefix', () => {
+    const defaultValues = {
+      people: {
+        name: 'A',
+      },
+      peopleCount: {
+        total: 2,
+      },
+    }
+
+    const form = new FormApi({
+      defaultValues,
+    })
+    form.mount()
+
+    const peopleField = new FieldApi({
+      form,
+      name: 'people.name',
+    })
+    const peopleCountField = new FieldApi({
+      form,
+      name: 'peopleCount.total',
+    })
+    peopleField.mount()
+    peopleCountField.mount()
+
+    form.setFieldValue('people.name', 'Updated')
+    form.setFieldValue('peopleCount.total', 99)
+
+    const group = new FieldGroupApi({
+      defaultValues: { name: '' },
+      form,
+      fields: 'people',
+    })
+    group.mount()
+
+    group.resetAllFields()
+
+    expect(form.state.values.people.name).toBe('A')
+    expect(form.state.values.peopleCount.total).toBe(99)
+  })
+
+  it('should resetAllFields even when no child fields are mounted', () => {
+    const defaultValues = {
+      nested: {
+        field: {
+          name: 'Default',
+          age: 33,
+        },
+      },
+    }
+
+    const form = new FormApi({
+      defaultValues,
+    })
+    form.mount()
+
+    form.setFieldValue('nested.field', {
+      name: 'Updated',
+      age: 100,
+    })
+
+    const group = new FieldGroupApi({
+      defaultValues: { name: '', age: 0 },
+      form,
+      fields: 'nested.field',
+    })
+    group.mount()
+
+    group.resetAllFields()
+
+    expect(form.state.values.nested.field).toEqual(defaultValues.nested.field)
+  })
+
+  it('should not overwrite group values when defaultValues are missing', () => {
+    const form = new FormApi({
+      defaultValues: undefined as
+        | {
+            nested: {
+              field: {
+                name: string
+                age: number
+              }
+            }
+          }
+        | undefined,
+    })
+    form.mount()
+
+    form.setFieldValue('nested.field.name', 'Updated')
+    form.setFieldValue('nested.field.age', 77)
+
+    const group = new FieldGroupApi({
+      defaultValues: { name: '', age: 0 },
+      form,
+      fields: 'nested.field',
+    })
+    group.mount()
+
+    group.resetAllFields()
+
+    expect(form.state.values.nested.field).toEqual({
+      name: 'Updated',
+      age: 77,
+    })
+  })
+
   it('should forward array methods to the form', async () => {
     vi.useFakeTimers()
     const defaultValues = {


### PR DESCRIPTION
## 🎯 Changes

Regarding: https://github.com/TanStack/form/discussions/1684

This PR adds functionalities to the Field Group API: 

`resetAllFields` - reset all group fields to their default values
`deleteAllFields` - delete all fields from the current group instance
`replaceAllFields` - replace all group fields with new provided values

When accepted, I will prepare documentation update. 

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [X] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk FieldGroup operations: delete all fields in a group, replace all fields with a provided object, and reset all fields to configured defaults (clearing related metadata where appropriate).

* **Tests**
  * Added comprehensive tests for bulk operations covering string-based and mapped groups, nested targets, sibling isolation, default-value behavior, and cases with no mounted child fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->