### PR TITLE
Port `withForm` feature to Angular Adapter

### DIFF
--- a/.changeset/swift-suns-remain.md
+++ b/.changeset/swift-suns-remain.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/angular-form': minor
+---
+
+Add tanstack-with-form API for more modular form usage

--- a/docs/framework/angular/guides/form-composition.md
+++ b/docs/framework/angular/guides/form-composition.md
@@ -168,3 +168,107 @@ export class AppComponent {
 ```
 
 > Here, the `tanstack-app-field` directive is taking the properties from `[tanstackField]` and `provide`ing them down to the `app-text-field` so that they can be more easily consumed as a component.
+
+## Breaking big forms into smaller pieces
+
+Sometimes forms get very large; it's just how it goes sometimes. While TanStack Form supports large forms well, it's never fun to work with hundreds or thousands of lines of code in a single component.
+
+To solve this, we support breaking forms into smaller pieces using the `[tanstack-with-form]` directive together with the `injectWithForm` function.
+
+The parent component owns the `form` (created via `injectForm`) and passes it down to a child component using the `tanstack-with-form` directive. The child component reads it back via `injectWithForm`, which returns a fully-typed reference to that same `FormApi` — meaning the child can render `[tanstackField]` bindings, `tanstack-app-field` components, etc. against the parent's form without needing to redeclare any generics.
+
+First, lift your shared form options out using `formOptions` so both the parent and the child can reference the same shape:
+
+```angular-ts
+// shared-form.ts
+import { formOptions } from '@tanstack/angular-form'
+
+export const peopleFormOpts = formOptions({
+  defaultValues: {
+    firstName: '',
+    lastName: '',
+  },
+})
+```
+
+Then, build a child component that consumes the form via `injectWithForm`:
+
+```angular-ts
+// child-form.component.ts
+import { Component } from '@angular/core'
+import {
+  TanStackAppField,
+  TanStackField,
+  injectWithForm,
+} from '@tanstack/angular-form'
+import { AppTextField } from './app-text-field.component'
+import { peopleFormOpts } from './shared-form'
+
+@Component({
+  selector: 'app-child-form',
+  standalone: true,
+  imports: [TanStackField, TanStackAppField, AppTextField],
+  template: `
+    <app-text-field
+      label="First name:"
+      tanstack-app-field
+      [tanstackField]="withForm.form"
+      name="firstName"
+    />
+    <app-text-field
+      label="Last name:"
+      tanstack-app-field
+      [tanstackField]="withForm.form"
+      name="lastName"
+    />
+  `,
+})
+export class ChildForm {
+  // Spreading the form options into `injectWithForm` is what gives `withForm.form`
+  // its full type inference — no generics needed.
+  withForm = injectWithForm({ ...peopleFormOpts })
+}
+```
+
+> The options passed to `injectWithForm({ ...peopleFormOpts })` are only used for type inference. They are not read at runtime; the actual `FormApi` instance comes from the ancestor `tanstack-with-form` directive.
+
+Finally, in the parent component, create the form with `injectForm` and pass it to the child via the `tanstack-with-form` directive:
+
+```angular-ts
+// app.component.ts
+import { Component } from '@angular/core'
+import {
+  TanStackWithForm,
+  injectForm,
+} from '@tanstack/angular-form'
+import { ChildForm } from './child-form.component'
+import { peopleFormOpts } from './shared-form'
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [TanStackWithForm, ChildForm],
+  template: `
+    <form (submit)="handleSubmit($event)">
+      <app-child-form tanstack-with-form [form]="form" />
+      <button type="submit">Submit</button>
+    </form>
+  `,
+})
+export class AppComponent {
+  form = injectForm({
+    ...peopleFormOpts,
+    onSubmit({ value }) {
+      console.log(value)
+    },
+  })
+
+  handleSubmit(event: SubmitEvent) {
+    event.preventDefault()
+    event.stopPropagation()
+    this.form.handleSubmit()
+  }
+}
+```
+
+This pattern lets you split a large form across many components while keeping a single source of truth for the form's state and types. Any descendant of the `tanstack-with-form` directive can call `injectWithForm({ ...peopleFormOpts })` to gain typed access to the same form instance.

--- a/examples/angular/large-form/src/app/app.component.ts
+++ b/examples/angular/large-form/src/app/app.component.ts
@@ -1,106 +1,69 @@
-import { Component, input } from '@angular/core'
+import { ChangeDetectionStrategy, Component } from '@angular/core'
 import {
   TanStackAppField,
   TanStackField,
-  injectField,
+  TanStackWithForm,
   injectForm,
   injectStore,
 } from '@tanstack/angular-form'
-import type {
-  FieldValidateAsyncFn,
-  FieldValidateFn,
-} from '@tanstack/angular-form'
-
-@Component({
-  selector: 'app-text-field',
-  standalone: true,
-  template: `
-    <label [for]="field.api.name">{{ label() }}</label>
-    <input
-      [id]="field.api.name"
-      [name]="field.api.name"
-      [value]="field.api.state.value"
-      (blur)="field.api.handleBlur()"
-      (input)="field.api.handleChange($any($event).target.value)"
-    />
-    @if (field.api.state.meta.isTouched) {
-      @for (error of field.api.state.meta.errors; track $index) {
-        <div style="color: red">
-          {{ error }}
-        </div>
-      }
-    }
-    @if (field.api.state.meta.isValidating) {
-      <p>Validating...</p>
-    }
-  `,
-})
-export class AppTextField {
-  label = input.required<string>()
-  field = injectField<string>()
-}
+import { TextField } from './components/text-field.component'
+import { AddressFields } from './features/people/address-fields.component'
+import { EmergencyContact } from './features/people/emergency-contact.component'
+import { peopleFormOpts } from './features/people/shared-form'
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [TanStackField, TanStackAppField, AppTextField],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    TanStackField,
+    TanStackAppField,
+    TanStackWithForm,
+    TextField,
+    AddressFields,
+    EmergencyContact,
+  ],
   template: `
     <form (submit)="handleSubmit($event)">
-      <div>
-        <app-text-field
-          label="First name:"
-          tanstack-app-field
-          [tanstackField]="form"
-          name="firstName"
-          [validators]="{
-            onChange: firstNameValidator,
-            onChangeAsyncDebounceMs: 500,
-            onChangeAsync: firstNameAsyncValidator,
-          }"
-        />
-      </div>
-      <div>
-        <app-text-field
-          label="Last name:"
-          tanstack-app-field
-          [tanstackField]="form"
-          name="lastName"
-        />
-      </div>
-      <button type="submit" [disabled]="!canSubmit()">
+      <h1>Personal Information</h1>
+      <app-text-field
+        label="Full Name"
+        tanstack-app-field
+        [tanstackField]="form"
+        name="fullName"
+      />
+      <app-text-field
+        label="Email"
+        tanstack-app-field
+        [tanstackField]="form"
+        name="email"
+      />
+      <app-text-field
+        label="Phone"
+        tanstack-app-field
+        [tanstackField]="form"
+        name="phone"
+      />
+
+      <app-address-fields tanstack-with-form [form]="form" />
+
+      <h2>Emergency Contact</h2>
+      <app-emergency-contact tanstack-with-form [form]="form" />
+
+      <button type="submit" [disabled]="isSubmitting()">
         {{ isSubmitting() ? '...' : 'Submit' }}
       </button>
-      <button type="reset" (click)="form.reset()">Reset</button>
     </form>
   `,
 })
 export class AppComponent {
-  firstNameValidator: FieldValidateFn<any, string, any> = ({ value }) =>
-    !value
-      ? 'A first name is required'
-      : value.length < 3
-        ? 'First name must be at least 3 characters'
-        : undefined
-
-  firstNameAsyncValidator: FieldValidateAsyncFn<any, string, any> = async ({
-    value,
-  }) => {
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-    return value.includes('error') && 'No "error" allowed in first name'
-  }
-
   form = injectForm({
-    defaultValues: {
-      firstName: '',
-      lastName: '',
-    },
-    onSubmit({ value }) {
-      // Do something with form data
-      console.log(value)
+    ...peopleFormOpts,
+    onSubmit: ({ value }) => {
+      alert(JSON.stringify(value, null, 2))
     },
   })
 
-  canSubmit = injectStore(this.form, (state) => state.canSubmit)
   isSubmitting = injectStore(this.form, (state) => state.isSubmitting)
 
   handleSubmit(event: SubmitEvent) {

--- a/examples/angular/large-form/src/app/components/text-field.component.ts
+++ b/examples/angular/large-form/src/app/components/text-field.component.ts
@@ -1,0 +1,29 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core'
+import { injectField } from '@tanstack/angular-form'
+
+@Component({
+  selector: 'app-text-field',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div>
+      <label [for]="field.api.name">
+        <div>{{ label() }}</div>
+        <input
+          [id]="field.api.name"
+          [name]="field.api.name"
+          [value]="field.api.state.value"
+          (blur)="field.api.handleBlur()"
+          (input)="field.api.handleChange($any($event).target.value)"
+        />
+      </label>
+      @for (error of field.api.state.meta.errors; track $index) {
+        <div style="color: red">{{ error }}</div>
+      }
+    </div>
+  `,
+})
+export class TextField {
+  label = input.required<string>()
+  field = injectField<string>()
+}

--- a/examples/angular/large-form/src/app/features/people/address-fields.component.ts
+++ b/examples/angular/large-form/src/app/features/people/address-fields.component.ts
@@ -1,0 +1,53 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core'
+import {
+  TanStackAppField,
+  TanStackField,
+  injectWithForm,
+} from '@tanstack/angular-form'
+import { TextField } from '../../components/text-field.component'
+import { peopleFormOpts } from './shared-form'
+
+@Component({
+  selector: 'app-address-fields',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [TanStackField, TanStackAppField, TextField],
+  template: `
+    <div>
+      <h2>Address</h2>
+      <app-text-field
+        label="Address Line 1"
+        tanstack-app-field
+        [tanstackField]="withForm.form"
+        name="address.line1"
+      />
+      <app-text-field
+        label="Address Line 2"
+        tanstack-app-field
+        [tanstackField]="withForm.form"
+        name="address.line2"
+      />
+      <app-text-field
+        label="City"
+        tanstack-app-field
+        [tanstackField]="withForm.form"
+        name="address.city"
+      />
+      <app-text-field
+        label="State"
+        tanstack-app-field
+        [tanstackField]="withForm.form"
+        name="address.state"
+      />
+      <app-text-field
+        label="ZIP Code"
+        tanstack-app-field
+        [tanstackField]="withForm.form"
+        name="address.zip"
+      />
+    </div>
+  `,
+})
+export class AddressFields {
+  withForm = injectWithForm({ ...peopleFormOpts })
+}

--- a/examples/angular/large-form/src/app/features/people/emergency-contact.component.ts
+++ b/examples/angular/large-form/src/app/features/people/emergency-contact.component.ts
@@ -1,0 +1,32 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core'
+import {
+  TanStackAppField,
+  TanStackField,
+  injectWithForm,
+} from '@tanstack/angular-form'
+import { TextField } from '../../components/text-field.component'
+import { peopleFormOpts } from './shared-form'
+
+@Component({
+  selector: 'app-emergency-contact',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [TanStackField, TanStackAppField, TextField],
+  template: `
+    <app-text-field
+      label="Full Name"
+      tanstack-app-field
+      [tanstackField]="withForm.form"
+      name="emergencyContact.fullName"
+    />
+    <app-text-field
+      label="Phone"
+      tanstack-app-field
+      [tanstackField]="withForm.form"
+      name="emergencyContact.phone"
+    />
+  `,
+})
+export class EmergencyContact {
+  withForm = injectWithForm({ ...peopleFormOpts })
+}

--- a/examples/angular/large-form/src/app/features/people/shared-form.ts
+++ b/examples/angular/large-form/src/app/features/people/shared-form.ts
@@ -1,0 +1,45 @@
+import { formOptions } from '@tanstack/angular-form'
+
+export const peopleFormOpts = formOptions({
+  defaultValues: {
+    fullName: '',
+    email: '',
+    phone: '',
+    address: {
+      line1: '',
+      line2: '',
+      city: '',
+      state: '',
+      zip: '',
+    },
+    emergencyContact: {
+      fullName: '',
+      phone: '',
+    },
+  },
+  validators: {
+    onChangeAsync: async ({ value }) => {
+      const errors = {
+        fields: {},
+      } as {
+        fields: Record<string, string>
+      }
+      if (!value.fullName) {
+        errors.fields['fullName'] = 'Full name is required'
+      }
+      if (!value.phone) {
+        errors.fields['phone'] = 'Phone is required'
+      }
+      if (!value.emergencyContact.fullName) {
+        errors.fields['emergencyContact.fullName'] =
+          'Emergency contact full name is required'
+      }
+      if (!value.emergencyContact.phone) {
+        errors.fields['emergencyContact.phone'] =
+          'Emergency contact phone is required'
+      }
+
+      return errors
+    },
+  },
+})

--- a/packages/angular-form/src/index.ts
+++ b/packages/angular-form/src/index.ts
@@ -5,3 +5,8 @@ export { injectForm } from './inject-form'
 export { TanStackField } from './tanstack-field'
 export { injectStore } from './inject-store'
 export { TanStackFieldInjectable, injectField } from './injectable'
+export { TanStackWithForm } from './with-form'
+export {
+  TanStackWithFormInjectable,
+  injectWithForm,
+} from './with-form-injectable'

--- a/packages/angular-form/src/with-form-injectable.ts
+++ b/packages/angular-form/src/with-form-injectable.ts
@@ -1,0 +1,120 @@
+import { Injectable, inject, signal } from '@angular/core'
+import { FormApi } from '@tanstack/form-core'
+import type {
+  FormAsyncValidateOrFn,
+  FormOptions,
+  FormValidateOrFn,
+} from '@tanstack/form-core'
+
+@Injectable({ providedIn: null })
+export class TanStackWithFormInjectable {
+  _form = signal<
+    FormApi<any, any, any, any, any, any, any, any, any, any, any, any>
+  >(null as never)
+}
+
+export interface TanStackWithFormRef<
+  TFormData,
+  TOnMount extends undefined | FormValidateOrFn<TFormData>,
+  TOnChange extends undefined | FormValidateOrFn<TFormData>,
+  TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnBlur extends undefined | FormValidateOrFn<TFormData>,
+  TOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnSubmit extends undefined | FormValidateOrFn<TFormData>,
+  TOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnDynamic extends undefined | FormValidateOrFn<TFormData>,
+  TOnDynamicAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnServer extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TSubmitMeta,
+> {
+  readonly form: FormApi<
+    TFormData,
+    TOnMount,
+    TOnChange,
+    TOnChangeAsync,
+    TOnBlur,
+    TOnBlurAsync,
+    TOnSubmit,
+    TOnSubmitAsync,
+    TOnDynamic,
+    TOnDynamicAsync,
+    TOnServer,
+    TSubmitMeta
+  >
+}
+
+/**
+ * Injects the form provided by an ancestor `[tanstack-with-form]` directive.
+ *
+ * Pass form options (typically the same options used to create the form) so
+ * the returned `form` is typed correctly without needing to specify generics:
+ *
+ * ```ts
+ * const withForm = injectWithForm({ ...peopleFormOpts })
+ * withForm.form // FormApi<PeopleFormData, ...>
+ * ```
+ *
+ * The options are only used for type inference and are not read at runtime.
+ */
+export function injectWithForm<
+  TFormData,
+  TOnMount extends undefined | FormValidateOrFn<TFormData>,
+  TOnChange extends undefined | FormValidateOrFn<TFormData>,
+  TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnBlur extends undefined | FormValidateOrFn<TFormData>,
+  TOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnSubmit extends undefined | FormValidateOrFn<TFormData>,
+  TOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnDynamic extends undefined | FormValidateOrFn<TFormData>,
+  TOnDynamicAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnServer extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TSubmitMeta,
+>(
+  _opts?: FormOptions<
+    TFormData,
+    TOnMount,
+    TOnChange,
+    TOnChangeAsync,
+    TOnBlur,
+    TOnBlurAsync,
+    TOnSubmit,
+    TOnSubmitAsync,
+    TOnDynamic,
+    TOnDynamicAsync,
+    TOnServer,
+    TSubmitMeta
+  >,
+): TanStackWithFormRef<
+  TFormData,
+  TOnMount,
+  TOnChange,
+  TOnChangeAsync,
+  TOnBlur,
+  TOnBlurAsync,
+  TOnSubmit,
+  TOnSubmitAsync,
+  TOnDynamic,
+  TOnDynamicAsync,
+  TOnServer,
+  TSubmitMeta
+> {
+  const injectable = inject(TanStackWithFormInjectable)
+  return {
+    get form() {
+      return injectable._form() as FormApi<
+        TFormData,
+        TOnMount,
+        TOnChange,
+        TOnChangeAsync,
+        TOnBlur,
+        TOnBlurAsync,
+        TOnSubmit,
+        TOnSubmitAsync,
+        TOnDynamic,
+        TOnDynamicAsync,
+        TOnServer,
+        TSubmitMeta
+      >
+    },
+  }
+}

--- a/packages/angular-form/src/with-form-injectable.ts
+++ b/packages/angular-form/src/with-form-injectable.ts
@@ -13,7 +13,7 @@ export class TanStackWithFormInjectable {
   >(null as never)
 }
 
-export interface TanStackWithFormRef<
+interface TanStackWithFormRef<
   TFormData,
   TOnMount extends undefined | FormValidateOrFn<TFormData>,
   TOnChange extends undefined | FormValidateOrFn<TFormData>,

--- a/packages/angular-form/src/with-form.ts
+++ b/packages/angular-form/src/with-form.ts
@@ -1,0 +1,53 @@
+import { Directive, effect, inject, input } from '@angular/core'
+import { FormApi } from '@tanstack/form-core'
+import { TanStackWithFormInjectable } from './with-form-injectable'
+import type {
+  FormAsyncValidateOrFn,
+  FormValidateOrFn,
+} from '@tanstack/form-core'
+
+@Directive({
+  selector: '[tanstack-with-form]',
+  standalone: true,
+  providers: [TanStackWithFormInjectable],
+})
+export class TanStackWithForm<
+  TFormData,
+  TOnMount extends undefined | FormValidateOrFn<TFormData>,
+  TOnChange extends undefined | FormValidateOrFn<TFormData>,
+  TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnBlur extends undefined | FormValidateOrFn<TFormData>,
+  TOnBlurAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnSubmit extends undefined | FormValidateOrFn<TFormData>,
+  TOnSubmitAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnDynamic extends undefined | FormValidateOrFn<TFormData>,
+  TOnDynamicAsync extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TOnServer extends undefined | FormAsyncValidateOrFn<TFormData>,
+  TSubmitMeta,
+> {
+  form =
+    input.required<
+      FormApi<
+        TFormData,
+        TOnMount,
+        TOnChange,
+        TOnChangeAsync,
+        TOnBlur,
+        TOnBlurAsync,
+        TOnSubmit,
+        TOnSubmitAsync,
+        TOnDynamic,
+        TOnDynamicAsync,
+        TOnServer,
+        TSubmitMeta
+      >
+    >()
+
+  base = inject(TanStackWithFormInjectable)
+
+  constructor() {
+    effect(() => {
+      this.base._form.set(this.form())
+    })
+  }
+}

--- a/packages/angular-form/tests/with-form.spec.ts
+++ b/packages/angular-form/tests/with-form.spec.ts
@@ -1,0 +1,75 @@
+import { render } from '@testing-library/angular'
+import { ChangeDetectionStrategy, Component } from '@angular/core'
+import { describe, expect, it } from 'vitest'
+import { formOptions } from '@tanstack/form-core'
+import {
+  TanStackField,
+  TanStackWithForm,
+  injectForm,
+  injectWithForm,
+} from '../src/index'
+
+describe('TanStackWithForm', () => {
+  it('should provide a form via injection to a child component with inferred types', async () => {
+    const personFormOpts = formOptions({
+      defaultValues: {
+        firstName: '',
+        lastName: 'Doe',
+      },
+    })
+
+    @Component({
+      selector: 'app-child-form',
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      standalone: true,
+      imports: [TanStackField],
+      template: `
+        <ng-container
+          [tanstackField]="withForm.form"
+          name="lastName"
+          #field="field"
+        >
+          <label [for]="field.api.name">Last name:</label>
+          <input
+            [id]="field.api.name"
+            [name]="field.api.name"
+            [value]="field.api.state.value"
+            (blur)="field.api.handleBlur()"
+            (input)="field.api.handleChange($any($event).target.value)"
+          />
+        </ng-container>
+      `,
+    })
+    class ChildForm {
+      // Types of `withForm.form` are inferred from the form options passed in.
+      withForm = injectWithForm({ ...personFormOpts })
+    }
+
+    @Component({
+      selector: 'app-root',
+      standalone: true,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      imports: [TanStackWithForm, ChildForm],
+      template: `
+        <form (submit)="handleSubmit($event)">
+          <app-child-form tanstack-with-form [form]="form" />
+        </form>
+      `,
+    })
+    class AppComponent {
+      form = injectForm({ ...personFormOpts })
+
+      handleSubmit(event: SubmitEvent) {
+        event.preventDefault()
+        event.stopPropagation()
+        this.form.handleSubmit()
+      }
+    }
+
+    const { getByLabelText } = await render(AppComponent)
+
+    const ourInput = getByLabelText('Last name:')
+    expect(ourInput).toBeInTheDocument()
+    expect(ourInput).toHaveValue('Doe')
+  })
+})


### PR DESCRIPTION
The new `tanstack-with-form` directive + `injectWithForm` helper let you split a large Angular form across multiple components without losing type safety. The parent owns the form via `injectForm`, hands it down through `[tanstack-with-form] [form]="form"`, and any child component reads it back with `injectWithForm({ ...formOpts })` — the spread options are only for type inference, so `withForm.form` is fully typed without manual generics.

```typescript
// shared-form.ts
export const personFormOpts = formOptions({
  defaultValues: { firstName: '', lastName: '' },
})

// name-fields.component.ts
@Component({
  selector: 'app-name-fields',
  imports: [TanStackField, TanStackAppField, AppTextField],
  template: `
    <app-text-field
      label="First name:"
      tanstack-app-field
      [tanstackField]="withForm.form"
      name="firstName"
    />
  `,
})
export class NameFields {
  withForm = injectWithForm({ ...personFormOpts })
}

// app.component.ts
@Component({
  selector: 'app-root',
  imports: [TanStackWithForm, NameFields],
  template: `<app-name-fields tanstack-with-form [form]="form" />`,
})
export class AppComponent {
  form = injectForm({ ...personFormOpts })
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `tanstack-with-form` directive and `injectWithForm` function for building modular forms across multiple components with full type inference support.

* **Documentation**
  * Added comprehensive guide on splitting large forms into smaller, reusable components with practical examples.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/form/pull/2163)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->