### PR TITLE
test(preact-form): fix duplicate-word typo in test description

### DIFF
--- a/packages/preact-form/tests/useForm.test.tsx
+++ b/packages/preact-form/tests/useForm.test.tsx
@@ -484,7 +484,7 @@ describe('useForm', () => {
     expect(getByText(error)).toBeInTheDocument()
   })
 
-  it("should set field errors from the the form's onChangeAsync validator", async () => {
+  it("should set field errors from the form's onChangeAsync validator", async () => {
     function Comp() {
       const form = useForm({
         defaultValues: {


### PR DESCRIPTION
## Changes

Fix a duplicate "the" in a test description (`packages/preact-form/tests/useForm.test.tsx`).

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## Release Impact

- [x] This change is docs/CI/dev-only (no release).
