### PR TITLE
docs: fix incorrect `children` prop on svelte validation guide

### DIFF
--- a/docs/framework/svelte/guides/validation.md
+++ b/docs/framework/svelte/guides/validation.md
@@ -391,11 +391,6 @@ You can subscribe to it via `form.Subscribe` and use the value in order to, for 
     canSubmit: state.canSubmit,
     isSubmitting: state.isSubmitting,
   })}
-  children={(state) => (
-    <button type="submit" disabled={!state().canSubmit}>
-      {state().isSubmitting ? '...' : 'Submit'}
-    </button>
-  )}
 >
   {#snippet children(state)}
     <button type="submit" disabled={!state.canSubmit}>


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
Removed a JSX `children` prop was left on the validation guide for Svelte's validation guide, which does not work and is duplicated as a correct snippet later in the code block.


## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.
	- I don't think this change needs to be tested

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated validation guide examples to reflect simplified syntax patterns while maintaining equivalent functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->