### PR TITLE
fix(react-form): use shallow equality in form.Subscribe to prevent unnecessary re-renders

### DIFF
--- a/packages/react-form/src/useForm.tsx
+++ b/packages/react-form/src/useForm.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { FormApi, functionalUpdate, mergeAndUpdate } from '@tanstack/form-core'
-import { useStore } from '@tanstack/react-store'
+import { shallow, useStore } from '@tanstack/react-store'
 import { useMemo, useRef, useState } from 'react'
 import { Field } from './useField'
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
@@ -145,7 +145,7 @@ function LocalSubscribe({
   form: AnyFormApi
   selector?: (state: AnyFormState) => AnyFormState
 }>): ReturnType<FunctionComponent> {
-  const data = useStore(form.store, selector)
+  const data = useStore(form.store, selector, shallow)
 
   return <>{functionalUpdate(children, data)}</>
 }


### PR DESCRIPTION
## Summary

Fixes #2090

`form.Subscribe` was triggering re-renders on every store update when the `selector` returned an object or array. Since `useStore` defaults to `Object.is` reference equality, selectors that construct new objects/arrays on each call always appeared to have changed — even when the underlying data was identical.

## Fix

Pass `shallow` from `@tanstack/react-store` as the compare function to `useStore` in `LocalSubscribe`. This is a one-line change: shallow equality avoids re-renders when the selector returns an object or array with the same primitive values.

```diff
-const data = useStore(form.store, selector)
+const data = useStore(form.store, selector, shallow)
```

`@tanstack/react-store` already exports `shallow` (and re-exports `@tanstack/store`), so no new dependencies are needed.

## Testing

All 86 existing tests pass with no changes. The fix is intentionally minimal — the change in equality semantics only matters when a selector returns a new object/array reference on every call with the same contents, which is the exact scenario described in the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form state change detection to ensure form components re-render correctly when data updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->