### PR TITLE
fix: type for use with decode-formdata

### DIFF
--- a/.changeset/lucky-beds-rush.md
+++ b/.changeset/lucky-beds-rush.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/react-form-nextjs': patch
+'@tanstack/react-form-remix': patch
+'@tanstack/react-form-start': patch
+---
+
+Fixes bad inference from `decode-formdata`'s weird typing of the `decode` function, including handling how it incorrectly doesn't handle undefined values for the form info object.

--- a/packages/react-form-nextjs/src/createServerValidate.ts
+++ b/packages/react-form-nextjs/src/createServerValidate.ts
@@ -14,6 +14,7 @@ import type {
   ServerFormState,
   UnwrapFormAsyncValidateOrFn,
 } from '@tanstack/react-form'
+import type { FormDataInfo } from 'decode-formdata'
 
 interface CreateServerValidateOptions<
   TFormData,
@@ -75,7 +76,7 @@ export const createServerValidate =
       TSubmitMeta
     >,
   ) =>
-  async (formData: FormData, info?: Parameters<typeof decode>[1]) => {
+  async (formData: FormData, info?: FormDataInfo) => {
     const { onServerValidate } = defaultOpts
 
     const runValidator = async ({
@@ -98,7 +99,9 @@ export const createServerValidate =
       })
     }
 
-    const values = decode(formData, info) as never as TFormData
+    const values = (info
+      ? decode(formData, info)
+      : decode(formData)) as never as TFormData
 
     const onServerError = (await runValidator({
       value: values,

--- a/packages/react-form-remix/src/createServerValidate.ts
+++ b/packages/react-form-remix/src/createServerValidate.ts
@@ -14,6 +14,7 @@ import type {
   ServerFormState,
   UnwrapFormAsyncValidateOrFn,
 } from '@tanstack/react-form'
+import type { FormDataInfo } from 'decode-formdata'
 
 interface CreateServerValidateOptions<
   TFormData,
@@ -75,7 +76,7 @@ export const createServerValidate =
       TSubmitMeta
     >,
   ) =>
-  async (formData: FormData, info?: Parameters<typeof decode>[1]) => {
+  async (formData: FormData, info?: FormDataInfo) => {
     const { onServerValidate } = defaultOpts
 
     const runValidator = async ({
@@ -98,7 +99,9 @@ export const createServerValidate =
       })
     }
 
-    const values = decode(formData, info) as never as TFormData
+    const values = (info
+      ? decode(formData, info)
+      : decode(formData)) as never as TFormData
 
     const onServerError = (await runValidator({
       value: values,

--- a/packages/react-form-start/src/createServerValidate.tsx
+++ b/packages/react-form-start/src/createServerValidate.tsx
@@ -17,6 +17,7 @@ import type {
   ServerFormState,
   UnwrapFormAsyncValidateOrFn,
 } from '@tanstack/react-form'
+import type { FormDataInfo } from 'decode-formdata'
 
 interface CreateServerValidateOptions<
   TFormData,
@@ -57,7 +58,7 @@ const serverFn = createServerFn({ method: 'POST' })
   .handler(async ({ data }) => {
     const { formData, info, defaultOpts } = data as {
       formData: FormData
-      info?: Parameters<typeof decode>[1]
+      info?: FormDataInfo
       defaultOpts: CreateServerValidateOptions<
         any,
         any,
@@ -97,7 +98,9 @@ const serverFn = createServerFn({ method: 'POST' })
 
     const referer = getRequestHeader('referer')!
 
-    const decodedData = decode(formData, info) as never as any
+    const decodedData = (info
+      ? decode(formData, info)
+      : decode(formData)) as never as any
 
     const onServerError = (await runValidator({
       value: decodedData,


### PR DESCRIPTION
## 🎯 Changes

The use of `Parameters<typeof decode>` here doesn't work right because `decode` has multiple definitions. This replaces that with a direct reference to the intended `FormDataInfo` type, with the ternaries as a workaround for `decode-formdata` having slightly wonky typing for `decode`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
