### PR TITLE
fix(form-core): clear stale onMount error on linked-field revalidation

### DIFF
--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -1735,17 +1735,28 @@ export class FieldApi<
 
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (field.state.meta.errorMap?.[errorMapKey] !== newErrorValue) {
-          field.setMeta((prev) => ({
-            ...prev,
-            errorMap: {
+          field.setMeta((prev) => {
+            const nextErrorMap = {
               ...prev.errorMap,
               [errorMapKey]: newErrorValue,
-            },
-            errorSourceMap: {
-              ...prev.errorSourceMap,
-              [errorMapKey]: newSource,
-            },
-          }))
+            }
+            // Clear stale onMount error when a later validator confirms the field is valid
+            if (
+              !newErrorValue &&
+              errorMapKey !== 'onMount' &&
+              prev.errorMap.onMount
+            ) {
+              nextErrorMap.onMount = undefined
+            }
+            return {
+              ...prev,
+              errorMap: nextErrorMap,
+              errorSourceMap: {
+                ...prev.errorSourceMap,
+                [errorMapKey]: newSource,
+              },
+            }
+          })
         }
         if (newErrorValue) {
           hasErrored = true
@@ -1934,13 +1945,22 @@ export class FieldApi<
           }
 
           field.setMeta((prev) => {
+            const nextErrorMap = {
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+              ...prev?.errorMap,
+              [errorMapKey]: newErrorValue,
+            }
+            // Clear stale onMount error when a later validator confirms the field is valid
+            if (
+              !newErrorValue &&
+              errorMapKey !== 'onMount' &&
+              prev.errorMap.onMount
+            ) {
+              nextErrorMap.onMount = undefined
+            }
             return {
               ...prev,
-              errorMap: {
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                ...prev?.errorMap,
-                [errorMapKey]: newErrorValue,
-              },
+              errorMap: nextErrorMap,
               errorSourceMap: {
                 ...prev.errorSourceMap,
                 [errorMapKey]: newSource,


### PR DESCRIPTION
Fixes #2124

When a field has an  validator and is linked to another field via /, the onMount error was never cleared even when the linked-field validator confirmed the field was valid. This left  and  stuck.

The fix: after a sync or async validator runs on a field (or its linked field) and reports no error, if an  entry is present, clear it — the later validation supersedes the mount-time check. Same pattern already used for clearing submit errors on change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced form field validation to properly manage error states during synchronous and asynchronous validation cycles, ensuring outdated errors are cleared when fields become valid.
  * Improved error cleanup logic to prevent stale validation messages from one validation run from persisting into subsequent validation attempts, resulting in more accurate field status displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->