### PR TITLE
docs(react-form): Fix validator typo in TanStack Start docs

### DIFF
--- a/docs/framework/react/guides/ssr.md
+++ b/docs/framework/react/guides/ssr.md
@@ -58,7 +58,7 @@ const serverValidate = createServerValidate({
 export const handleForm = createServerFn({
   method: 'POST',
 })
-  .validator((data: unknown) => {
+  .inputValidator((data: unknown) => {
     if (!(data instanceof FormData)) {
       throw new Error('Invalid form data')
     }


### PR DESCRIPTION
## 🎯 Changes

I am using `@tanstack/react-start` version `1.145.3` and following the [Tanstack form React Meta-Framework Usage guide](https://tanstack.com/form/latest/docs/framework/react/guides/ssr)

The guide has `createServerFn.validator` when it should be `createServerFn.inputValidator` according to the [Tanstack Start Server Functions doc](https://tanstack.com/start/latest/docs/framework/react/guide/server-functions#parameters--validation)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
