### PR TITLE
test: replaceFieldValue should clear onMount errors

### DIFF
--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -366,6 +366,92 @@ describe('form api', () => {
     expect(form.getFieldValue('names')).toStrictEqual(['one', 'two', 'three'])
   })
 
+  it("should clean onMount errors when replacing an array field's value", async () => {
+    const form = new FormApi({
+      defaultValues: {
+        people: [
+          {
+            firstName: '',
+            lastName: '',
+          },
+        ],
+      },
+      validators: {
+        onMount: ({ value }) => {
+          let fieldErrors: Record<string, string> = {}
+
+          value.people.map((x, index) => {
+            if (x.firstName.length < 3) {
+              fieldErrors[`people[${index}].firstName`] =
+                'First name is too short'
+            }
+
+            if (x.lastName.length < 3) {
+              fieldErrors[`people[${index}].lastName`] =
+                'Last name is too short'
+            }
+          })
+
+          if (Object.keys(fieldErrors).length > 0) {
+            return {
+              fields: { ...fieldErrors },
+            }
+          }
+
+          return fieldErrors
+        },
+        onChange: ({ value }) => {
+          let fieldErrors: Record<string, string> = {}
+
+          value.people.map((x, index) => {
+            if (x.firstName.length < 3) {
+              fieldErrors[`people[${index}].firstName`] =
+                'First name is too short'
+            }
+
+            if (x.lastName.length < 3) {
+              fieldErrors[`people[${index}].lastName`] =
+                'Last name is too short'
+            }
+          })
+
+          if (Object.keys(fieldErrors).length > 0) {
+            return {
+              fields: { ...fieldErrors },
+            }
+          }
+
+          return fieldErrors
+        },
+      },
+    })
+    form.mount()
+
+    // Since validation runs through the field, a field must be mounted for that array
+    new FieldApi({ form, name: 'people' }).mount()
+
+    await form.replaceFieldValue('people', 0, {
+      firstName: 'Chuck',
+      lastName: 'Norris',
+    })
+
+    expect(form.state.values).toStrictEqual({
+      people: [
+        {
+          firstName: 'Chuck',
+          lastName: 'Norris',
+        },
+      ],
+    })
+    expect.soft(form.state.fieldMetaBase['people']!.errorMap).toStrictEqual({})
+    expect
+      .soft(form.state.fieldMetaBase['people[0].firstName']!.errorMap)
+      .toStrictEqual({})
+    expect
+      .soft(form.state.fieldMetaBase['people[0].firstName']!.errorSourceMap)
+      .toStrictEqual({})
+  })
+
   it("should run onChange validation when inserting an array field's value", () => {
     const form = new FormApi({
       defaultValues: {

--- a/packages/form-core/tests/standardSchemaValidator.spec.ts
+++ b/packages/form-core/tests/standardSchemaValidator.spec.ts
@@ -608,4 +608,55 @@ describe('standard schema validator', () => {
       ])
     })
   })
+
+  it("should clean onMount errors when replacing an array field's value", async () => {
+    const schema = z.object({
+      people: z.array(
+        z.object({
+          firstName: z.string().min(3),
+          lastName: z.string().min(3),
+        }),
+      ),
+    })
+
+    const form = new FormApi({
+      defaultValues: {
+        people: [
+          {
+            firstName: '',
+            lastName: '',
+          },
+        ],
+      },
+      validators: {
+        onMount: schema,
+        onChange: schema,
+      },
+    })
+    form.mount()
+
+    // Since validation runs through the field, a field must be mounted for that array
+    new FieldApi({ form, name: 'people' }).mount()
+
+    await form.replaceFieldValue('people', 0, {
+      firstName: 'Chuck',
+      lastName: 'Norris',
+    })
+
+    expect(form.state.values).toStrictEqual({
+      people: [
+        {
+          firstName: 'Chuck',
+          lastName: 'Norris',
+        },
+      ],
+    })
+    expect.soft(form.state.fieldMetaBase['people']!.errorMap).toStrictEqual({})
+    expect
+      .soft(form.state.fieldMetaBase['people[0].firstName']!.errorMap)
+      .toStrictEqual({})
+    expect
+      .soft(form.state.fieldMetaBase['people[0].firstName']!.errorSourceMap)
+      .toStrictEqual({})
+  })
 })


### PR DESCRIPTION
This is a failing test for now to showcase a bug I think I found.

https://stackblitz.com/edit/github-sn7a9r3i?file=src%2Findex.tsx

**Repro:**
- use lines 115-118 instead of lines 120-121
- Click the "Set Person Names"-Button
- 👀 Observe: fieldMetaBase["people[0].firstName"].errorMap.onMount is present

## 🎯 Changes

ToDo

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for form array field replacement operations with schema validation. Tests verify validation errors are properly cleared at both array root and nested field path levels when replacing field values, ensuring consistent and reliable error state tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->