### PR TITLE
fix(solid-form): prevent full array re-renders in array mode

### DIFF
--- a/.changeset/dull-baboons-like.md
+++ b/.changeset/dull-baboons-like.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-form': patch
+---
+
+prevent full array re-renders in array mode

--- a/docs/framework/solid/guides/arrays.md
+++ b/docs/framework/solid/guides/arrays.md
@@ -83,7 +83,7 @@ function App() {
           form.handleSubmit()
         }}
       >
-        <form.Field name="people">
+        <form.Field name="people" mode="array">
           {(field) => (
             <div>
               <Show when={field().state.value.length > 0}>

--- a/examples/solid/array/src/index.tsx
+++ b/examples/solid/array/src/index.tsx
@@ -21,7 +21,7 @@ function App() {
           form.handleSubmit()
         }}
       >
-        <form.Field name="people">
+        <form.Field name="people" mode="array">
           {(field) => (
             <div>
               <Show when={field().state.value.length > 0}>

--- a/packages/solid-form/src/createField.tsx
+++ b/packages/solid-form/src/createField.tsx
@@ -18,7 +18,11 @@ import type {
 } from '@tanstack/form-core'
 
 import type { Accessor, JSX, JSXElement } from 'solid-js'
-import type { CreateFieldOptions, CreateFieldOptionsBound } from './types'
+import type {
+  CreateFieldOptions,
+  CreateFieldOptionsBound,
+  FieldOptionsMode,
+} from './types'
 
 interface SolidFieldApi<
   TParentData,
@@ -122,7 +126,8 @@ function makeFieldReactive<
       TFormOnDynamicAsync,
       TFormOnServer,
       TParentSubmitMeta
-    >,
+    > &
+    FieldOptionsMode,
 ): () => FieldApi<
   TParentData,
   TName,
@@ -163,12 +168,50 @@ function makeFieldReactive<
     TParentSubmitMeta
   > {
   const [field, setField] = createSignal(fieldApi, { equals: false })
-  // Handle shallow comparison to make sure that Derived doesn't create a new setField call every time
-  const store = useStore(fieldApi.store, (store) => store)
+  // Subscribe to the pieces of state that should trigger a re-render of the
+  // field. For array mode, we only track the length of the array value to
+  // avoid re-renders when child properties change. Meta is tracked piece by
+  // piece so that consumers re-render when any meta property updates.
+  // See: https://github.com/TanStack/form/issues/1961
+  const reactiveStateValue = useStore(fieldApi.store, (state) =>
+    mode === 'array'
+      ? Object.keys((state.value as unknown) ?? []).length
+      : state.value,
+  )
+  const reactiveMetaIsTouched = useStore(
+    fieldApi.store,
+    (state) => state.meta.isTouched,
+  )
+  const reactiveMetaIsBlurred = useStore(
+    fieldApi.store,
+    (state) => state.meta.isBlurred,
+  )
+  const reactiveMetaIsDirty = useStore(
+    fieldApi.store,
+    (state) => state.meta.isDirty,
+  )
+  const reactiveMetaErrorMap = useStore(
+    fieldApi.store,
+    (state) => state.meta.errorMap,
+  )
+  const reactiveMetaErrorSourceMap = useStore(
+    fieldApi.store,
+    (state) => state.meta.errorSourceMap,
+  )
+  const reactiveMetaIsValidating = useStore(
+    fieldApi.store,
+    (state) => state.meta.isValidating,
+  )
   // Run before initial render
   createComputed(() => {
-    // Use the store to track dependencies
-    store()
+    // Read all reactive sources to track them as dependencies
+    reactiveStateValue()
+    reactiveMetaIsTouched()
+    reactiveMetaIsBlurred()
+    reactiveMetaIsDirty()
+    reactiveMetaErrorMap()
+    reactiveMetaErrorSourceMap()
+    reactiveMetaIsValidating()
     setField(fieldApi)
   })
   return field
@@ -285,7 +328,7 @@ export function createField<
     TFormOnDynamicAsync,
     TFormOnServer,
     TParentSubmitMeta
-  >(extendedApi as never)
+  >(extendedApi as never, options.mode)
 }
 
 interface FieldComponentBoundProps<

--- a/packages/solid-form/src/createField.tsx
+++ b/packages/solid-form/src/createField.tsx
@@ -126,8 +126,8 @@ function makeFieldReactive<
       TFormOnDynamicAsync,
       TFormOnServer,
       TParentSubmitMeta
-    > &
-    FieldOptionsMode,
+    >,
+  { mode }: FieldOptionsMode,
 ): () => FieldApi<
   TParentData,
   TName,
@@ -328,7 +328,7 @@ export function createField<
     TFormOnDynamicAsync,
     TFormOnServer,
     TParentSubmitMeta
-  >(extendedApi as never, options.mode)
+  >(extendedApi as never, { mode: options.mode })
 }
 
 interface FieldComponentBoundProps<

--- a/packages/solid-form/src/types.ts
+++ b/packages/solid-form/src/types.ts
@@ -9,7 +9,10 @@ import type {
   FormValidateOrFn,
 } from '@tanstack/form-core'
 
-interface FieldOptionsMode {
+/**
+ * @private
+ */
+export interface FieldOptionsMode {
   mode?: 'value' | 'array'
 }
 

--- a/packages/solid-form/tests/createField.test.tsx
+++ b/packages/solid-form/tests/createField.test.tsx
@@ -567,4 +567,32 @@ describe('createField', () => {
     await user.click(await findByText('Submit'))
     expect(fn).toHaveBeenCalledWith({ people: [{ name: 'John', age: 0 }] })
   })
+
+  it('should support array mode', async () => {
+    function Comp() {
+      const form = createForm(() => ({
+        defaultValues: {
+          test: ['a'],
+        },
+      }))
+
+      return (
+        <form.Field name="test" mode="array">
+          {(field) => (
+            <div>
+              <div data-testid="val">{JSON.stringify(field().state.value)}</div>
+              <button onClick={() => field().pushValue('b')}>push</button>
+            </div>
+          )}
+        </form.Field>
+      )
+    }
+
+    const { getByTestId, getByText } = render(() => <Comp />)
+    expect(getByTestId('val')).toHaveTextContent('["a"]')
+    await user.click(getByText('push'))
+    await waitFor(() =>
+      expect(getByTestId('val')).toHaveTextContent('["a","b"]'),
+    )
+  })
 })


### PR DESCRIPTION
Mirrors https://github.com/TanStack/form/pull/1963/ but for the Solid.js adapter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified example to explicitly declare an array-mode field in the form guide.

* **Bug Fixes**
  * Prevented unnecessary full re-renders for array-mode fields, improving performance.

* **Tests**
  * Added test coverage validating array-mode field reactivity and updates.

* **Chores**
  * Added a patch changeset for the solid-form release.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/form/pull/2169)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->