### PR TITLE
docs: clarify devtools should be installed as dev dependency

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -44,13 +44,13 @@ react: @tanstack/react-form-remix
 
 ## Devtools
 
-Developer tools are available using [TanStack Devtools](https://tanstack.com/devtools/latest). Install the devtools adapter for your framework to debug forms and inspect their state.
+Developer tools are available using [TanStack Devtools](https://tanstack.com/devtools/latest). Install the devtools adapter for your framework as a dev dependency to debug forms and inspect their state.
 
 # Solid
 
 ## Devtools
 
-Developer tools are available using [TanStack Devtools](https://tanstack.com/devtools/latest). Install the devtools adapter for your framework to debug forms and inspect their state.
+Developer tools are available using [TanStack Devtools](https://tanstack.com/devtools/latest). Install the devtools adapter for your framework as a dev dependency to debug forms and inspect their state.
 
 <!-- ::end:framework -->
 


### PR DESCRIPTION
Updated the devtools installation instructions to specify that the adapter should be installed as a dev dependency, since devtools are only used during development.

Fixes #2016

## ✅ Checklist

- [x] This change is docs/CI/dev-only (no release).