### PR TITLE
fix(form-core): Validate fields without instances

### DIFF
--- a/.changeset/happy-pillows-hear.md
+++ b/.changeset/happy-pillows-hear.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/form-core': patch
+---
+
+run validation for fields without instances

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -1599,7 +1599,18 @@ export class FormApi<
   ) => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const fieldInstance = this.fieldInfo[field]?.instance
-    if (!fieldInstance) return []
+
+    if (!fieldInstance) {
+      const { hasErrored } = this.validateSync(cause)
+
+      if (hasErrored && !this.options.asyncAlways) {
+        return this.getFieldMeta(field)?.errors ?? []
+      }
+
+      return this.validateAsync(cause).then(() => {
+        return this.getFieldMeta(field)?.errors ?? []
+      })
+    }
 
     // If the field is not touched (same logic as in validateAllFields)
     if (!fieldInstance.state.meta.isTouched) {

--- a/packages/form-core/tests/standardSchemaValidator.spec.ts
+++ b/packages/form-core/tests/standardSchemaValidator.spec.ts
@@ -108,6 +108,31 @@ describe('standard schema validator', () => {
       ])
     })
 
+    it('should handle form-level field errors for fields without a mounted FieldApi instance', () => {
+      const form = new FormApi({
+        defaultValues: {
+          email: '',
+        },
+        validators: {
+          onChange: z.object({
+            email: z.string().email('email must be an email address'),
+          }),
+        },
+      })
+
+      form.mount()
+
+      form.setFieldValue('email', 'not-an-email')
+
+      expect(form.state.errors).toMatchObject([
+        { email: [{ message: 'email must be an email address' }] },
+      ])
+
+      form.setFieldValue('email', 'test@example.com')
+
+      expect(form.state.errors).toEqual([])
+    })
+
     it('should support standard schema async validation with zod', async () => {
       vi.useFakeTimers()
 


### PR DESCRIPTION
## 🎯 Changes

Fixes: https://github.com/TanStack/form/issues/1865

So far, in case when there was no field instance - validation was not run for a given field.
Explicit call to form validation will not be expensive, so it will be better to have this as fallback than nothing at all.

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [X] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
