### PR TITLE
docs(svelte): add Form Composition guide and example to site nav

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -303,6 +303,10 @@
             {
               "label": "Linked Fields",
               "to": "framework/svelte/guides/linked-fields"
+            },
+            {
+              "label": "Form Composition",
+              "to": "framework/svelte/guides/form-composition"
             }
           ]
         }
@@ -677,6 +681,10 @@
             {
               "label": "Standard Schema",
               "to": "framework/svelte/examples/standard-schema"
+            },
+            {
+              "label": "Form Composition",
+              "to": "framework/svelte/examples/large-form"
             }
           ]
         }


### PR DESCRIPTION
## 🎯 Changes

Add the Svelte "Form Composition" guide and "Large Form" example to the docs site navigation.

Both `docs/framework/svelte/guides/form-composition.md` and `examples/svelte/large-form/` already exist (added in #1713) but were never added to `docs/config.json`, so they don't appear on the website.

This brings Svelte in line with React, Angular, and Solid which all have their Form Composition guide and example listed.

### Note: other orphaned docs

While investigating this, I found **39 total doc files** across all frameworks that exist on disk but aren't wired into `docs/config.json`. This PR only addresses the Svelte gaps, but here's the full picture:

**Guides missing from nav:**
- `angular/guides/listeners.md`
- `angular/guides/submission-handling.md`
- `solid/guides/devtools.md`
- `solid/guides/submission-handling.md`
- `vue/guides/listeners.md`
- `vue/guides/submission-handling.md`

**Auto-generated API reference docs missing from nav (32 files):**
Spread across React (13), Solid (13), Angular (3), and Vue (4) — mostly newer API surface like `createFormHook`, `WithFormProps`, `useFieldGroup`, etc.

Happy to open follow-up PRs for those if helpful.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] This change is docs/CI/dev-only (no release).

---

### 💡 Idea: prevent orphaned docs in the future

The existing `test:docs` script (`scripts/verify-links.ts`) checks that links inside markdown files are valid, but it doesn't check the reverse — that doc files on disk have a corresponding entry in `docs/config.json`. That's how these slipped through.

A small addition to `verify-links.ts` (or a separate script added to the `test:docs` target) could catch this:

```ts
// For each .md in docs/framework/*, ensure it has a matching "to" in config.json
const configPaths = new Set(extractAllToPaths('docs/config.json'))
const docFiles = glob('docs/framework/**/*.md')

for (const file of docFiles) {
  const configPath = file.replace('docs/', '').replace('.md', '')
  if (!configPaths.has(configPath)) {
    console.warn(`Orphaned doc: ${file} has no entry in docs/config.json`)
  }
}
```

Would that be useful? Happy to open a follow-up PR if so.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new Form Composition guide to Svelte documentation.
  * Added large form example to Svelte resources.
  * Updated navigation to include new guides and examples for developers building forms with Svelte.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->