### PR TITLE
feat(core): add form listners for reset

### DIFF
--- a/.changeset/reset-listeners.md
+++ b/.changeset/reset-listeners.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/form-core": minor
+---
+
+Add `onReset` listener support for forms and fields, add `reset` method to `FieldApi`, and expand `ListenerCause` type with `'reset'` and `'unmount'` values

--- a/.changeset/reset-listeners.md
+++ b/.changeset/reset-listeners.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/form-core": minor
+'@tanstack/form-core': minor
 ---
 
 Add `onReset` listener support for forms and fields, add `reset` method to `FieldApi`, and expand `ListenerCause` type with `'reset'` and `'unmount'` values

--- a/docs/framework/angular/guides/listeners.md
+++ b/docs/framework/angular/guides/listeners.md
@@ -20,6 +20,7 @@ Events that can be "listened" to are:
 - `onMount`
 - `onSubmit`
 - `onUnmount`
+- `onReset`
 
 ```angular-ts
 @Component({

--- a/docs/framework/react/guides/listeners.md
+++ b/docs/framework/react/guides/listeners.md
@@ -13,7 +13,7 @@ Imagine the following user flow:
 
 In this example, when the user changes the country, the selected province needs to be reset as it's no longer valid. With the listener API, we can subscribe to the `onChange` event and dispatch a reset to the "province" field when the listener is fired.
 
-Events that can be "listened" to are:
+Field level events that can be "listened" to are:
 
 - `onChange`
 - `onBlur`
@@ -94,9 +94,9 @@ We enable an easy method for debouncing your listeners by adding a `onChangeDebo
 
 ### Form listeners
 
-At a higher level, listeners are also available at the form level, allowing you access to the `onMount` and `onSubmit` events, and having `onChange` and `onBlur` propagated to all the form's children. Form-level listeners can also be debounced in the same way as previously discussed.
+At a higher level, listeners are also available at the form level, allowing you access to the `onMount`, `onSubmit`, and `onReset` events, and having `onChange` and `onBlur` propagated to all the form's children. Form-level listeners can also be debounced in the same way as previously discussed.
 
-`onMount` and `onSubmit` listeners have the following parameters:
+`onMount`, `onSubmit`, `onReset` listeners have the following parameters:
 
 - `formApi`
 

--- a/docs/framework/react/guides/listeners.md
+++ b/docs/framework/react/guides/listeners.md
@@ -20,6 +20,7 @@ Events that can be "listened" to are:
 - `onMount`
 - `onSubmit`
 - `onUnmount`
+- `onReset`
 
 ```tsx
 function App() {

--- a/docs/framework/vue/guides/listeners.md
+++ b/docs/framework/vue/guides/listeners.md
@@ -20,6 +20,7 @@ Events that can be "listened" to are:
 - `onMount`
 - `onSubmit`
 - `onUnmount`
+- `onReset`
 
 ```vue
 <script setup>

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -8,8 +8,10 @@ import {
   determineFieldLevelErrorSourceAndValue,
   evaluate,
   getAsyncValidatorArray,
+  getBy,
   getSyncValidatorArray,
   mergeOpts,
+  setBy,
 } from './utils'
 import { defaultValidationLogic } from './ValidationLogic'
 import type { ReadonlyStore } from '@tanstack/store'
@@ -384,6 +386,7 @@ export interface FieldListeners<
   onMount?: FieldListenerFn<TParentData, TName, TData>
   onUnmount?: FieldListenerFn<TParentData, TName, TData>
   onSubmit?: FieldListenerFn<TParentData, TName, TData>
+  onReset?: FieldListenerFn<TParentData, TName, TData>
 }
 
 /**
@@ -2088,6 +2091,17 @@ export class FieldApi<
       { value: this.state.value, validationSource: 'field' },
       schema,
     )
+  }
+
+  /**
+   * Resets the field value and meta to default state.
+   */
+  reset = () => {
+    this.form.resetField(this.name)
+    this.options.listeners?.onReset?.({
+      value: this.state.value,
+      fieldApi: this,
+    })
   }
 
   private triggerOnBlurListener() {

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -8,10 +8,8 @@ import {
   determineFieldLevelErrorSourceAndValue,
   evaluate,
   getAsyncValidatorArray,
-  getBy,
   getSyncValidatorArray,
   mergeOpts,
-  setBy,
 } from './utils'
 import { defaultValidationLogic } from './ValidationLogic'
 import type { ReadonlyStore } from '@tanstack/store'

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -324,6 +324,23 @@ export interface FormListeners<
     >
     fieldApi: AnyFieldApi
   }) => void
+
+  onReset?: (props: {
+    formApi: FormApi<
+      TFormData,
+      TOnMount,
+      TOnChange,
+      TOnChangeAsync,
+      TOnBlur,
+      TOnBlurAsync,
+      TOnSubmit,
+      TOnSubmitAsync,
+      TOnDynamic,
+      TOnDynamicAsync,
+      TOnServer,
+      TSubmitMeta
+    >
+  }) => void
 }
 
 /**
@@ -1541,6 +1558,8 @@ export class FormApi<
         fieldMetaBase,
       }),
     )
+
+    this.options.listeners?.onReset?.({ formApi: this })
   }
 
   /**

--- a/packages/form-core/src/types.ts
+++ b/packages/form-core/src/types.ts
@@ -21,7 +21,13 @@ export type ValidationCause =
 /**
  * @private
  */
-export type ListenerCause = 'change' | 'blur' | 'submit' | 'mount'
+export type ListenerCause =
+  | 'change'
+  | 'blur'
+  | 'submit'
+  | 'mount'
+  | 'reset'
+  | 'unmount'
 
 /**
  * @private

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -3529,4 +3529,81 @@ describe('edge cases and error handling', () => {
     field.handleChange(undefined)
     expect(field.state.value).toBeUndefined()
   })
+
+  it('should run listener onReset when field.reset() is called', () => {
+    const form = new FormApi({
+      defaultValues: {
+        name: 'test',
+      },
+    })
+
+    let triggered: string | undefined
+    const field = new FieldApi({
+      form,
+      name: 'name',
+      listeners: {
+        onReset: ({ value }) => {
+          triggered = value
+        },
+      },
+    })
+
+    form.mount()
+    field.mount()
+    field.setValue('changed')
+    field.reset()
+
+    expect(triggered).toStrictEqual('test')
+  })
+
+  it('should not run onReset listener when form.reset() is called directly', () => {
+    const form = new FormApi({
+      defaultValues: {
+        name: 'test',
+      },
+    })
+
+    const onReset = vi.fn()
+    const field = new FieldApi({
+      form,
+      name: 'name',
+      listeners: {
+        onReset,
+      },
+    })
+
+    form.mount()
+    field.mount()
+    form.reset()
+
+    expect(onReset).not.toHaveBeenCalled()
+  })
+
+  it('should provide value and fieldApi in the onReset listener', () => {
+    const form = new FormApi({
+      defaultValues: {
+        name: 'test',
+      },
+    })
+
+    let capturedFieldApi: any
+    let capturedValue: string | undefined
+    const field = new FieldApi({
+      form,
+      name: 'name',
+      listeners: {
+        onReset: ({ value, fieldApi }) => {
+          capturedValue = value
+          capturedFieldApi = fieldApi
+        },
+      },
+    })
+
+    form.mount()
+    field.mount()
+    field.reset()
+
+    expect(capturedValue).toStrictEqual('test')
+    expect(capturedFieldApi).toBe(field)
+  })
 })

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -4183,4 +4183,61 @@ describe('form transform', () => {
 
     expect(field.state.meta.errorMap.onChange).toBe('Error')
   })
+
+  it('should run the form listener onReset', () => {
+    let triggered!: string
+    const form = new FormApi({
+      defaultValues: {
+        name: 'test',
+      },
+      listeners: {
+        onReset: ({ formApi }) => {
+          triggered = formApi.state.values.name
+        },
+      },
+    })
+
+    form.mount()
+    form.reset()
+
+    expect(triggered).toStrictEqual('test')
+  })
+
+  it('should run the form listener onReset with new values', () => {
+    let triggered!: string
+    const form = new FormApi({
+      defaultValues: {
+        name: 'test',
+      },
+      listeners: {
+        onReset: ({ formApi }) => {
+          triggered = formApi.state.values.name
+        },
+      },
+    })
+
+    form.mount()
+    form.reset({ name: 'reset-value' })
+
+    expect(triggered).toStrictEqual('reset-value')
+  })
+
+  it('should provide formApi in the onReset listener', () => {
+    let capturedFormApi: any
+    const form = new FormApi({
+      defaultValues: {
+        name: 'test',
+      },
+      listeners: {
+        onReset: ({ formApi }) => {
+          capturedFormApi = formApi
+        },
+      },
+    })
+
+    form.mount()
+    form.reset()
+
+    expect(capturedFormApi).toBe(form)
+  })
 })


### PR DESCRIPTION
adds form listeners for the reset event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added onReset listener support for forms and fields; onReset is invoked after a reset and receives the relevant API and reset value
  * Added a reset method to the Field API
  * Expanded listener cause types to include 'reset' and 'unmount'

* **Documentation**
  * Updated Angular, React, and Vue guides to document the new onReset listener

* **Tests**
  * Added tests covering form- and field-level onReset behavior and payloads
<!-- end of auto-generated comment: release notes by coderabbit.ai -->