### PR TITLE
fix: revalidate nested fields after parent object updates

### DIFF
--- a/.changeset/stale-nested-field-meta.md
+++ b/.changeset/stale-nested-field-meta.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/form-core': patch
+---
+
+Fix stale nested field errors when setting a parent object field by revalidating mounted descendant fields after the parent value changes.

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -2284,6 +2284,17 @@ export class FormApi<
     const dontUpdateMeta = opts?.dontUpdateMeta ?? false
     const dontRunListeners = opts?.dontRunListeners ?? false
     const dontValidate = opts?.dontValidate ?? false
+    const fieldString = field.toString()
+    const descendantFields = Object.keys(this.fieldInfo).filter((fieldKey) => {
+      if (fieldKey === fieldString) {
+        return false
+      }
+
+      return (
+        fieldKey.startsWith(`${fieldString}.`) ||
+        fieldKey.startsWith(`${fieldString}[`)
+      )
+    }) as DeepKeys<TFormData>[]
 
     batch(() => {
       if (!dontUpdateMeta) {
@@ -2313,6 +2324,10 @@ export class FormApi<
 
     if (!dontValidate) {
       this.validateField(field, 'change')
+
+      descendantFields.forEach((descendantField) => {
+        this.getFieldInfo(descendantField).instance?.validate('change')
+      })
     }
   }
 

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -225,6 +225,40 @@ describe('form api', () => {
     expect(form.getFieldValue('name')).toEqual('other')
   })
 
+  it('should clear nested field errors when setting a parent object field', () => {
+    const form = new FormApi({
+      defaultValues: {
+        a: {
+          b: 0,
+        },
+      },
+    })
+
+    const childField = new FieldApi({
+      form,
+      name: 'a.b',
+      validators: {
+        onChange: ({ value }) =>
+          value > 0 ? undefined : 'Must be greater than 0',
+      },
+    })
+
+    form.mount()
+    childField.mount()
+
+    childField.setValue(0)
+
+    expect(childField.state.meta.errors).toEqual(['Must be greater than 0'])
+
+    form.setFieldValue('a', {
+      b: 1,
+    })
+
+    expect(form.getFieldValue('a.b')).toBe(1)
+    expect(childField.state.meta.errors).toEqual([])
+    expect(childField.state.meta.isValid).toBe(true)
+  })
+
   it("should be dirty after a field's value has been set", () => {
     const form = new FormApi({
       defaultValues: {


### PR DESCRIPTION
## 🎯 Changes

Fixes the stale nested field meta described in #2113.

When `setFieldValue` updates a parent object field like `a`, mounted descendant fields like `a.b` are now revalidated on change as well. This keeps nested field-level errors in sync after programmatic parent object updates.

Added a regression test covering the reported case where updating `a` from `{ b: 0 }` to `{ b: 1 }` should clear the existing validation error on `a.b`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where nested field validation errors would become stale when updating a parent object field. Nested descendant fields are now properly revalidated whenever their parent object changes, ensuring that validation errors, validity states, and field values remain accurate and in sync with your data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->