### PR TITLE
fix(react-form-start): remove sensitive data logging in createServerValidate

### DIFF
--- a/.changeset/five-sites-poke.md
+++ b/.changeset/five-sites-poke.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-form-start': patch
+---
+
+Removed a console.log statement in `src/createServerValidate.tsx` that was logging the whole data object during server-side validation.

--- a/packages/react-form-start/src/createServerValidate.tsx
+++ b/packages/react-form-start/src/createServerValidate.tsx
@@ -54,7 +54,7 @@ const serverFn = createServerFn({ method: 'POST' })
       return data
     },
   )
-  .handler(async ({ data, ...props }) => {
+  .handler(async ({ data }) => {
     const { formData, info, defaultOpts } = data as {
       formData: FormData
       info?: Parameters<typeof decode>[1]


### PR DESCRIPTION
## 🎯 Changes

Removed a `console.log` statement in 
`src/createServerValidate.tsx`
 that was logging the whole data object and props during server-side validation. This object can contain sensitive information such as formData, passwords, or other PII, which should not be exposed in server logs.

Motivation: To prevent sensitive data leaks in server-side logs and improve the security of the library.
## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
