### PR TITLE
fix(form-core): exclude undefined from errors type to match runtime behavior

### DIFF
--- a/.changeset/tiny-webs-poke.md
+++ b/.changeset/tiny-webs-poke.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/react-form-nextjs': patch
+'@tanstack/react-form-remix': patch
+'@tanstack/form-core': patch
+---
+
+Fix type mismatch in `errors` field - exclude undefined to match runtime behavior

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -691,37 +691,48 @@ export type FieldMetaDerived<
    * An array of errors related to the field value.
    */
   errors: Array<
-    | UnwrapOneLevelOfArray<
-        UnwrapFieldValidateOrFn<TName, TOnMount, TFormOnMount>
-      >
-    | UnwrapOneLevelOfArray<
-        UnwrapFieldValidateOrFn<TName, TOnChange, TFormOnChange>
-      >
-    | UnwrapOneLevelOfArray<
-        UnwrapFieldAsyncValidateOrFn<TName, TOnChangeAsync, TFormOnChangeAsync>
-      >
-    | UnwrapOneLevelOfArray<
-        UnwrapFieldValidateOrFn<TName, TOnBlur, TFormOnBlur>
-      >
-    | UnwrapOneLevelOfArray<
-        UnwrapFieldAsyncValidateOrFn<TName, TOnBlurAsync, TFormOnBlurAsync>
-      >
-    | UnwrapOneLevelOfArray<
-        UnwrapFieldValidateOrFn<TName, TOnSubmit, TFormOnSubmit>
-      >
-    | UnwrapOneLevelOfArray<
-        UnwrapFieldAsyncValidateOrFn<TName, TOnSubmitAsync, TFormOnSubmitAsync>
-      >
-    | UnwrapOneLevelOfArray<
-        UnwrapFieldValidateOrFn<TName, TOnDynamic, TFormOnDynamic>
-      >
-    | UnwrapOneLevelOfArray<
-        UnwrapFieldAsyncValidateOrFn<
-          TName,
-          TOnDynamicAsync,
-          TFormOnDynamicAsync
+    Exclude<
+      | UnwrapOneLevelOfArray<
+          UnwrapFieldValidateOrFn<TName, TOnMount, TFormOnMount>
         >
-      >
+      | UnwrapOneLevelOfArray<
+          UnwrapFieldValidateOrFn<TName, TOnChange, TFormOnChange>
+        >
+      | UnwrapOneLevelOfArray<
+          UnwrapFieldAsyncValidateOrFn<
+            TName,
+            TOnChangeAsync,
+            TFormOnChangeAsync
+          >
+        >
+      | UnwrapOneLevelOfArray<
+          UnwrapFieldValidateOrFn<TName, TOnBlur, TFormOnBlur>
+        >
+      | UnwrapOneLevelOfArray<
+          UnwrapFieldAsyncValidateOrFn<TName, TOnBlurAsync, TFormOnBlurAsync>
+        >
+      | UnwrapOneLevelOfArray<
+          UnwrapFieldValidateOrFn<TName, TOnSubmit, TFormOnSubmit>
+        >
+      | UnwrapOneLevelOfArray<
+          UnwrapFieldAsyncValidateOrFn<
+            TName,
+            TOnSubmitAsync,
+            TFormOnSubmitAsync
+          >
+        >
+      | UnwrapOneLevelOfArray<
+          UnwrapFieldValidateOrFn<TName, TOnDynamic, TFormOnDynamic>
+        >
+      | UnwrapOneLevelOfArray<
+          UnwrapFieldAsyncValidateOrFn<
+            TName,
+            TOnDynamicAsync,
+            TFormOnDynamicAsync
+          >
+        >,
+      undefined
+    >
   >
   /**
    * A flag that is `true` if the field's value has not been modified by the user. Opposite of `isDirty`.

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -684,16 +684,19 @@ export type DerivedFormState<
    * The error array for the form itself.
    */
   errors: Array<
-    | UnwrapFormValidateOrFn<TOnMount>
-    | UnwrapFormValidateOrFn<TOnChange>
-    | UnwrapFormAsyncValidateOrFn<TOnChangeAsync>
-    | UnwrapFormValidateOrFn<TOnBlur>
-    | UnwrapFormAsyncValidateOrFn<TOnBlurAsync>
-    | UnwrapFormValidateOrFn<TOnSubmit>
-    | UnwrapFormAsyncValidateOrFn<TOnSubmitAsync>
-    | UnwrapFormValidateOrFn<TOnDynamic>
-    | UnwrapFormAsyncValidateOrFn<TOnDynamicAsync>
-    | UnwrapFormAsyncValidateOrFn<TOnServer>
+    Exclude<
+      | UnwrapFormValidateOrFn<TOnMount>
+      | UnwrapFormValidateOrFn<TOnChange>
+      | UnwrapFormAsyncValidateOrFn<TOnChangeAsync>
+      | UnwrapFormValidateOrFn<TOnBlur>
+      | UnwrapFormAsyncValidateOrFn<TOnBlurAsync>
+      | UnwrapFormValidateOrFn<TOnSubmit>
+      | UnwrapFormAsyncValidateOrFn<TOnSubmitAsync>
+      | UnwrapFormValidateOrFn<TOnDynamic>
+      | UnwrapFormAsyncValidateOrFn<TOnDynamicAsync>
+      | UnwrapFormAsyncValidateOrFn<TOnServer>,
+      undefined
+    >
   >
   /**
    * A boolean indicating if any of the form fields are currently validating.
@@ -1200,14 +1203,19 @@ export class FormApi<
         ) {
           errors = Object.values(currBaseStore.errorMap).reduce<
             Array<
-              | UnwrapFormValidateOrFn<TOnMount>
-              | UnwrapFormValidateOrFn<TOnChange>
-              | UnwrapFormAsyncValidateOrFn<TOnChangeAsync>
-              | UnwrapFormValidateOrFn<TOnBlur>
-              | UnwrapFormAsyncValidateOrFn<TOnBlurAsync>
-              | UnwrapFormValidateOrFn<TOnSubmit>
-              | UnwrapFormAsyncValidateOrFn<TOnSubmitAsync>
-              | UnwrapFormAsyncValidateOrFn<TOnServer>
+              Exclude<
+                | UnwrapFormValidateOrFn<TOnMount>
+                | UnwrapFormValidateOrFn<TOnChange>
+                | UnwrapFormAsyncValidateOrFn<TOnChangeAsync>
+                | UnwrapFormValidateOrFn<TOnBlur>
+                | UnwrapFormAsyncValidateOrFn<TOnBlurAsync>
+                | UnwrapFormValidateOrFn<TOnSubmit>
+                | UnwrapFormAsyncValidateOrFn<TOnSubmitAsync>
+                | UnwrapFormValidateOrFn<TOnDynamic>
+                | UnwrapFormAsyncValidateOrFn<TOnDynamicAsync>
+                | UnwrapFormAsyncValidateOrFn<TOnServer>,
+                undefined
+              >
             >
           >((prev, curr) => {
             if (curr === undefined) return prev

--- a/packages/form-core/tests/FieldApi.test-d.ts
+++ b/packages/form-core/tests/FieldApi.test-d.ts
@@ -221,9 +221,7 @@ it('should have the correct types returned from field validators in array', () =
     },
   })
 
-  expectTypeOf(field.state.meta.errors).toEqualTypeOf<
-    Array<'123' | undefined>
-  >()
+  expectTypeOf(field.state.meta.errors).toEqualTypeOf<Array<'123'>>()
 })
 
 it('should have the correct types returned from form validators in array', () => {
@@ -238,7 +236,7 @@ it('should have the correct types returned from form validators in array', () =>
     },
   } as const)
 
-  expectTypeOf(form.state.errors).toEqualTypeOf<Array<'123' | undefined>>()
+  expectTypeOf(form.state.errors).toEqualTypeOf<Array<'123'>>()
 })
 
 it('should handle "fields" return types added to the field\'s errorMap itself', () => {
@@ -288,9 +286,7 @@ it('should handle "fields" return types added to the field\'s error array itself
     name: 'firstName',
   })
 
-  expectTypeOf(field.getMeta().errors).toEqualTypeOf<
-    Array<'Testing' | undefined>
-  >()
+  expectTypeOf(field.getMeta().errors).toEqualTypeOf<Array<'Testing'>>()
 })
 
 it('should handle "fields" async return types added to the field\'s errorMap itself', () => {
@@ -340,9 +336,7 @@ it('should handle "fields" async return types added to the field\'s error array 
     name: 'firstName',
   })
 
-  expectTypeOf(field.getMeta().errors).toEqualTypeOf<
-    Array<'Testing' | undefined>
-  >()
+  expectTypeOf(field.getMeta().errors).toEqualTypeOf<Array<'Testing'>>()
 })
 
 it('should handle "sub-fields" async return types added to the field\'s error array itself', () => {
@@ -368,9 +362,7 @@ it('should handle "sub-fields" async return types added to the field\'s error ar
     name: 'person.firstName',
   })
 
-  expectTypeOf(field.getMeta().errors).toEqualTypeOf<
-    Array<'Testing' | undefined>
-  >()
+  expectTypeOf(field.getMeta().errors).toEqualTypeOf<Array<'Testing'>>()
 })
 
 it('should only have field-level error types returned from parseValueWithSchema and parseValueWithSchemaAsync', () => {

--- a/packages/form-core/tests/FormApi.test-d.ts
+++ b/packages/form-core/tests/FormApi.test-d.ts
@@ -365,15 +365,8 @@ it('should extract the form error type from a global form error', () => {
   >()
 
   expectTypeOf(form.state.errors).toEqualTypeOf<
-    (
-      | 'onMount'
-      | 'onChange'
-      | 'onChangeAsync'
-      | 'onBlur'
-      | 'onBlurAsync'
-      | undefined
-    )[]
-  >
+    ('onMount' | 'onChange' | 'onChangeAsync' | 'onBlur' | 'onBlurAsync')[]
+  >()
 })
 
 it('listeners should be typed correctly', () => {

--- a/packages/form-core/tests/formOptions.test-d.ts
+++ b/packages/form-core/tests/formOptions.test-d.ts
@@ -286,9 +286,7 @@ describe('formOptions', () => {
 
     const form = new FormApi(formOpts)
 
-    expectTypeOf(form.state.errors).toEqualTypeOf<
-      ('I just need an error' | undefined)[]
-    >()
+    expectTypeOf(form.state.errors).toEqualTypeOf<'I just need an error'[]>()
 
     const form2 = new FormApi({
       ...formOpts,
@@ -302,9 +300,7 @@ describe('formOptions', () => {
       },
     })
 
-    expectTypeOf(form2.state.errors).toEqualTypeOf<
-      (undefined | 'Too short!')[]
-    >()
+    expectTypeOf(form2.state.errors).toEqualTypeOf<'Too short!'[]>()
 
     const form3 = new FormApi({
       ...formOpts,
@@ -320,7 +316,7 @@ describe('formOptions', () => {
     })
 
     expectTypeOf(form3.state.errors).toEqualTypeOf<
-      (undefined | 'Too short!' | 'I just need an error')[]
+      ('Too short!' | 'I just need an error')[]
     >()
   })
 })

--- a/packages/react-form-nextjs/src/createServerValidate.ts
+++ b/packages/react-form-nextjs/src/createServerValidate.ts
@@ -118,7 +118,9 @@ export const createServerValidate =
         onServer: onServerError,
       },
       values,
-      errors: onServerErrorVal ? [onServerErrorVal] : [],
+      errors: (onServerErrorVal ? [onServerErrorVal] : []) as Array<
+        Exclude<UnwrapFormAsyncValidateOrFn<TOnServer>, undefined>
+      >,
     }
 
     throw new ServerValidateError({

--- a/packages/react-form-remix/src/createServerValidate.ts
+++ b/packages/react-form-remix/src/createServerValidate.ts
@@ -118,7 +118,9 @@ export const createServerValidate =
         onServer: onServerError,
       },
       values,
-      errors: onServerErrorVal ? [onServerErrorVal] : [],
+      errors: (onServerErrorVal ? [onServerErrorVal] : []) as Array<
+        Exclude<UnwrapFormAsyncValidateOrFn<TOnServer>, undefined>
+      >,
     }
 
     throw new ServerValidateError({

--- a/packages/react-form/tests/useField.test.tsx
+++ b/packages/react-form/tests/useField.test.tsx
@@ -847,7 +847,7 @@ describe('useField', () => {
                     />
                   </label>
                   {field.state.meta.errors.map((err) => {
-                    return <div key={err?.toString()}>{err}</div>
+                    return <div key={err.toString()}>{err}</div>
                   })}
                 </div>
               )


### PR DESCRIPTION
## 🎯 Changes

The runtime implementation filters out undefined values from errorMap, but the type definition included undefined in the union types. This caused type errors when accessing error properties without undefined checks.

Wrap the errors type union with Exclude<..., undefined> in both FormApi and FieldApi to align the type system with the actual runtime behavior.

Closes #2022

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
