### PR TITLE
fix(listeners): rename onFieldUnmount to match that of the other listeners

### DIFF
--- a/.changeset/rename-onFieldUnmount-to-onUnmount.md
+++ b/.changeset/rename-onFieldUnmount-to-onUnmount.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/form-core": minor
+---
+
+Rename `onFieldUnmount` listener to `onUnmount` to match the naming convention of other form listeners.

--- a/.changeset/rename-onFieldUnmount-to-onUnmount.md
+++ b/.changeset/rename-onFieldUnmount-to-onUnmount.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/form-core": minor
+'@tanstack/form-core': minor
 ---
 
 Rename `onFieldUnmount` listener to `onUnmount` to match the naming convention of other form listeners.

--- a/docs/framework/lit/guides/listeners.md
+++ b/docs/framework/lit/guides/listeners.md
@@ -21,48 +21,50 @@ Events that can be "listened" to are:
 - `onSubmit`
 - `onUnmount`
 
-```vue
-<script setup>
-import { useForm } from '@tanstack/vue-form'
-
-const form = useForm({
-  defaultValues: {
-    country: '',
-    province: '',
+```ts
+${this.#form.field(
+  {
+    name: 'country',
+    listeners: {
+      onChange: ({ value }) => {
+        console.log(`Country changed to: ${value}, resetting province`)
+        this.#form.api.setFieldValue('province', '')
+      },
+    },
   },
-  // ...
-})
-</script>
-
-<template>
-  <div>
-    <form.Field
-      name="country"
-      :listeners="{
-        onChange: ({ value }) => {
-          console.log(`Country changed to: ${value}, resetting province`)
-          form.setFieldValue('province', '')
-        },
-      }"
-    >
-      <template v-slot="{ field }">
+  (field) => {
+    return html`
+      <label>
+        <div>Country</div>
         <input
-          :value="field.state.value"
-          @input="(e) => field.handleChange(e.target.value)"
+          .value="${field.state.value}"
+          @input="${(e: Event) => {
+            const target = e.target as HTMLInputElement
+            field.handleChange(target.value)
+          }}"
         />
-      </template>
-    </form.Field>
+      </label>
+    `
+  },
+)}
 
-    <form.Field name="province">
-      <template v-slot="{ field }">
+${this.#form.field(
+  { name: 'province' },
+  (field) => {
+    return html`
+      <label>
+        <div>Province</div>
         <input
-          :value="field.state.value"
-          @input="(e) => field.handleChange(e.target.value)"
+          .value="${field.state.value}"
+          @input="${(e: Event) => {
+            const target = e.target as HTMLInputElement
+            field.handleChange(target.value)
+          }}"
         />
-      </template>
-    </form.Field>
-  </div>
-</template>
+      </label>
+    `
+  },
+)}
 ```
 
 ## Built-in Debouncing
@@ -70,21 +72,22 @@ const form = useForm({
 If you are making an API request inside a listener, you may want to debounce the calls as it can lead to performance issues.
 We enable an easy method for debouncing your listeners by adding a `onChangeDebounceMs` or `onBlurDebounceMs`.
 
-```vue
-<form.Field
-  name="country"
-  :listeners="{
-    onChangeDebounceMs: 500,
-    onChange: ({ value }) => {
-      console.log(`Country changed to: ${value} without a change within 500ms, resetting province`)
-      form.setFieldValue('province', '')
+```ts
+${this.#form.field(
+  {
+    name: 'country',
+    listeners: {
+      onChangeDebounceMs: 500, // 500ms debounce
+      onChange: ({ value }) => {
+        console.log(`Country changed to: ${value} without a change within 500ms, resetting province`)
+        this.#form.api.setFieldValue('province', '')
+      },
     },
-  }"
->
-  <template v-slot="{ field }">
-    <!-- ... -->
-  </template>
-</form.Field>
+  },
+  (field) => {
+    return html`<!-- ... -->`
+  },
+)}
 ```
 
 ## Form listeners
@@ -100,11 +103,8 @@ At a higher level, listeners are also available at the form level, allowing you 
 - `fieldApi`
 - `formApi`
 
-```vue
-<script setup>
-import { useForm } from '@tanstack/vue-form'
-
-const form = useForm({
+```ts
+#form = new TanStackFormController(this, {
   listeners: {
     onMount: ({ formApi }) => {
       // custom logging service
@@ -123,5 +123,4 @@ const form = useForm({
     onChangeDebounceMs: 500,
   },
 })
-</script>
 ```

--- a/docs/framework/react/guides/listeners.md
+++ b/docs/framework/react/guides/listeners.md
@@ -93,13 +93,13 @@ We enable an easy method for debouncing your listeners by adding a `onChangeDebo
 
 ### Form listeners
 
-At a higher level, listeners are also available at the form level, allowing you access to the `onMount` and `onSubmit` events, and having `onChange` and `onBlur` propagated to all the form's children. Form-level listeners can also be debounced in the same way as previously discussed.
+At a higher level, listeners are also available at the form level, allowing you access to the `onMount` and `onSubmit` events, and having `onChange`, `onBlur`, and `onUnmount` propagated to all the form's children. Form-level listeners can also be debounced in the same way as previously discussed.
 
 `onMount` and `onSubmit` listeners have the following parameters:
 
 - `formApi`
 
-`onChange` and `onBlur` listeners have access to:
+`onChange`, `onBlur`, and `onUnmount` listeners have access to:
 
 - `fieldApi`
 - `formApi`

--- a/docs/framework/solid/guides/listeners.md
+++ b/docs/framework/solid/guides/listeners.md
@@ -21,48 +21,52 @@ Events that can be "listened" to are:
 - `onSubmit`
 - `onUnmount`
 
-```vue
-<script setup>
-import { useForm } from '@tanstack/vue-form'
+```tsx
+export default function App() {
+  const form = createForm(() => ({
+    defaultValues: {
+      country: '',
+      province: '',
+    },
+    // ...
+  }))
 
-const form = useForm({
-  defaultValues: {
-    country: '',
-    province: '',
-  },
-  // ...
-})
-</script>
+  return (
+    <div>
+      <form.Field
+        name="country"
+        listeners={{
+          onChange: ({ value }) => {
+            console.log(`Country changed to: ${value}, resetting province`)
+            form.setFieldValue('province', '')
+          },
+        }}
+      >
+        {(field) => (
+          <label>
+            <div>Country</div>
+            <input
+              value={field().state.value}
+              onChange={(e) => field().handleChange(e.target.value)}
+            />
+          </label>
+        )}
+      </form.Field>
 
-<template>
-  <div>
-    <form.Field
-      name="country"
-      :listeners="{
-        onChange: ({ value }) => {
-          console.log(`Country changed to: ${value}, resetting province`)
-          form.setFieldValue('province', '')
-        },
-      }"
-    >
-      <template v-slot="{ field }">
-        <input
-          :value="field.state.value"
-          @input="(e) => field.handleChange(e.target.value)"
-        />
-      </template>
-    </form.Field>
-
-    <form.Field name="province">
-      <template v-slot="{ field }">
-        <input
-          :value="field.state.value"
-          @input="(e) => field.handleChange(e.target.value)"
-        />
-      </template>
-    </form.Field>
-  </div>
-</template>
+      <form.Field name="province">
+        {(field) => (
+          <label>
+            <div>Province</div>
+            <input
+              value={field().state.value}
+              onChange={(e) => field().handleChange(e.target.value)}
+            />
+          </label>
+        )}
+      </form.Field>
+    </div>
+  )
+}
 ```
 
 ## Built-in Debouncing
@@ -70,20 +74,20 @@ const form = useForm({
 If you are making an API request inside a listener, you may want to debounce the calls as it can lead to performance issues.
 We enable an easy method for debouncing your listeners by adding a `onChangeDebounceMs` or `onBlurDebounceMs`.
 
-```vue
+```tsx
 <form.Field
   name="country"
-  :listeners="{
-    onChangeDebounceMs: 500,
+  listeners={{
+    onChangeDebounceMs: 500, // 500ms debounce
     onChange: ({ value }) => {
       console.log(`Country changed to: ${value} without a change within 500ms, resetting province`)
       form.setFieldValue('province', '')
     },
-  }"
+  }}
 >
-  <template v-slot="{ field }">
-    <!-- ... -->
-  </template>
+  {(field) => (
+    /* ... */
+  )}
 </form.Field>
 ```
 
@@ -100,11 +104,8 @@ At a higher level, listeners are also available at the form level, allowing you 
 - `fieldApi`
 - `formApi`
 
-```vue
-<script setup>
-import { useForm } from '@tanstack/vue-form'
-
-const form = useForm({
+```tsx
+const form = createForm(() => ({
   listeners: {
     onMount: ({ formApi }) => {
       // custom logging service
@@ -122,6 +123,5 @@ const form = useForm({
     },
     onChangeDebounceMs: 500,
   },
-})
-</script>
+}))
 ```

--- a/docs/framework/svelte/guides/listeners.md
+++ b/docs/framework/svelte/guides/listeners.md
@@ -21,44 +21,52 @@ Events that can be "listened" to are:
 - `onSubmit`
 - `onUnmount`
 
-```angular-ts
-@Component({
-  selector: 'app-root',
-  standalone: true,
-  imports: [TanStackField],
-  template: `
-    <ng-container
-      [tanstackField]="form"
-      name="country"
-      [listeners]="{
-        onChange: onCountryChange
-      }"
-      #country="field"
-    ></ng-container>
+```svelte
+<script>
+  import { createForm } from '@tanstack/svelte-form'
 
-    <ng-container
-      [tanstackField]="form"
-      name="province"
-      #province="field"
-    ></ng-container>
-  `,
-})
-
-export class AppComponent {
-  form = injectForm({
+  const form = createForm(() => ({
     defaultValues: {
       country: '',
       province: '',
     },
-  })
+    // ...
+  }))
+</script>
 
-  onCountryChange: FieldListenerFn<any, any, any, any, string> = ({
-    value,
-  }) => {
-    console.log(`Country changed to: ${value}, resetting province`)
-    this.form.setFieldValue('province', '')
-  }
-}
+<div>
+  <form.Field
+    name="country"
+    listeners={{
+      onChange: ({ value }) => {
+        console.log(`Country changed to: ${value}, resetting province`)
+        form.setFieldValue('province', '')
+      },
+    }}
+  >
+    {#snippet children(field)}
+      <label>
+        <div>Country</div>
+        <input
+          value={field.state.value}
+          onchange={(e) => field.handleChange(e.target.value)}
+        />
+      </label>
+    {/snippet}
+  </form.Field>
+
+  <form.Field name="province">
+    {#snippet children(field)}
+      <label>
+        <div>Province</div>
+        <input
+          value={field.state.value}
+          onchange={(e) => field.handleChange(e.target.value)}
+        />
+      </label>
+    {/snippet}
+  </form.Field>
+</div>
 ```
 
 ## Built-in Debouncing
@@ -66,38 +74,21 @@ export class AppComponent {
 If you are making an API request inside a listener, you may want to debounce the calls as it can lead to performance issues.
 We enable an easy method for debouncing your listeners by adding a `onChangeDebounceMs` or `onBlurDebounceMs`.
 
-```angular-ts
-@Component({
-  selector: 'app-root',
-  standalone: true,
-  imports: [TanStackField],
-  template: `
-    <ng-container
-      [tanstackField]="form"
-      name="country"
-      [listeners]="{
-        onChangeDebounceMs: 500,
-        onChange: onCountryChange
-      }"
-      #country="field"
-    ></ng-container>
-  `,
-})
-export class AppComponent {
-  form = injectForm({
-    defaultValues: {
-      country: '',
-      province: '',
+```svelte
+<form.Field
+  name="country"
+  listeners={{
+    onChangeDebounceMs: 500,
+    onChange: ({ value }) => {
+      console.log(`Country changed to: ${value} without a change within 500ms, resetting province`)
+      form.setFieldValue('province', '')
     },
-  })
-
-  onCountryChange: FieldListenerFn<any, any, any, any, string> = ({
-    value,
-  }) => {
-    console.log(`Country changed to: ${value} without a change within 500ms, resetting province`)
-    this.form.setFieldValue('province', '')
-  }
-}
+  }}
+>
+  {#snippet children(field)}
+    <!-- ... -->
+  {/snippet}
+</form.Field>
 ```
 
 ## Form listeners
@@ -113,9 +104,11 @@ At a higher level, listeners are also available at the form level, allowing you 
 - `fieldApi`
 - `formApi`
 
-```angular-ts
-export class AppComponent {
-  form = injectForm({
+```svelte
+<script>
+  import { createForm } from '@tanstack/svelte-form'
+
+  const form = createForm(() => ({
     listeners: {
       onMount: ({ formApi }) => {
         // custom logging service
@@ -133,6 +126,6 @@ export class AppComponent {
       },
       onChangeDebounceMs: 500,
     },
-  })
-}
+  }))
+</script>
 ```

--- a/docs/framework/vue/guides/listeners.md
+++ b/docs/framework/vue/guides/listeners.md
@@ -76,7 +76,9 @@ We enable an easy method for debouncing your listeners by adding a `onChangeDebo
   :listeners="{
     onChangeDebounceMs: 500,
     onChange: ({ value }) => {
-      console.log(`Country changed to: ${value} without a change within 500ms, resetting province`)
+      console.log(
+        `Country changed to: ${value} without a change within 500ms, resetting province`,
+      )
       form.setFieldValue('province', '')
     },
   }"

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -1399,7 +1399,7 @@ export class FieldApi<
         fieldApi: this,
       })
 
-      this.form.options.listeners?.onFieldUnmount?.({
+      this.form.options.listeners?.onUnmount?.({
         formApi: this.form,
         fieldApi: this,
       })

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -307,7 +307,7 @@ export interface FormListeners<
     meta: TSubmitMeta
   }) => void
 
-  onFieldUnmount?: (props: {
+  onUnmount?: (props: {
     formApi: FormApi<
       TFormData,
       TOnMount,

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -1514,7 +1514,7 @@ describe('field api', () => {
     expect(triggered).toStrictEqual('test')
   })
 
-  it('should run form listener onFieldUnmount', () => {
+  it('should run form listener onUnmount', () => {
     let capturedName: string | undefined
 
     const form = new FormApi({
@@ -1522,7 +1522,7 @@ describe('field api', () => {
         name: 'test',
       },
       listeners: {
-        onFieldUnmount: ({ fieldApi }) => {
+        onUnmount: ({ fieldApi }) => {
           capturedName = fieldApi.name as string
         },
       },

--- a/packages/react-form/tests/useField.test.tsx
+++ b/packages/react-form/tests/useField.test.tsx
@@ -440,7 +440,7 @@ describe('useField', () => {
           name: 'test',
         },
         listeners: {
-          onFieldUnmount: formFieldUnmount,
+          onUnmount: formFieldUnmount,
         },
       })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed form-level listener key from onFieldUnmount to onUnmount for consistency with other listeners.

* **New Features**
  * Built-in debouncing for listeners via onChangeDebounceMs and onBlurDebounceMs.

* **Documentation**
  * Added or updated comprehensive listener guides across frameworks covering events (onChange/onBlur/onMount/onSubmit/onUnmount), debouncing, field- and form-level listener examples, and propagated listener behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->