### PR TITLE
feat: add ability to get form type from Svelte

### DIFF
--- a/.changeset/tasty-turkeys-jump.md
+++ b/.changeset/tasty-turkeys-jump.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/svelte-form': minor
+---
+
+Add ability to get form type from Svelte

--- a/docs/framework/svelte/guides/form-composition.md
+++ b/docs/framework/svelte/guides/form-composition.md
@@ -148,7 +148,7 @@ import { createFormCreator } from '@tanstack/svelte-form'
 import TextField from './text-field.svelte'
 import SubscribeButton from './subscribe-button.svelte'
 
-export const { createAppForm } = createFormCreator({
+export const { createAppForm, getFormType } = createFormCreator({
   fieldComponents: {
     TextField,
   },
@@ -200,12 +200,12 @@ export const peopleFormOpts = formOptions({
 ```svelte
 <!-- child-form.svelte -->
 <script lang="ts">
-  import type { createAppForm } from './form.js'
+  import { getFormType } from './form.js'
   import { peopleFormOpts } from './shared-form.js'
 
-  type AppForm = ReturnType<typeof createAppForm<typeof peopleFormOpts.defaultValues>>
+  const formType = getFormType({ ...peopleFormOpts })
 
-  const { form, title = 'Child Form' }: { form: AppForm; title?: string } = $props()
+  const { form, title = 'Child Form' }: { form: typeof formType; title?: string } = $props()
 </script>
 
 <div>
@@ -237,6 +237,52 @@ export const peopleFormOpts = formOptions({
 
 <ChildForm {form} title="Testing" />
 ```
+
+## Getting the Form Type
+
+When you split a form into smaller child components, those child components need a typed `form` prop so that `form.AppField`, `form.AppForm`, and the registered field/form components remain fully type-safe. Writing out the full `createAppForm` generics by hand is verbose and error-prone.
+
+`createFormCreator` returns a `getFormType` helper alongside `createAppForm` for exactly this purpose. It accepts the same options object as `createAppForm` and returns a value whose type matches the form instance that `createAppForm` would produce — without actually running any logic at runtime.
+
+```ts
+// form.ts
+import { createFormCreator } from '@tanstack/svelte-form'
+import TextField from './text-field.svelte'
+import SubscribeButton from './subscribe-button.svelte'
+
+export const { createAppForm, getFormType } = createFormCreator({
+  fieldComponents: {
+    TextField,
+  },
+  formComponents: {
+    SubscribeButton,
+  },
+})
+```
+
+Use it together with your shared `formOptions` to derive the expected `form` prop type:
+
+```svelte
+<!-- child-form.svelte -->
+<script lang="ts">
+  import { getFormType } from './form.js'
+  import { peopleFormOpts } from './shared-form.js'
+
+  const formType = getFormType({ ...peopleFormOpts })
+
+  const { form }: { form: typeof formType } = $props()
+</script>
+
+<form.AppField name="firstName">
+  {#snippet children(field)}
+    <field.TextField label="First Name" />
+  {/snippet}
+</form.AppField>
+```
+
+This gives the child component a fully typed `form` prop — including the registered `fieldComponents` and `formComponents` — without having to repeat the form generics by hand or maintain a `ReturnType<typeof createAppForm<...>>` alias.
+
+> `useFormContext` is still the best fit for registered form components rendered inside `form.AppForm`. Use `getFormType` when you pass the form instance down as a prop to a child component.
 
 ## Reusing groups of fields in multiple forms
 
@@ -363,7 +409,7 @@ import { createFormCreator } from '@tanstack/svelte-form'
 import TextField from '../components/text-field.svelte'
 import SubscribeButton from '../components/subscribe-button.svelte'
 
-export const { createAppForm } = createFormCreator({
+export const { createAppForm, getFormType } = createFormCreator({
   fieldComponents: {
     TextField,
   },
@@ -437,7 +483,7 @@ import { createFormCreator } from '@tanstack/svelte-form'
 import TextField from '../components/text-field.svelte'
 import SubscribeButton from '../components/subscribe-button.svelte'
 
-export const { createAppForm } = createFormCreator({
+export const { createAppForm, getFormType } = createFormCreator({
   fieldComponents: {
     TextField,
   },
@@ -462,12 +508,12 @@ export const peopleFormOpts = formOptions({
 ```svelte
 <!-- /src/features/people/child-form.svelte, to be used in the `people` page -->
 <script lang="ts">
-  import type { createAppForm } from '../../utils/form.js'
+  import { getFormType } from '../../utils/form.js'
   import { peopleFormOpts } from './shared-form.js'
 
-  type AppForm = ReturnType<typeof createAppForm<typeof peopleFormOpts.defaultValues>>
+  const formType = getFormType({ ...peopleFormOpts })
 
-  const { form, title = 'Child Form' }: { form: AppForm; title?: string } = $props()
+  const { form, title = 'Child Form' }: { form: typeof formType; title?: string } = $props()
 </script>
 
 <div>

--- a/examples/svelte/large-form/src/features/people/address-fields.svelte
+++ b/examples/svelte/large-form/src/features/people/address-fields.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import type { createAppForm } from '../../runes/form.js'
+  import { getFormType } from '../../runes/form.js'
   import { peopleFormOpts } from './shared-form.js'
 
-  type AppForm = ReturnType<typeof createAppForm<typeof peopleFormOpts.defaultValues>>
+  const formType = getFormType({ ...peopleFormOpts })
 
-  const { form }: { form: AppForm } = $props()
+  const { form }: { form: typeof formType } = $props()
 </script>
 
 <div>

--- a/examples/svelte/large-form/src/features/people/emergency-contact.svelte
+++ b/examples/svelte/large-form/src/features/people/emergency-contact.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import type { createAppForm } from '../../runes/form.js'
+  import { getFormType } from '../../runes/form.js'
   import { peopleFormOpts } from './shared-form.js'
 
-  type AppForm = ReturnType<typeof createAppForm<typeof peopleFormOpts.defaultValues>>
+  const formType = getFormType({ ...peopleFormOpts })
 
-  const { form }: { form: AppForm } = $props()
+  const { form }: { form: typeof formType } = $props()
 </script>
 
 <form.AppField name="emergencyContact.fullName">

--- a/examples/svelte/large-form/src/runes/form.ts
+++ b/examples/svelte/large-form/src/runes/form.ts
@@ -2,7 +2,7 @@ import { createFormCreator } from '@tanstack/svelte-form'
 import TextField from '../components/text-field.svelte'
 import SubscribeButton from '../components/subscribe-button.svelte'
 
-export const { createAppForm } = createFormCreator({
+export const { createAppForm, getFormType } = createFormCreator({
   fieldComponents: {
     TextField,
   },

--- a/packages/svelte-form/src/createFormCreator.svelte.ts
+++ b/packages/svelte-form/src/createFormCreator.svelte.ts
@@ -267,7 +267,55 @@ export function createFormCreator<
     return extendedForm
   }
 
+  function getFormType<
+    TFormData,
+    TOnMount extends undefined | FormValidateOrFn<TFormData>,
+    TOnChange extends undefined | FormValidateOrFn<TFormData>,
+    TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+    TOnBlur extends undefined | FormValidateOrFn<TFormData>,
+    TOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+    TOnSubmit extends undefined | FormValidateOrFn<TFormData>,
+    TOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+    TOnDynamic extends undefined | FormValidateOrFn<TFormData>,
+    TOnDynamicAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+    TOnServer extends undefined | FormAsyncValidateOrFn<TFormData>,
+    TSubmitMeta,
+  >(
+    _formProps: FormOptions<
+      TFormData,
+      TOnMount,
+      TOnChange,
+      TOnChangeAsync,
+      TOnBlur,
+      TOnBlurAsync,
+      TOnSubmit,
+      TOnSubmitAsync,
+      TOnDynamic,
+      TOnDynamicAsync,
+      TOnServer,
+      TSubmitMeta
+    >,
+  ): AppFieldExtendedSvelteFormApi<
+    TFormData,
+    TOnMount,
+    TOnChange,
+    TOnChangeAsync,
+    TOnBlur,
+    TOnBlurAsync,
+    TOnSubmit,
+    TOnSubmitAsync,
+    TOnDynamic,
+    TOnDynamicAsync,
+    TOnServer,
+    TSubmitMeta,
+    TComponents,
+    TFormComponents
+  > {
+    return undefined as never
+  }
+
   return {
     createAppForm,
+    getFormType,
   }
 }


### PR DESCRIPTION
This PR adds the ability to get the type of `form` to be passed via props:

# Before

```svelte
<script lang="ts">
  import type { createAppForm } from '../../runes/form.js'
  import { peopleFormOpts } from './shared-form.js'

  type AppForm = ReturnType<typeof createAppForm<typeof peopleFormOpts.defaultValues>>

  const { form }: { form: AppForm } = $props()
</script>
```

# After

```svelte
<script lang="ts">
  import { getFormType } from '../../runes/form.js'
  import { peopleFormOpts } from './shared-form.js'

  const formType = getFormType({ ...peopleFormOpts })

  const { form }: { form: typeof formType } = $props()
</script>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new helper to derive strongly typed form props for Svelte components.

* **Documentation**
  * Updated form composition guide with a dedicated section showing how to get form types for child components and revised examples accordingly.

* **Refactor**
  * Example Svelte components and form creator exports updated to use the new helper consistently.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/form/pull/2159)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->