### PR TITLE
fix(form-core): set isValidating synchronously before debounce delay

### DIFF
--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -1782,8 +1782,13 @@ export class FieldApi<
     )
     const hasAsyncValidators = hasOwnAsyncValidators || hasLinkedAsyncValidators
 
-    // Set isValidating for linked fields (own field already set above before await)
+    // Set isValidating for linked fields and current field when linked fields are validating
+    // This preserves original behavior where current field shows validating
+    // when any of its linked fields are validating
     if (hasLinkedAsyncValidators) {
+      if (!this.state.meta.isValidating) {
+        this.setMeta((prev) => ({ ...prev, isValidating: true }))
+      }
       for (const linkedField of linkedFields) {
         linkedField.setMeta((prev) => ({ ...prev, isValidating: true }))
       }

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -3000,5 +3000,7 @@ describe('edge cases and error handling', () => {
     // Now validation is complete
     expect(field.getMeta().isValidating).toBe(false)
     expect(field.getMeta().errors).toContain('Server error')
+
+    vi.useRealTimers()
   })
 })


### PR DESCRIPTION
## Summary

When async validation is scheduled with debounce, the `isValidating` flag was being set AFTER an `await`, causing a gap where callers would see `isValidating: false` during the debounce period. This caused `form.canSubmit` to be `true` when it should be `false`.

**Before (bug):**
1. User types value that passes sync validation
2. Async validation is scheduled with 500ms debounce
3. `isValidating` remains `false` during the debounce period ← BUG
4. Submit button is enabled when it shouldn't be

**After (fix):**
1. User types value that passes sync validation  
2. Async validation is scheduled with 500ms debounce
3. `isValidating` is set to `true` immediately (synchronously)
4. Submit button is correctly disabled

## Changes

- Move `isValidating = true` assignment to happen synchronously, before any `await`, when async validators are detected
- Add test case to verify `isValidating` is true during debounce period

## Test plan

- [x] Added unit test for the specific scenario (sync passes, async debounced)
- [x] All 363 existing form-core tests pass
- [x] TypeScript compiles without errors

Fixes #1833

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.