### PR TITLE
Fixed Vue's Subscribe component `v-slot` type when using `selector`

### DIFF
--- a/.changeset/ninety-ducks-design.md
+++ b/.changeset/ninety-ducks-design.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/vue-form': patch
+---
+
+Make subscribe component accept the selector type properly

--- a/packages/vue-form/src/useForm.tsx
+++ b/packages/vue-form/src/useForm.tsx
@@ -103,21 +103,7 @@ type SubscribeComponent<
     false,
     {},
     SlotsType<{
-      default: NoInfer<
-        FormState<
-          TParentData,
-          TFormOnMount,
-          TFormOnChange,
-          TFormOnChangeAsync,
-          TFormOnBlur,
-          TFormOnBlurAsync,
-          TFormOnSubmit,
-          TFormOnSubmitAsync,
-          TFormOnDynamic,
-          TFormOnDynamicAsync,
-          TFormOnServer
-        >
-      >
+      default: TSelected
     }>
   >
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Subscribe component to correctly accept and reflect selector types in its slot payload, improving type accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->