### PR TITLE
fix(react-form): complie error with webpack when react lower than v18

### DIFF
--- a/.changeset/smooth-teeth-send.md
+++ b/.changeset/smooth-teeth-send.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-form': patch
+---
+
+Fix compile error with webpack when using react v17

--- a/packages/react-form/src/useFormId.ts
+++ b/packages/react-form/src/useFormId.ts
@@ -1,6 +1,11 @@
 import * as React from 'react'
 import { useUUID } from './useUUID'
 
-/** React 17 does not have the useId hook, so we use a random uuid as a fallback. */
+/**
+ * React 17 does not have the useId hook, so we use a random uuid as a fallback.
+ * This is needed to avoid bundlers trying to import non-existing export.
+ * Read more: https://github.com/webpack/webpack/issues/14814
+ */
+const _React = React
 export const useFormId =
-  React.version.split('.')[0] === '17' ? useUUID : React.useId
+  React.version.split('.')[0] === '17' ? useUUID : _React.useId


### PR DESCRIPTION
Change-Id: Ia4b18c0cf0d6a2c809923588c567f2cabbd08bde

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
Patch needed to avoid bundlers trying to import non-existing export.
Original PR: https://github.com/iTwin/iTwinUI/pull/1284
Read more: https://github.com/webpack/webpack/issues/14814

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
