### PR TITLE
docs(react-form): show how to render formErrorMap.onChange when using Standard Schema

### DIFF
--- a/docs/framework/react/guides/validation.md
+++ b/docs/framework/react/guides/validation.md
@@ -221,17 +221,19 @@ export default function App() {
 _Note:_ The example above uses a function validator that returns a `string`. When using a [Standard Schema](#standard-schema-libraries) validator (Zod, Valibot, ArkType, Effect/Schema), `state.errorMap.onChange` is typed as `Record<string, StandardSchemaV1Issue[]>` instead, keyed by field name. Iterate the record to render the messages:
 
 ```tsx
-{formErrorMap.onChange ? (
-  <div>
-    <em>
-      There was an error on the form:{' '}
-      {Object.values(formErrorMap.onChange)
-        .flat()
-        .map((issue) => issue.message)
-        .join(', ')}
-    </em>
-  </div>
-) : null}
+{
+  formErrorMap.onChange ? (
+    <div>
+      <em>
+        There was an error on the form:{' '}
+        {Object.values(formErrorMap.onChange)
+          .flat()
+          .map((issue) => issue.message)
+          .join(', ')}
+      </em>
+    </div>
+  ) : null
+}
 ```
 
 ### Setting field-level errors from the form's validators

--- a/docs/framework/react/guides/validation.md
+++ b/docs/framework/react/guides/validation.md
@@ -218,6 +218,22 @@ export default function App() {
 }
 ```
 
+_Note:_ The example above uses a function validator that returns a `string`. When using a [Standard Schema](#standard-schema-libraries) validator (Zod, Valibot, ArkType, Effect/Schema), `state.errorMap.onChange` is typed as `Record<string, StandardSchemaV1Issue[]>` instead, keyed by field name. Iterate the record to render the messages:
+
+```tsx
+{formErrorMap.onChange ? (
+  <div>
+    <em>
+      There was an error on the form:{' '}
+      {Object.values(formErrorMap.onChange)
+        .flat()
+        .map((issue) => issue.message)
+        .join(', ')}
+    </em>
+  </div>
+) : null}
+```
+
 ### Setting field-level errors from the form's validators
 
 You can set errors on the fields from the form's validators. One common use case for this is validating all the fields on submit by calling a single API endpoint in the form's `onSubmitAsync` validator.


### PR DESCRIPTION
## Changes

Closes #1564.

The form-level error rendering example uses a function validator that returns a `string`. With a Standard Schema validator (Zod, Valibot, ArkType, Effect/Schema), `errorMap.onChange` is `Record<string, StandardSchemaV1Issue[]>` instead, so the existing JSX cannot render it directly. Adds a note after the example with the iteration pattern for that case.

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified validation guide to explain differences in error shape between validator types.
  * Replaced single-value example with an iteration-based example showing how to flatten and join per-field validation messages for clearer error rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->