### PR TITLE
docs: fix punctuation and grammar issues

### DIFF
--- a/docs/framework/angular/guides/arrays.md
+++ b/docs/framework/angular/guides/arrays.md
@@ -66,7 +66,7 @@ Finally, you can use a subfield like so:
 </ng-container>
 ```
 
-Where `getPeopleName` is a method on the class like so
+Where `getPeopleName` is a method on the class like so:
 
 ```typescript
 export class AppComponent {

--- a/docs/framework/lit/guides/arrays.md
+++ b/docs/framework/lit/guides/arrays.md
@@ -86,7 +86,7 @@ return html`
 export class TestForm extends LitElement {
   #form = new TanStackFormController(this, {
     defaultValues: {
-      people: [] as Array<{ name: string}>,
+      people: [] as Array<{ name: string }>,
     },
   });
   render() {

--- a/docs/framework/lit/quick-start.md
+++ b/docs/framework/lit/quick-start.md
@@ -46,7 +46,7 @@ export class TestForm extends LitElement {
     },
   })
   render() {
-    return html` <p>Please enter your first name></p>
+    return html` <p>Please enter your first name</p>
       ${this.#form.field(
         {
           name: `firstName`,

--- a/docs/framework/react/guides/async-initial-values.md
+++ b/docs/framework/react/guides/async-initial-values.md
@@ -40,7 +40,7 @@ export default function App() {
     },
   })
 
-  if (isLoading) return <p>Loading..</p>
+  if (isLoading) return <p>Loading...</p>
 
   return (
     // ...

--- a/docs/framework/react/guides/debugging.md
+++ b/docs/framework/react/guides/debugging.md
@@ -36,7 +36,7 @@ If you see this error in the console when running `tsc`:
 Type instantiation is excessively deep and possibly infinite
 ```
 
-You've ran into a bug that we didn't catch in our type definitions. While we've done our best to make sure our types are as accurate as possible, there are some edge cases where TypeScript struggled with the complexity of our types.
+You've run into a bug that we didn't catch in our type definitions. While we've done our best to make sure our types are as accurate as possible, there are some edge cases where TypeScript struggled with the complexity of our types.
 
 Please [report this issue to us on GitHub](https://github.com/TanStack/form/issues) so we can fix it. Just make sure to include a minimal reproduction so that we're able to help you debug.
 

--- a/docs/framework/react/guides/ssr.md
+++ b/docs/framework/react/guides/ssr.md
@@ -256,7 +256,7 @@ Finally, we'll use `someAction` in our client-side form component.
 
 import { useActionState } from 'react'
 import {
-  initialFormState
+  initialFormState,
   mergeForm,
   useForm,
   useStore,
@@ -412,7 +412,7 @@ Finally, the `action` will be called when the form submits.
 import {
   Form,
   mergeForm,
-  useActionData
+  useActionData,
   useForm,
   useStore,
   useTransform,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,4 +83,4 @@ $ bun add @tanstack/svelte-form
 $ yarn add @tanstack/svelte-form
 ```
 
-> Depending on your environment, you might need to add polyfills. If you want to support older browsers, you need to transpile the library from `node_modules` yourselves.
+> Depending on your environment, you might need to add polyfills. If you want to support older browsers, you need to transpile the library from `node_modules` yourself.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -65,7 +65,7 @@ export default function App() {
         }}
       >
         <div>
-          {/* A type-safe field component*/}
+          {/* A type-safe field component */}
           <form.Field
             name="firstName"
             validators={{
@@ -139,4 +139,4 @@ createRoot(rootElement).render(<App />)
 
 ## You talked me into it, so what now?
 
-- Learn TanStack Form at your own pace with our thorough [Walkthrough Guide](./installation) and [API Reference](./reference/classes/FormApi)
+- Learn TanStack Form at your own pace with our thorough [Walkthrough Guide](./installation) and [API Reference](./reference/classes/FormApi).

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -27,7 +27,7 @@ As a result, TanStack Form supports multiple methods for validation:
 
 ## Controlled is Cool
 
-In a world where controlled vs uncontrolled inputs are a hot topic, TanStack Form is firmly in the controlled camp.
+In a world where controlled vs. uncontrolled inputs are a hot topic, TanStack Form is firmly in the controlled camp.
 
 This comes with a number of advantages:
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -3,7 +3,7 @@ id: typescript
 title: TypeScript
 ---
 
-TanStack Form is written 100% in **TypeScript** with the highest quality generics, constraints and interfaces to make sure the library and your projects are as type-safe as possible!
+TanStack Form is written 100% in **TypeScript** with the highest quality generics, constraints, and interfaces to make sure the library and your projects are as type-safe as possible!
 
 Things to keep in mind:
 


### PR DESCRIPTION
## 🎯 Changes

Fixed punctuation and grammar errors across documentation files.

**Corrections applied**:
- Pronoun agreement (yourselves → yourself)
- Missing punctuation (periods, commas)
- Grammar fixes (ran → run)
- JSX comment spacing
- Malformed HTML tag
- TypeScript formatting

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] This change is docs/CI/dev-only (no release).