### PR TITLE
fix(form-core): prevent removeValue from auto-touching shifted siblings

### DIFF
--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -1582,6 +1582,7 @@ export class FormApi<
     field: TField,
     index: number,
     cause: ValidationCause,
+    options?: { avoidTouch?: boolean },
   ) => {
     const currentValue = this.getFieldValue(field)
 
@@ -1605,12 +1606,29 @@ export class FormApi<
     batch(() => {
       fieldsToValidate.forEach((nestedField) => {
         fieldValidationPromises.push(
-          Promise.resolve().then(() => {
-            // If the field instance already exists, call validate directly
-            // to avoid auto-touching shifted siblings
-            const fieldInstance = this.fieldInfo[nestedField]?.instance
-            if (fieldInstance) {
-              return fieldInstance.validate(cause)
+          Promise.resolve().then(async () => {
+            // If avoidTouch is set and the field instance already exists,
+            // run validation without permanently marking the field as touched
+            if (options?.avoidTouch) {
+              const fieldInstance = this.fieldInfo[nestedField]?.instance
+              if (fieldInstance) {
+                const wasTouched = fieldInstance.state.meta.isTouched
+                if (!wasTouched) {
+                  // Temporarily touch the field so validation runs, then restore
+                  fieldInstance.setMeta((prev) => ({
+                    ...prev,
+                    isTouched: true,
+                  }))
+                }
+                const result = await fieldInstance.validate(cause)
+                if (!wasTouched) {
+                  fieldInstance.setMeta((prev) => ({
+                    ...prev,
+                    isTouched: false,
+                  }))
+                }
+                return result
+              }
             }
             return this.validateField(nestedField, cause)
           }),
@@ -2477,7 +2495,10 @@ export class FormApi<
     if (!dontValidate) {
       // Validate the whole array + all fields that have shifted
       await this.validateField(field, 'change')
-      await this.validateArrayFieldsStartingFrom(field, index, 'change')
+      // avoidTouch: true prevents auto-touching siblings that shifted after removal
+      await this.validateArrayFieldsStartingFrom(field, index, 'change', {
+        avoidTouch: true,
+      })
     }
   }
 

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -1605,7 +1605,15 @@ export class FormApi<
     batch(() => {
       fieldsToValidate.forEach((nestedField) => {
         fieldValidationPromises.push(
-          Promise.resolve().then(() => this.validateField(nestedField, cause)),
+          Promise.resolve().then(() => {
+            // If the field instance already exists, call validate directly
+            // to avoid auto-touching shifted siblings
+            const fieldInstance = this.fieldInfo[nestedField]?.instance
+            if (fieldInstance) {
+              return fieldInstance.validate(cause)
+            }
+            return this.validateField(nestedField, cause)
+          }),
         )
       })
     })


### PR DESCRIPTION
### What changed

In `validateArrayFieldsStartingFrom`, fields with an existing instance now call `fieldInstance.validate(cause)` directly instead of going through `this.validateField()`. This avoids the auto-touch side-effect in `validateField` that marks fields as touched even when the user never interacted with them.

### Why

Calling `form.removeValue(index)` on an array field was flipping `isTouched` to `true` on every sibling at index ≥ removed index. The bug lives in `validateField` which auto-touches any field that has an instance but isn't yet touched.

### How to reproduce

1. Create a form with an array field
2. Call `form.removeValue(0)` without interacting with other fields
3. Observe that `isTouched` becomes `true` on all shifted siblings

Closes #2131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation behavior for array fields so removing or reordering items no longer incorrectly marks sibling fields as “touched.”
  * Preserves fields' prior touched state when validating already-mounted nested fields, reducing unexpected validation side effects during array operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->