### PR TITLE
docs: clarify that useStore selector is required

### DIFF
--- a/docs/framework/react/guides/reactivity.md
+++ b/docs/framework/react/guides/reactivity.md
@@ -24,7 +24,7 @@ You can access any piece of the form state in the selector.
 
 > Note, that `useStore` will cause a whole component re-render whenever the value subscribed to changes.
 
-While it IS possible to omit the selector, resist the urge as omitting it would result in many unnecessary re-renders whenever any of the form state changes.
+The selector parameter is required. It allows you to subscribe to only the specific part of the form state your component needs, helping avoid unnecessary re-renders when other parts of the state change.
 
 ## form.Subscribe
 


### PR DESCRIPTION
## 🎯 Changes

#2035
Update the documentation to reflect that the `useStore` selector parameter is required.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
