### PR TITLE
test(form-core): add coverage for Map and Set comparison in evaluate

### DIFF
--- a/packages/form-core/tests/utils.spec.ts
+++ b/packages/form-core/tests/utils.spec.ts
@@ -692,6 +692,67 @@ describe('evaluate', () => {
     const dateObjectFalse = evaluate({ date: date1 }, { date: date3 })
     expect(dateObjectFalse).toEqual(false)
   })
+
+  it('should test equality between Map objects', () => {
+    const map1 = new Map([
+      ['a', 1],
+      ['b', 2],
+    ])
+    const map2 = new Map([
+      ['a', 1],
+      ['b', 2],
+    ])
+    expect(evaluate(map1, map2)).toEqual(true)
+
+    const emptyMap1 = new Map()
+    const emptyMap2 = new Map()
+    expect(evaluate(emptyMap1, emptyMap2)).toEqual(true)
+
+    const mapSmall = new Map([['a', 1]])
+    const mapLarge = new Map([
+      ['a', 1],
+      ['b', 2],
+    ])
+    expect(evaluate(mapSmall, mapLarge)).toEqual(false)
+
+    const mapA = new Map([
+      ['a', 1],
+      ['b', 2],
+    ])
+    const mapC = new Map([
+      ['a', 1],
+      ['c', 2],
+    ])
+    expect(evaluate(mapA, mapC)).toEqual(false)
+
+    const mapVal1 = new Map([
+      ['a', 1],
+      ['b', 2],
+    ])
+    const mapVal2 = new Map([
+      ['a', 1],
+      ['b', 3],
+    ])
+    expect(evaluate(mapVal1, mapVal2)).toEqual(false)
+  })
+
+  it('should test equality between Set objects', () => {
+    const set1 = new Set([1, 2, 3])
+    const set2 = new Set([1, 2, 3])
+    expect(evaluate(set1, set2)).toEqual(true)
+
+    const emptySet1 = new Set()
+    const emptySet2 = new Set()
+    expect(evaluate(emptySet1, emptySet2)).toEqual(true)
+
+    const setSmall = new Set([1, 2])
+    const setLarge = new Set([1, 2, 3])
+    expect(evaluate(setSmall, setLarge)).toEqual(false)
+
+    const setA = new Set([1, 2, 3])
+    const setB = new Set([1, 2, 4])
+    expect(evaluate(setA, setB)).toEqual(false)
+  })
 })
 
 describe('concatenatePaths', () => {


### PR DESCRIPTION
## 🎯 Changes

Add test Coverage for the `evaluate` utility function - Map and Set comparison logic.

**Test cases added:**
- **Map equality**: equal maps, empty maps, different sizes, different keys, different values
- **Set equality**: equal sets, empty sets, different sizes, different values

This improves `utils.ts` statement coverage from 90.34% to 97.15%.

|AS-IS|TO-BE|
|---|---|
|<img width="1663" height="486" alt="image" src="https://github.com/user-attachments/assets/f7240537-ab48-4b25-9513-96a7e632db15" />|<img width="1643" height="483" alt="image" src="https://github.com/user-attachments/assets/1ce031b7-d548-4838-9cfd-54040f6ee5e4" />

**Why not 100% coverage?**

The remaining 3% uncovered lines are intentionally excluded for:

1. **Focused scope**: This PR specifically targets Map and Set comparison
2. **Easier review**: Narrow scope = faster merge
3. **Logical separation**: Remaining lines belong to different utilities:
   - Line 86: `setBy` edge case
   - Line 138: `deleteBy` unreachable error
   - Line 160: `makePathArray` array input
   - Line 164: TypeScript-protected error
   - Line 395: unreachable default case

These would be better addressed in separate PRs if needed.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
```
