### PR TITLE
fix(react-form): restore optional selector in re-exported useStore

### DIFF
--- a/packages/react-form/src/index.ts
+++ b/packages/react-form/src/index.ts
@@ -1,6 +1,6 @@
 export * from '@tanstack/form-core'
 
-export { useStore } from '@tanstack/react-store'
+export { useStore } from './useStore'
 
 export * from './createFormHook'
 export * from './types'

--- a/packages/react-form/src/useStore.ts
+++ b/packages/react-form/src/useStore.ts
@@ -1,0 +1,44 @@
+import { useStore as _useStore } from '@tanstack/react-store'
+import type { AnyAtom } from '@tanstack/store'
+
+type AtomSnapshot<TAtom> = TAtom extends { get: () => infer TSnapshot }
+  ? TSnapshot
+  : undefined
+
+/**
+ * Subscribe to a store atom and return its current state.
+ *
+ * When called without a `selector` the full atom snapshot is returned.
+ *
+ * @example
+ * // Return the full form state (selector optional for back-compat)
+ * const formState = useStore(form.store)
+ *
+ * @example
+ * // Return a specific slice
+ * const isValid = useStore(form.store, (s) => s.isValid)
+ */
+export function useStore<TAtom extends AnyAtom | undefined>(
+  atom: TAtom,
+): AtomSnapshot<TAtom>
+
+export function useStore<TAtom extends AnyAtom | undefined, T>(
+  atom: TAtom,
+  selector: (snapshot: AtomSnapshot<TAtom>) => T,
+  compare?: (a: T, b: T) => boolean,
+): T
+
+export function useStore<TAtom extends AnyAtom | undefined, T>(
+  atom: TAtom,
+  selector?: (snapshot: AtomSnapshot<TAtom>) => T,
+  compare?: (a: T, b: T) => boolean,
+): T | AtomSnapshot<TAtom> {
+  // When no selector is provided fall back to the identity function so that
+  // callers that were using `useStore(form.store)` without a selector
+  // (as was valid in prior releases) continue to work.
+  return _useStore(
+    atom,
+    (selector ?? ((s: any) => s)) as (snapshot: AtomSnapshot<TAtom>) => T,
+    compare,
+  )
+}

--- a/packages/react-form/src/useStore.ts
+++ b/packages/react-form/src/useStore.ts
@@ -1,5 +1,5 @@
 import { useStore as _useStore } from '@tanstack/react-store'
-import type { AnyAtom } from '@tanstack/store'
+import type { AnyAtom } from '@tanstack/react-store'
 
 type AtomSnapshot<TAtom> = TAtom extends { get: () => infer TSnapshot }
   ? TSnapshot


### PR DESCRIPTION
## Summary

Fixes TanStack/store#323

## Problem

Prior to `@tanstack/react-store@0.9.1`, `useStore` could be called with just a store reference:

```ts
const formState = useStore(form.store) // ✅ worked before
```

The `0.9.1` update to `react-store` made the `selector` argument required in its TypeScript types. Because `@tanstack/react-form` re-exported `useStore` directly:

```ts
export { useStore } from '@tanstack/react-store'
```

…any project that had previously used the single-argument form now sees a TypeScript build error:

```
error TS2554: Expected 2-3 arguments, but got 1.
```

## Fix

Instead of re-exporting `useStore` verbatim, this PR adds a thin overload wrapper in `packages/react-form/src/useStore.ts` that:

1. **No selector** – returns the full atom snapshot (restores pre-1.28.4 behaviour)
2. **With selector** – passes through to the underlying `@tanstack/react-store` implementation

At runtime the identity function `(s) => s` is used as the default selector, which matches what the underlying implementation would have done before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the useStore hook with stronger typing, overloads for returning full snapshots or selector-derived slices, and preserved comparison behavior for selectors.
* **Chore**
  * Switched the public export source of useStore to the package's local implementation (no public API name changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->