### PR TITLE
fix(form-core): treat non-plain objects with no own enumerable keys as unequal in evaluate

### DIFF
--- a/.changeset/fix-evaluate-getter-only-objects.md
+++ b/.changeset/fix-evaluate-getter-only-objects.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/form-core': patch
+---
+
+`evaluate()` incorrectly treated distinct non-plain objects with no own enumerable keys (Temporal types, RegExp, getter-only class instances) as equal because the key-iteration loop vacuously succeeded. A guard now returns `false` for such objects, falling back to referential inequality.

--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -464,6 +464,20 @@ export function evaluate<T>(objA: T, objB: T) {
     return false
   }
 
+  // Two distinct non-plain, non-array objects with no own enumerable keys cannot
+  // be compared by key iteration — the loop below would vacuously succeed and
+  // treat them as equal regardless of their internal state. This covers Temporal
+  // types, RegExp, and any class that exposes values only through getters.
+  if (
+    keysA.length === 0 &&
+    !Array.isArray(objA) &&
+    !Array.isArray(objB) &&
+    (Object.getPrototypeOf(objA) !== Object.prototype ||
+      Object.getPrototypeOf(objB) !== Object.prototype)
+  ) {
+    return false
+  }
+
   for (const key of keysA) {
     // performs recursive search down the object tree
 

--- a/packages/form-core/tests/utils.spec.ts
+++ b/packages/form-core/tests/utils.spec.ts
@@ -753,6 +753,41 @@ describe('evaluate', () => {
     const setB = new Set([1, 2, 4])
     expect(evaluate(setA, setB)).toEqual(false)
   })
+
+  it('should treat distinct non-plain objects with no own enumerable keys as not equal', () => {
+    // Simulates Temporal.Duration, RegExp, or any class that exposes state only
+    // through getters. Object.keys() returns [] for these, so without this guard
+    // the key-iteration loop would vacuously succeed and return true.
+    class Duration {
+      #ms: number
+      constructor(ms: number) {
+        this.#ms = ms
+      }
+      get milliseconds() {
+        return this.#ms
+      }
+    }
+
+    const d1 = new Duration(1000)
+    const d2 = new Duration(2000)
+    const d3 = new Duration(1000)
+    const dSame = d1
+
+    expect(evaluate(d1, dSame)).toEqual(true) // same reference
+    expect(evaluate(d1, d2)).toEqual(false) // different instances, different state
+    expect(evaluate(d1, d3)).toEqual(false) // different instances, same state — still false
+  })
+
+  it('should still treat two plain empty objects as equal', () => {
+    expect(evaluate({}, {})).toEqual(true)
+    expect(evaluate({ a: {} }, { a: {} })).toEqual(true)
+  })
+
+  it('should treat a non-plain object against a plain empty object as not equal', () => {
+    class Empty {}
+    expect(evaluate(new Empty(), {})).toEqual(false)
+    expect(evaluate({}, new Empty())).toEqual(false)
+  })
 })
 
 describe('concatenatePaths', () => {


### PR DESCRIPTION
## 🎯 Changes

Fixes #1628.

`evaluate()` compares objects by iterating `Object.keys()`. That works fine for plain objects, but for anything whose state lives only in getters, `Object.keys()` returns `[]`. The key-iteration loop then vacuously succeeds and two distinct instances are treated as equal, regardless of what they actually contain. `Temporal.Duration`, `RegExp`, any class that exposes values through getters — they all hit this. The result is that form updates get dropped silently when a field value changes to a new instance of such a type.

The fix is a single guard placed after the key-count check:

```ts
if (
  keysA.length === 0 &&
  !Array.isArray(objA) &&
  !Array.isArray(objB) &&
  (Object.getPrototypeOf(objA) !== Object.prototype ||
    Object.getPrototypeOf(objB) !== Object.prototype)
) {
  return false
}
```

When both objects have zero own enumerable keys and at least one isn't a plain `{}`, they fall back to referential inequality (`Object.is` at the top already returned `false`). Arrays get an explicit carve-out so `evaluate([], [])` still returns `true`.

PR #1939 adds a specific `instanceof Blob` guard for `File`/`Blob`. This guard is more general and covers the same case, plus `Temporal`, `RegExp`, `Error`, and anything else with a getter-only design. If #1939 merges first, its `instanceof Blob` check fires before reaching this one, so there's no conflict. If this merges first, `File`/`Blob` is already covered.

One thing to flag: two `RegExp` literals with identical source and flags (like `/abc/g` vs `/abc/g`) now return `false`, since they're different instances. Previously they returned `true` vacuously, which was also wrong: it suppressed updates when a regex field actually changed. The behavior is now in the right direction. A dedicated `instanceof RegExp` handler (like the existing `Date` one) could add semantic equality if that turns out to be useful.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed form validation comparison logic that was incorrectly treating distinct non-plain objects as equivalent. This affected special object types including Temporal, RegExp, and classes with getter-only properties.
  * Strengthened test coverage to ensure accurate object comparison behavior across all supported object types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->