### PR TITLE
fix(core): field unmount

### DIFF
--- a/.changeset/red-hats-jam.md
+++ b/.changeset/red-hats-jam.md
@@ -1,6 +1,6 @@
 ---
-"@tanstack/form-core": patch
-"@tanstack/react-form": patch
+'@tanstack/form-core': patch
+'@tanstack/react-form': patch
 ---
 
 fix(core): field unmount

--- a/.changeset/red-hats-jam.md
+++ b/.changeset/red-hats-jam.md
@@ -1,0 +1,6 @@
+---
+"@tanstack/form-core": patch
+"@tanstack/react-form": patch
+---
+
+fix(core): field unmount

--- a/docs/framework/angular/guides/listeners.md
+++ b/docs/framework/angular/guides/listeners.md
@@ -15,10 +15,11 @@ In this example, when the user changes the country, the selected province needs 
 
 Events that can be "listened" to are:
 
-- onChange
-- onBlur
-- onMount
-- onSubmit
+- `onChange`
+- `onBlur`
+- `onMount`
+- `onSubmit`
+- `onUnmount`
 
 ```angular-ts
 @Component({

--- a/docs/framework/react/guides/listeners.md
+++ b/docs/framework/react/guides/listeners.md
@@ -19,6 +19,7 @@ Events that can be "listened" to are:
 - `onBlur`
 - `onMount`
 - `onSubmit`
+- `onUnmount`
 
 ```tsx
 function App() {

--- a/docs/framework/vue/guides/listeners.md
+++ b/docs/framework/vue/guides/listeners.md
@@ -15,10 +15,11 @@ In this example, when the user changes the country, the selected province needs 
 
 Events that can be "listened" to are:
 
-- onChange
-- onBlur
-- onMount
-- onSubmit
+- `onChange`
+- `onBlur`
+- `onMount`
+- `onSubmit`
+- `onUnmount`
 
 ```vue
 <script setup>

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -1361,6 +1361,10 @@ export class FieldApi<
       const fieldInfo = this.form.fieldInfo[this.name]
       if (!fieldInfo) return
 
+      // If a newer field instance has already been mounted for this name,
+      // avoid touching its shared validation state during teardown.
+      if (fieldInfo.instance !== this) return
+
       for (const [key, validationMeta] of Object.entries(
         fieldInfo.validationMetaMap,
       )) {
@@ -1370,15 +1374,24 @@ export class FieldApi<
         ] = undefined
       }
 
-      // If a newer field instance has already been mounted for this name,
-      // avoid clearing its state during teardown of an older instance.
-      if (fieldInfo.instance !== this) return
-
       this.form.baseStore.setState((prev) => ({
+        // Preserve interaction flags so field-level defaultValue does not
+        // reseed user-entered values on remount.
         ...prev,
         fieldMetaBase: {
           ...prev.fieldMetaBase,
-          [this.name]: defaultFieldMeta,
+          [this.name]: {
+            ...defaultFieldMeta,
+            isTouched:
+              prev.fieldMetaBase[this.name]?.isTouched ??
+              defaultFieldMeta.isTouched,
+            isBlurred:
+              prev.fieldMetaBase[this.name]?.isBlurred ??
+              defaultFieldMeta.isBlurred,
+            isDirty:
+              prev.fieldMetaBase[this.name]?.isDirty ??
+              defaultFieldMeta.isDirty,
+          },
         },
       }))
 

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -1323,10 +1323,6 @@ export class FieldApi<
       fieldApi: this,
     })
 
-    if (!this.form.options.cleanupFieldsOnUnmount) {
-      return () => {}
-    }
-
     return () => {
       // Stop any in-flight async validation or listener work tied to this instance.
       for (const [key, timeout] of Object.entries(

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -1355,6 +1355,7 @@ export class FieldApi<
       }
 
       const fieldInfo = this.form.fieldInfo[this.name]
+      if (!fieldInfo) return
 
       for (const [key, validationMeta] of Object.entries(
         fieldInfo.validationMetaMap,

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -1324,41 +1324,44 @@ export class FieldApi<
 
     return () => {
       // Stop any in-flight async validation or listener work tied to this instance.
-      for (const key of Object.keys(
+      for (const [key, timeout] of Object.entries(
         this.timeoutIds.validations,
-      ) as ValidationCause[]) {
-        const timeout = this.timeoutIds.validations[key]
+      )) {
         if (timeout) {
           clearTimeout(timeout)
-          this.timeoutIds.validations[key] = null
+          this.timeoutIds.validations[
+            key as keyof typeof this.timeoutIds.validations
+          ] = null
         }
       }
-      for (const key of Object.keys(
-        this.timeoutIds.listeners,
-      ) as ListenerCause[]) {
-        const timeout = this.timeoutIds.listeners[key]
+      for (const [key, timeout] of Object.entries(this.timeoutIds.listeners)) {
         if (timeout) {
           clearTimeout(timeout)
-          this.timeoutIds.listeners[key] = null
+          this.timeoutIds.listeners[
+            key as keyof typeof this.timeoutIds.listeners
+          ] = null
         }
       }
-      for (const key of Object.keys(
+      for (const [key, timeout] of Object.entries(
         this.timeoutIds.formListeners,
-      ) as ListenerCause[]) {
-        const timeout = this.timeoutIds.formListeners[key]
+      )) {
         if (timeout) {
           clearTimeout(timeout)
-          this.timeoutIds.formListeners[key] = null
+          this.timeoutIds.formListeners[
+            key as keyof typeof this.timeoutIds.formListeners
+          ] = null
         }
       }
 
       const fieldInfo = this.form.fieldInfo[this.name]
 
-      for (const key of Object.keys(fieldInfo.validationMetaMap) as Array<
-        keyof typeof fieldInfo.validationMetaMap
-      >) {
-        fieldInfo.validationMetaMap[key]?.lastAbortController.abort()
-        fieldInfo.validationMetaMap[key] = undefined
+      for (const [key, validationMeta] of Object.entries(
+        fieldInfo.validationMetaMap,
+      )) {
+        validationMeta?.lastAbortController.abort()
+        fieldInfo.validationMetaMap[
+          key as keyof typeof fieldInfo.validationMetaMap
+        ] = undefined
       }
 
       // If a newer field instance has already been mounted for this name,

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -382,6 +382,7 @@ export interface FieldListeners<
   onBlur?: FieldListenerFn<TParentData, TName, TData>
   onBlurDebounceMs?: number
   onMount?: FieldListenerFn<TParentData, TName, TData>
+  onUnmount?: FieldListenerFn<TParentData, TName, TData>
   onSubmit?: FieldListenerFn<TParentData, TName, TData>
 }
 
@@ -1392,6 +1393,16 @@ export class FieldApi<
       }))
 
       fieldInfo.instance = null
+
+      this.options.listeners?.onUnmount?.({
+        value: this.state.value,
+        fieldApi: this,
+      })
+
+      this.form.options.listeners?.onFieldUnmount?.({
+        formApi: this.form,
+        fieldApi: this,
+      })
     }
   }
 

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -1323,6 +1323,10 @@ export class FieldApi<
       fieldApi: this,
     })
 
+    if (!this.form.options.cleanupFieldsOnUnmount) {
+      return () => {}
+    }
+
     return () => {
       // Stop any in-flight async validation or listener work tied to this instance.
       for (const [key, timeout] of Object.entries(

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -1863,12 +1863,13 @@ export class FieldApi<
       promises: Promise<ValidationError | undefined>[],
     ) => {
       const errorMapKey = getErrorMapKey(validateObj.cause)
-      const fieldValidatorMeta = field.getInfo().validationMetaMap[errorMapKey]
+      const fieldInfo = field.getInfo()
+      const fieldValidatorMeta = fieldInfo.validationMetaMap[errorMapKey]
 
       fieldValidatorMeta?.lastAbortController.abort()
       const controller = new AbortController()
 
-      this.getInfo().validationMetaMap[errorMapKey] = {
+      fieldInfo.validationMetaMap[errorMapKey] = {
         lastAbortController: controller,
       }
 
@@ -1877,11 +1878,11 @@ export class FieldApi<
           let rawError!: ValidationError | undefined
           try {
             rawError = await new Promise((rawResolve, rawReject) => {
-              if (this.timeoutIds.validations[validateObj.cause]) {
-                clearTimeout(this.timeoutIds.validations[validateObj.cause]!)
+              if (field.timeoutIds.validations[validateObj.cause]) {
+                clearTimeout(field.timeoutIds.validations[validateObj.cause]!)
               }
 
-              this.timeoutIds.validations[validateObj.cause] = setTimeout(
+              field.timeoutIds.validations[validateObj.cause] = setTimeout(
                 async () => {
                   if (controller.signal.aborted) return rawResolve(undefined)
                   try {
@@ -1911,13 +1912,19 @@ export class FieldApi<
 
           const fieldLevelError = normalizeError(rawError)
           const formLevelError =
-            asyncFormValidationResults[this.name]?.[errorMapKey]
+            asyncFormValidationResults[
+              field.name as keyof typeof asyncFormValidationResults
+            ]?.[errorMapKey]
 
           const { newErrorValue, newSource } =
             determineFieldLevelErrorSourceAndValue({
               formLevelError,
               fieldLevelError,
             })
+
+          if (field.getInfo().instance !== field) {
+            return resolve(undefined)
+          }
 
           field.setMeta((prev) => {
             return {

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -1275,6 +1275,7 @@ export class FieldApi<
 
   /**
    * Mounts the field instance to the form.
+   * @returns A function to unmount the field instance.
    */
   mount = () => {
     if (this.options.defaultValue !== undefined && !this.getMeta().isTouched) {

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -1322,8 +1322,59 @@ export class FieldApi<
       fieldApi: this,
     })
 
-    // TODO: Remove
-    return () => {}
+    return () => {
+      // Stop any in-flight async validation or listener work tied to this instance.
+      for (const key of Object.keys(
+        this.timeoutIds.validations,
+      ) as ValidationCause[]) {
+        const timeout = this.timeoutIds.validations[key]
+        if (timeout) {
+          clearTimeout(timeout)
+          this.timeoutIds.validations[key] = null
+        }
+      }
+      for (const key of Object.keys(
+        this.timeoutIds.listeners,
+      ) as ListenerCause[]) {
+        const timeout = this.timeoutIds.listeners[key]
+        if (timeout) {
+          clearTimeout(timeout)
+          this.timeoutIds.listeners[key] = null
+        }
+      }
+      for (const key of Object.keys(
+        this.timeoutIds.formListeners,
+      ) as ListenerCause[]) {
+        const timeout = this.timeoutIds.formListeners[key]
+        if (timeout) {
+          clearTimeout(timeout)
+          this.timeoutIds.formListeners[key] = null
+        }
+      }
+
+      const fieldInfo = this.form.fieldInfo[this.name]
+
+      for (const key of Object.keys(fieldInfo.validationMetaMap) as Array<
+        keyof typeof fieldInfo.validationMetaMap
+      >) {
+        fieldInfo.validationMetaMap[key]?.lastAbortController.abort()
+        fieldInfo.validationMetaMap[key] = undefined
+      }
+
+      // If a newer field instance has already been mounted for this name,
+      // avoid clearing its state during teardown of an older instance.
+      if (fieldInfo.instance !== this) return
+
+      this.form.baseStore.setState((prev) => ({
+        ...prev,
+        fieldMetaBase: {
+          ...prev.fieldMetaBase,
+          [this.name]: defaultFieldMeta,
+        },
+      }))
+
+      fieldInfo.instance = null
+    }
   }
 
   /**

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -306,6 +306,24 @@ export interface FormListeners<
     >
     meta: TSubmitMeta
   }) => void
+
+  onFieldUnmount?: (props: {
+    formApi: FormApi<
+      TFormData,
+      TOnMount,
+      TOnChange,
+      TOnChangeAsync,
+      TOnBlur,
+      TOnBlurAsync,
+      TOnSubmit,
+      TOnSubmitAsync,
+      TOnDynamic,
+      TOnDynamicAsync,
+      TOnServer,
+      TSubmitMeta
+    >
+    fieldApi: AnyFieldApi
+  }) => void
 }
 
 /**

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -374,6 +374,11 @@ export interface FormOptions<
    */
   canSubmitWhenInvalid?: boolean
   /**
+   * If true, mounted fields clean up their validation state when they unmount.
+   * Defaults to false.
+   */
+  cleanupFieldsOnUnmount?: boolean
+  /**
    * A list of validators to pass to the form
    */
   validators?: FormValidators<

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -925,7 +925,7 @@ export class FormApi<
   /**
    * A record of field information for each field in the form.
    */
-  fieldInfo: Record<DeepKeys<TFormData>, FieldInfo<TFormData>> = {} as any
+  fieldInfo: Partial<Record<DeepKeys<TFormData>, FieldInfo<TFormData>>> = {}
 
   get state() {
     return this.store.state
@@ -1603,7 +1603,6 @@ export class FormApi<
     field: TField,
     cause: ValidationCause,
   ) => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const fieldInstance = this.fieldInfo[field]?.instance
 
     if (!fieldInstance) {
@@ -2222,7 +2221,6 @@ export class FormApi<
   getFieldInfo = <TField extends DeepKeys<TFormData>>(
     field: TField,
   ): FieldInfo<TFormData> => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     return (this.fieldInfo[field] ||= {
       instance: null,
       validationMetaMap: {

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -374,11 +374,6 @@ export interface FormOptions<
    */
   canSubmitWhenInvalid?: boolean
   /**
-   * If true, mounted fields clean up their validation state when they unmount.
-   * Defaults to false.
-   */
-  cleanupFieldsOnUnmount?: boolean
-  /**
    * A list of validators to pass to the form
    */
   validators?: FormValidators<

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -2229,6 +2229,61 @@ describe('field api', () => {
     ])
   })
 
+  it('should cancel linked field async validation when the target field unmounts', async () => {
+    vi.useFakeTimers()
+
+    let resolve!: () => void
+    const promise = new Promise((r) => {
+      resolve = r as never
+    })
+
+    const form = new FormApi({
+      defaultValues: {
+        password: '',
+        confirm_password: '',
+      },
+      cleanupFieldsOnUnmount: true,
+    })
+
+    form.mount()
+
+    const passField = new FieldApi({
+      form,
+      name: 'password',
+    })
+
+    const passconfirmField = new FieldApi({
+      form,
+      name: 'confirm_password',
+      validators: {
+        onChangeListenTo: ['password'],
+        onChangeAsyncDebounceMs: 0,
+        onChangeAsync: async () => {
+          await promise
+          return 'Passwords do not match'
+        },
+      },
+    })
+
+    passField.mount()
+    const unmount = passconfirmField.mount()
+
+    passField.setValue('one')
+    await vi.runAllTimersAsync()
+
+    expect(unmount).toBeTypeOf('function')
+    unmount()
+    resolve()
+    await vi.runAllTimersAsync()
+
+    expect(form.state.fieldMeta.confirm_password).toMatchObject({
+      errors: [],
+      isValid: true,
+    })
+
+    vi.useRealTimers()
+  })
+
   it('should add  a new value to the fieldApi errorMap', () => {
     interface Form {
       name: string

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -1603,12 +1603,42 @@ describe('field api', () => {
     expect(form.getFieldInfo(field.name)).toBeDefined()
   })
 
+  it('should keep field meta on unmount by default', async () => {
+    const form = new FormApi({
+      defaultValues: {
+        name: '',
+      },
+    })
+
+    form.mount()
+
+    const field = new FieldApi({
+      form,
+      name: 'name',
+      validators: {
+        onSubmit: ({ value }) =>
+          value.length > 0 ? undefined : 'name is required',
+      },
+    })
+
+    const unmount = field.mount()
+
+    await form.handleSubmit()
+    expect(form.state.fieldMeta.name?.errors).toContain('name is required')
+
+    expect(unmount).toBeTypeOf('function')
+    unmount()
+    expect(form.state.fieldMeta.name?.errors).toContain('name is required')
+    expect(form.state.canSubmit).toBe(false)
+  })
+
   it('should clear meta on unmount while preserving value', async () => {
     const form = new FormApi({
       defaultValues: {
         firstName: 'a',
         lastName: 'abc',
       },
+      cleanupFieldsOnUnmount: true,
       onSubmit: () => {},
     })
 
@@ -1636,7 +1666,8 @@ describe('field api', () => {
       'last name must be at least 5 chars',
     )
 
-    unmountLastName()
+    expect(unmountLastName).toBeTypeOf('function')
+    unmountLastName?.()
 
     expect(form.getFieldValue('lastName')).toBe('abc')
     expect(form.state.fieldMeta.lastName).toMatchObject({
@@ -1673,6 +1704,7 @@ describe('field api', () => {
       defaultValues: {
         name: '',
       },
+      cleanupFieldsOnUnmount: true,
     })
 
     form.mount()
@@ -1694,7 +1726,8 @@ describe('field api', () => {
     field.setValue('trigger')
     await vi.runAllTimersAsync()
 
-    unmount()
+    expect(unmount).toBeTypeOf('function')
+    unmount?.()
     resolveValidation()
     await vi.runAllTimersAsync()
 
@@ -1717,6 +1750,7 @@ describe('field api', () => {
       defaultValues: {
         name: '',
       },
+      cleanupFieldsOnUnmount: true,
       listeners: {
         onChange: formListener,
         onChangeDebounceMs: 200,
@@ -1736,7 +1770,8 @@ describe('field api', () => {
 
     const unmount = field.mount()
     field.setValue('trigger')
-    unmount()
+    expect(unmount).toBeTypeOf('function')
+    unmount?.()
 
     await vi.advanceTimersByTimeAsync(500)
 
@@ -1751,6 +1786,7 @@ describe('field api', () => {
       defaultValues: {
         name: '',
       },
+      cleanupFieldsOnUnmount: true,
     })
 
     form.mount()
@@ -1768,7 +1804,8 @@ describe('field api', () => {
     newField.mount()
     newField.setValue('new value')
 
-    oldUnmount()
+    expect(oldUnmount).toBeTypeOf('function')
+    oldUnmount?.()
 
     expect(form.getFieldInfo('name').instance).toBe(newField)
     expect(newField.getValue()).toBe('new value')

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -1810,6 +1810,28 @@ describe('field api', () => {
     vi.useRealTimers()
   })
 
+  it('should ignore cleanup when fieldInfo was deleted before unmount', () => {
+    const form = new FormApi({
+      defaultValues: {
+        name: '',
+      },
+      cleanupFieldsOnUnmount: true,
+    })
+
+    form.mount()
+
+    const field = new FieldApi({
+      form,
+      name: 'name',
+    })
+
+    const unmount = field.mount()
+    form.deleteField('name')
+
+    expect(unmount).toBeTypeOf('function')
+    expect(() => unmount()).not.toThrow()
+  })
+
   it('should not clear newer instance state when older instance unmounts', () => {
     const form = new FormApi({
       defaultValues: {
@@ -1878,6 +1900,84 @@ describe('field api', () => {
     await vi.runAllTimersAsync()
 
     expect(newField.getMeta().errors).toContain('name is taken')
+
+    vi.useRealTimers()
+  })
+
+  it('should ignore stale async validation results from an older remounted instance', async () => {
+    vi.useFakeTimers()
+
+    let resolve!: () => void
+    const promise = new Promise((r) => {
+      resolve = r as never
+    })
+
+    const form = new FormApi({
+      defaultValues: {
+        name: '',
+      },
+      cleanupFieldsOnUnmount: true,
+    })
+
+    form.mount()
+
+    const oldField = new FieldApi({
+      form,
+      name: 'name',
+      validators: {
+        onChangeAsyncDebounceMs: 0,
+        onChangeAsync: async () => {
+          await promise
+          return 'stale error'
+        },
+      },
+    })
+
+    oldField.mount()
+    oldField.setValue('taken')
+    await vi.runAllTimersAsync()
+
+    const newField = new FieldApi({
+      form,
+      name: 'name',
+    })
+    newField.mount()
+
+    resolve()
+    await vi.runAllTimersAsync()
+
+    expect(newField.getMeta().errors).toStrictEqual([])
+
+    vi.useRealTimers()
+  })
+
+  it('should surface thrown async validator errors', async () => {
+    vi.useFakeTimers()
+
+    const form = new FormApi({
+      defaultValues: {
+        name: '',
+      },
+    })
+
+    form.mount()
+
+    const field = new FieldApi({
+      form,
+      name: 'name',
+      validators: {
+        onChangeAsyncDebounceMs: 0,
+        onChangeAsync: async () => {
+          throw 'async validation failed'
+        },
+      },
+    })
+
+    field.mount()
+    field.setValue('test')
+    await vi.runAllTimersAsync()
+
+    expect(field.getMeta().errors).toContain('async validation failed')
 
     vi.useRealTimers()
   })

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -1661,6 +1661,120 @@ describe('field api', () => {
     expect(remountedLastName.getValue()).toBe('abc')
   })
 
+  it('should not apply in-flight async validation results after unmount', async () => {
+    vi.useFakeTimers()
+
+    let resolveValidation!: () => void
+    const validationPromise = new Promise<void>((resolve) => {
+      resolveValidation = resolve
+    })
+
+    const form = new FormApi({
+      defaultValues: {
+        name: '',
+      },
+    })
+
+    form.mount()
+
+    const field = new FieldApi({
+      form,
+      name: 'name',
+      validators: {
+        onChangeAsyncDebounceMs: 0,
+        onChangeAsync: async () => {
+          await validationPromise
+          return 'async error should be ignored after unmount'
+        },
+      },
+    })
+
+    const unmount = field.mount()
+
+    field.setValue('trigger')
+    await vi.runAllTimersAsync()
+
+    unmount()
+    resolveValidation()
+    await vi.runAllTimersAsync()
+
+    expect(form.state.fieldMeta.name).toMatchObject({
+      isTouched: false,
+      isValid: true,
+      errors: [],
+    })
+
+    vi.useRealTimers()
+  })
+
+  it('should cancel debounced field and form listeners on unmount', async () => {
+    vi.useFakeTimers()
+
+    const fieldListener = vi.fn()
+    const formListener = vi.fn()
+
+    const form = new FormApi({
+      defaultValues: {
+        name: '',
+      },
+      listeners: {
+        onChange: formListener,
+        onChangeDebounceMs: 200,
+      },
+    })
+
+    form.mount()
+
+    const field = new FieldApi({
+      form,
+      name: 'name',
+      listeners: {
+        onChange: fieldListener,
+        onChangeDebounceMs: 200,
+      },
+    })
+
+    const unmount = field.mount()
+    field.setValue('trigger')
+    unmount()
+
+    await vi.advanceTimersByTimeAsync(500)
+
+    expect(fieldListener).toHaveBeenCalledTimes(0)
+    expect(formListener).toHaveBeenCalledTimes(0)
+
+    vi.useRealTimers()
+  })
+
+  it('should not clear newer instance state when older instance unmounts', () => {
+    const form = new FormApi({
+      defaultValues: {
+        name: '',
+      },
+    })
+
+    form.mount()
+
+    const oldField = new FieldApi({
+      form,
+      name: 'name',
+    })
+    const oldUnmount = oldField.mount()
+
+    const newField = new FieldApi({
+      form,
+      name: 'name',
+    })
+    newField.mount()
+    newField.setValue('new value')
+
+    oldUnmount()
+
+    expect(form.getFieldInfo('name').instance).toBe(newField)
+    expect(newField.getValue()).toBe('new value')
+    expect(newField.getMeta().isTouched).toBe(true)
+  })
+
   it('should show onSubmit errors', async () => {
     const form = new FormApi({
       defaultValues: {

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -1671,7 +1671,7 @@ describe('field api', () => {
 
     expect(form.getFieldValue('lastName')).toBe('abc')
     expect(form.state.fieldMeta.lastName).toMatchObject({
-      isTouched: false,
+      isTouched: true,
       isValid: true,
       errors: [],
     })
@@ -1688,8 +1688,37 @@ describe('field api', () => {
 
     remountedLastName.mount()
     expect(remountedLastName.getMeta().errors).toStrictEqual([])
-    expect(remountedLastName.getMeta().isTouched).toBe(false)
+    expect(remountedLastName.getMeta().isTouched).toBe(true)
     expect(remountedLastName.getValue()).toBe('abc')
+  })
+
+  it('should preserve field-level defaultValue changes across unmount remount cleanup', () => {
+    const form = new FormApi({
+      defaultValues: {} as { name?: string },
+      cleanupFieldsOnUnmount: true,
+    })
+
+    form.mount()
+
+    const field = new FieldApi({
+      form,
+      name: 'name',
+      defaultValue: 'initial',
+    })
+
+    const unmount = field.mount()
+    field.setValue('changed')
+    expect(unmount).toBeTypeOf('function')
+    unmount()
+
+    const remountedField = new FieldApi({
+      form,
+      name: 'name',
+      defaultValue: 'initial',
+    })
+
+    remountedField.mount()
+    expect(remountedField.getValue()).toBe('changed')
   })
 
   it('should not apply in-flight async validation results after unmount', async () => {
@@ -1732,7 +1761,7 @@ describe('field api', () => {
     await vi.runAllTimersAsync()
 
     expect(form.state.fieldMeta.name).toMatchObject({
-      isTouched: false,
+      isTouched: true,
       isValid: true,
       errors: [],
     })
@@ -1810,6 +1839,47 @@ describe('field api', () => {
     expect(form.getFieldInfo('name').instance).toBe(newField)
     expect(newField.getValue()).toBe('new value')
     expect(newField.getMeta().isTouched).toBe(true)
+  })
+
+  it('should not cancel newer instance async validation when older instance unmounts', async () => {
+    vi.useFakeTimers()
+
+    const form = new FormApi({
+      defaultValues: {
+        name: '',
+      },
+      cleanupFieldsOnUnmount: true,
+    })
+
+    form.mount()
+
+    const oldField = new FieldApi({
+      form,
+      name: 'name',
+    })
+    const oldUnmount = oldField.mount()
+
+    const newField = new FieldApi({
+      form,
+      name: 'name',
+      validators: {
+        onChangeAsyncDebounceMs: 10,
+        onChangeAsync: async ({ value }) =>
+          value === 'taken' ? 'name is taken' : undefined,
+      },
+    })
+
+    newField.mount()
+    newField.setValue('taken')
+
+    expect(oldUnmount).toBeTypeOf('function')
+    oldUnmount()
+
+    await vi.runAllTimersAsync()
+
+    expect(newField.getMeta().errors).toContain('name is taken')
+
+    vi.useRealTimers()
   })
 
   it('should show onSubmit errors', async () => {

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -1667,7 +1667,7 @@ describe('field api', () => {
     )
 
     expect(unmountLastName).toBeTypeOf('function')
-    unmountLastName?.()
+    unmountLastName()
 
     expect(form.getFieldValue('lastName')).toBe('abc')
     expect(form.state.fieldMeta.lastName).toMatchObject({
@@ -1727,7 +1727,7 @@ describe('field api', () => {
     await vi.runAllTimersAsync()
 
     expect(unmount).toBeTypeOf('function')
-    unmount?.()
+    unmount()
     resolveValidation()
     await vi.runAllTimersAsync()
 
@@ -1771,7 +1771,7 @@ describe('field api', () => {
     const unmount = field.mount()
     field.setValue('trigger')
     expect(unmount).toBeTypeOf('function')
-    unmount?.()
+    unmount()
 
     await vi.advanceTimersByTimeAsync(500)
 
@@ -1805,7 +1805,7 @@ describe('field api', () => {
     newField.setValue('new value')
 
     expect(oldUnmount).toBeTypeOf('function')
-    oldUnmount?.()
+    oldUnmount()
 
     expect(form.getFieldInfo('name').instance).toBe(newField)
     expect(newField.getValue()).toBe('new value')

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -1489,6 +1489,83 @@ describe('field api', () => {
     expect(triggered).toStrictEqual('test')
   })
 
+  it('should run listener onUnmount', () => {
+    const form = new FormApi({
+      defaultValues: {
+        name: 'test',
+      },
+    })
+
+    let triggered: string | undefined
+    const field = new FieldApi({
+      form,
+      name: 'name',
+      listeners: {
+        onUnmount: ({ value }) => {
+          triggered = value
+        },
+      },
+    })
+
+    const unmount = field.mount()
+    expect(triggered).toBeUndefined()
+
+    unmount()
+    expect(triggered).toStrictEqual('test')
+  })
+
+  it('should run form listener onFieldUnmount', () => {
+    let capturedName: string | undefined
+
+    const form = new FormApi({
+      defaultValues: {
+        name: 'test',
+      },
+      listeners: {
+        onFieldUnmount: ({ fieldApi }) => {
+          capturedName = fieldApi.name as string
+        },
+      },
+    })
+
+    form.mount()
+
+    const field = new FieldApi({
+      form,
+      name: 'name',
+    })
+
+    const unmount = field.mount()
+    expect(capturedName).toBeUndefined()
+
+    unmount()
+    expect(capturedName).toStrictEqual('name')
+  })
+
+  it('should not run onUnmount listener if fieldInfo was already deleted', () => {
+    const onUnmount = vi.fn()
+
+    const form = new FormApi({
+      defaultValues: {
+        name: '',
+      },
+    })
+
+    form.mount()
+
+    const field = new FieldApi({
+      form,
+      name: 'name',
+      listeners: { onUnmount },
+    })
+
+    const unmount = field.mount()
+    form.deleteField('name')
+
+    expect(() => unmount()).not.toThrow()
+    expect(onUnmount).not.toHaveBeenCalled()
+  })
+
   it('should contain multiple errors when running validation onBlur and onChange', () => {
     const form = new FormApi({
       defaultValues: {

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -1603,42 +1603,12 @@ describe('field api', () => {
     expect(form.getFieldInfo(field.name)).toBeDefined()
   })
 
-  it('should keep field meta on unmount by default', async () => {
-    const form = new FormApi({
-      defaultValues: {
-        name: '',
-      },
-    })
-
-    form.mount()
-
-    const field = new FieldApi({
-      form,
-      name: 'name',
-      validators: {
-        onSubmit: ({ value }) =>
-          value.length > 0 ? undefined : 'name is required',
-      },
-    })
-
-    const unmount = field.mount()
-
-    await form.handleSubmit()
-    expect(form.state.fieldMeta.name?.errors).toContain('name is required')
-
-    expect(unmount).toBeTypeOf('function')
-    unmount()
-    expect(form.state.fieldMeta.name?.errors).toContain('name is required')
-    expect(form.state.canSubmit).toBe(false)
-  })
-
   it('should clear meta on unmount while preserving value', async () => {
     const form = new FormApi({
       defaultValues: {
         firstName: 'a',
         lastName: 'abc',
       },
-      cleanupFieldsOnUnmount: true,
       onSubmit: () => {},
     })
 
@@ -1695,7 +1665,6 @@ describe('field api', () => {
   it('should preserve field-level defaultValue changes across unmount remount cleanup', () => {
     const form = new FormApi({
       defaultValues: {} as { name?: string },
-      cleanupFieldsOnUnmount: true,
     })
 
     form.mount()
@@ -1733,7 +1702,6 @@ describe('field api', () => {
       defaultValues: {
         name: '',
       },
-      cleanupFieldsOnUnmount: true,
     })
 
     form.mount()
@@ -1779,7 +1747,6 @@ describe('field api', () => {
       defaultValues: {
         name: '',
       },
-      cleanupFieldsOnUnmount: true,
       listeners: {
         onChange: formListener,
         onChangeDebounceMs: 200,
@@ -1815,7 +1782,6 @@ describe('field api', () => {
       defaultValues: {
         name: '',
       },
-      cleanupFieldsOnUnmount: true,
     })
 
     form.mount()
@@ -1837,7 +1803,6 @@ describe('field api', () => {
       defaultValues: {
         name: '',
       },
-      cleanupFieldsOnUnmount: true,
     })
 
     form.mount()
@@ -1870,7 +1835,6 @@ describe('field api', () => {
       defaultValues: {
         name: '',
       },
-      cleanupFieldsOnUnmount: true,
     })
 
     form.mount()
@@ -1916,7 +1880,6 @@ describe('field api', () => {
       defaultValues: {
         name: '',
       },
-      cleanupFieldsOnUnmount: true,
     })
 
     form.mount()
@@ -2342,7 +2305,6 @@ describe('field api', () => {
         password: '',
         confirm_password: '',
       },
-      cleanupFieldsOnUnmount: true,
     })
 
     form.mount()

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -1603,6 +1603,64 @@ describe('field api', () => {
     expect(form.getFieldInfo(field.name)).toBeDefined()
   })
 
+  it('should clear meta on unmount while preserving value', async () => {
+    const form = new FormApi({
+      defaultValues: {
+        firstName: 'a',
+        lastName: 'abc',
+      },
+      onSubmit: () => {},
+    })
+
+    form.mount()
+
+    const firstName = new FieldApi({
+      form,
+      name: 'firstName',
+    })
+    const lastName = new FieldApi({
+      form,
+      name: 'lastName',
+      validators: {
+        onSubmit: ({ value }) =>
+          value.length >= 5 ? undefined : 'last name must be at least 5 chars',
+      },
+    })
+
+    firstName.mount()
+    const unmountLastName = lastName.mount()
+
+    await form.handleSubmit()
+    expect(form.state.canSubmit).toBe(false)
+    expect(lastName.getMeta().errors).toContain(
+      'last name must be at least 5 chars',
+    )
+
+    unmountLastName()
+
+    expect(form.getFieldValue('lastName')).toBe('abc')
+    expect(form.state.fieldMeta.lastName).toMatchObject({
+      isTouched: false,
+      isValid: true,
+      errors: [],
+    })
+    expect(form.state.canSubmit).toBe(true)
+
+    const remountedLastName = new FieldApi({
+      form,
+      name: 'lastName',
+      validators: {
+        onSubmit: ({ value }) =>
+          value.length >= 5 ? undefined : 'last name must be at least 5 chars',
+      },
+    })
+
+    remountedLastName.mount()
+    expect(remountedLastName.getMeta().errors).toStrictEqual([])
+    expect(remountedLastName.getMeta().isTouched).toBe(false)
+    expect(remountedLastName.getValue()).toBe('abc')
+  })
+
   it('should show onSubmit errors', async () => {
     const form = new FormApi({
       defaultValues: {

--- a/packages/react-form/tests/useField.test.tsx
+++ b/packages/react-form/tests/useField.test.tsx
@@ -337,7 +337,6 @@ describe('useField', () => {
           firstName: '',
           lastName: '',
         },
-        cleanupFieldsOnUnmount: true,
         onSubmit: ({ value }) => onSubmit(value),
       })
 

--- a/packages/react-form/tests/useField.test.tsx
+++ b/packages/react-form/tests/useField.test.tsx
@@ -328,6 +328,107 @@ describe('useField', () => {
     expect((getByTestId('first-field') as HTMLInputElement).value).toBe('hello')
   })
 
+  it('should not keep hidden field submit errors after unmount', async () => {
+    const onSubmit = vi.fn()
+
+    function Comp() {
+      const form = useForm({
+        defaultValues: {
+          firstName: '',
+          lastName: '',
+        },
+        onSubmit: ({ value }) => onSubmit(value),
+      })
+
+      return (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            form.handleSubmit()
+          }}
+        >
+          <form.Field name="firstName">
+            {(field) => (
+              <input
+                data-testid="first-name"
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+            )}
+          </form.Field>
+
+          <form.Subscribe selector={(state) => state.values.firstName === 'a'}>
+            {(showLastName) =>
+              showLastName ? (
+                <form.Field
+                  name="lastName"
+                  validators={{
+                    onSubmit: ({ value }) =>
+                      value.length >= 5 ? undefined : 'lastName too short',
+                  }}
+                >
+                  {(field) => (
+                    <input
+                      data-testid="last-name"
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                    />
+                  )}
+                </form.Field>
+              ) : null
+            }
+          </form.Subscribe>
+
+          <form.Subscribe
+            selector={(state) => [state.canSubmit, state.isSubmitting]}
+          >
+            {([canSubmit, isSubmitting]) => (
+              <button data-testid="submit" type="submit" disabled={!canSubmit}>
+                {isSubmitting ? '...' : 'Submit'}
+              </button>
+            )}
+          </form.Subscribe>
+        </form>
+      )
+    }
+
+    const { getByTestId, queryByTestId } = render(
+      <StrictMode>
+        <Comp />
+      </StrictMode>,
+    )
+
+    const submitButton = getByTestId('submit')
+
+    await user.type(getByTestId('first-name'), 'a')
+    await user.type(getByTestId('last-name'), 'abc')
+    await user.click(submitButton)
+
+    await waitFor(() => expect(submitButton).toBeDisabled())
+    expect(onSubmit).toHaveBeenCalledTimes(0)
+
+    await user.clear(getByTestId('first-name'))
+    await user.type(getByTestId('first-name'), 'b')
+
+    await waitFor(() =>
+      expect(queryByTestId('last-name')).not.toBeInTheDocument(),
+    )
+    await waitFor(() => expect(submitButton).toBeEnabled())
+
+    await user.click(submitButton)
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+
+    await user.clear(getByTestId('first-name'))
+    await user.type(getByTestId('first-name'), 'a')
+
+    const remountedLastName = await waitFor(() => getByTestId('last-name'))
+    expect((remountedLastName as HTMLInputElement).value).toBe('abc')
+    expect(submitButton).toBeEnabled()
+  })
+
   it('should validate async on change', async () => {
     type Person = {
       firstName: string

--- a/packages/react-form/tests/useField.test.tsx
+++ b/packages/react-form/tests/useField.test.tsx
@@ -460,10 +460,7 @@ describe('useField', () => {
           <form.Subscribe selector={(s) => s.values.show}>
             {(show) =>
               show ? (
-                <form.Field
-                  name="name"
-                  listeners={{ onUnmount: fieldUnmount }}
-                >
+                <form.Field name="name" listeners={{ onUnmount: fieldUnmount }}>
                   {(field) => (
                     <input
                       data-testid="name"

--- a/packages/react-form/tests/useField.test.tsx
+++ b/packages/react-form/tests/useField.test.tsx
@@ -337,6 +337,7 @@ describe('useField', () => {
           firstName: '',
           lastName: '',
         },
+        cleanupFieldsOnUnmount: true,
         onSubmit: ({ value }) => onSubmit(value),
       })
 

--- a/packages/react-form/tests/useField.test.tsx
+++ b/packages/react-form/tests/useField.test.tsx
@@ -420,7 +420,7 @@ describe('useField', () => {
     await waitFor(() => expect(submitButton).toBeEnabled())
 
     await user.click(submitButton)
-    expect(onSubmit).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
 
     await user.clear(getByTestId('first-name'))
     await user.type(getByTestId('first-name'), 'a')

--- a/packages/react-form/tests/useField.test.tsx
+++ b/packages/react-form/tests/useField.test.tsx
@@ -429,6 +429,74 @@ describe('useField', () => {
     expect(submitButton).toBeEnabled()
   })
 
+  it('should call onUnmount listener when a field is conditionally removed', async () => {
+    const fieldUnmount = vi.fn()
+    const formFieldUnmount = vi.fn()
+
+    function Comp() {
+      const form = useForm({
+        defaultValues: {
+          show: true,
+          name: 'test',
+        },
+        listeners: {
+          onFieldUnmount: formFieldUnmount,
+        },
+      })
+
+      return (
+        <>
+          <form.Field name="show">
+            {(field) => (
+              <input
+                data-testid="toggle"
+                type="checkbox"
+                checked={field.state.value}
+                onChange={(e) => field.handleChange(e.target.checked)}
+              />
+            )}
+          </form.Field>
+
+          <form.Subscribe selector={(s) => s.values.show}>
+            {(show) =>
+              show ? (
+                <form.Field
+                  name="name"
+                  listeners={{ onUnmount: fieldUnmount }}
+                >
+                  {(field) => (
+                    <input
+                      data-testid="name"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                    />
+                  )}
+                </form.Field>
+              ) : null
+            }
+          </form.Subscribe>
+        </>
+      )
+    }
+
+    const { getByTestId, queryByTestId } = render(
+      <StrictMode>
+        <Comp />
+      </StrictMode>,
+    )
+
+    await waitFor(() => expect(getByTestId('name')).toBeInTheDocument())
+
+    const callsBefore = fieldUnmount.mock.calls.length
+    const formCallsBefore = formFieldUnmount.mock.calls.length
+
+    await user.click(getByTestId('toggle'))
+
+    await waitFor(() => expect(queryByTestId('name')).not.toBeInTheDocument())
+    expect(fieldUnmount).toHaveBeenCalledTimes(callsBefore + 1)
+    expect(formFieldUnmount).toHaveBeenCalledTimes(formCallsBefore + 1)
+  })
+
   it('should validate async on change', async () => {
     type Person = {
       firstName: string


### PR DESCRIPTION
Add unmounting to fields. `field.mount` now returns a cleanup function for unmounting.

Without unmounting, conditionally rendered fields will keep their field-level validations running even though the field isn’t rendered anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added form option cleanupFieldsOnUnmount (default: false) to control clearing field meta/state on unmount.
  * Field mount now returns an explicit cleanup/unmount function.

* **Bug Fixes**
  * Unmount now cancels in-flight async validations and debounced listeners to avoid stale callbacks.
  * Hidden/conditionally rendered fields no longer retain submit errors after unmount when cleanup is enabled.

* **Tests**
  * Expanded coverage for mount/unmount, value/meta preservation, async cancellation, and remount behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->