### PR TITLE
fix(form-core): clear onSubmit error for fields without associated instance

### DIFF
--- a/.changeset/salty-carpets-follow.md
+++ b/.changeset/salty-carpets-follow.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/form-core': patch
+---
+
+clear onSubmit error for fields without associated instance

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -1655,6 +1655,23 @@ export class FormApi<
     if (!fieldInstance) {
       const { hasErrored } = this.validateSync(cause)
 
+      // Clear stale onSubmit errors on this field when validation passes,
+      // mirroring what FieldApi.validateSync does for mounted fields.
+      if (!hasErrored && cause !== 'submit') {
+        const submitErrKey = getErrorMapKey('submit')
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (this.getFieldMeta(field)?.errorMap?.[submitErrKey]) {
+          this.setFieldMeta(field, (prev = defaultFieldMeta) => ({
+            ...prev,
+            errorMap: { ...prev.errorMap, [submitErrKey]: undefined },
+            errorSourceMap: {
+              ...prev.errorSourceMap,
+              [submitErrKey]: undefined,
+            },
+          }))
+        }
+      }
+
       if (hasErrored && !this.options.asyncAlways) {
         return this.getFieldMeta(field)?.errors ?? []
       }

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -2568,6 +2568,35 @@ describe('form api', () => {
     expect(form.state.errors).toStrictEqual([])
   })
 
+  it('should clear onSubmit field errors via setFieldValue without field instance mounted', async () => {
+    const validateMessage = 'first name is required'
+    const form = new FormApi({
+      defaultValues: { firstName: '' },
+      validators: {
+        onSubmit: ({ value }) => {
+          if (value.firstName.length === 0)
+            return { fields: { firstName: validateMessage } }
+          return null
+        },
+      },
+    })
+
+    form.mount()
+
+    await form.handleSubmit()
+    expect(form.state.isFieldsValid).toBe(false)
+    expect(form.state.canSubmit).toBe(false)
+    expect(form.state.fieldMeta.firstName?.errorMap.onSubmit).toBe(
+      validateMessage,
+    )
+
+    form.setFieldValue('firstName', 'John')
+
+    expect(form.state.fieldMeta.firstName?.errorMap.onSubmit).toBeUndefined()
+    expect(form.state.isFieldsValid).toBe(true)
+    expect(form.state.canSubmit).toBe(true)
+  })
+
   it('should run validators in order form sync -> field sync -> form async -> field async', async () => {
     const order: string[] = []
     const formAsyncChange = vi.fn().mockImplementation(async () => {


### PR DESCRIPTION
## 🎯 Changes

When a field does not have an associated instance (e.g. `<form.Field />`), its error map never get reset when the value is changed by `form.setFieldValue`. This PR fixes it to ensure error state is correctly updated.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
