### PR TITLE
docs(contributing): refer to package.json for pnpm version to resolve mismatch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ If you have been assigned to fix an issue or develop a new feature, please follo
   pnpm install
   ```
 
-  - We use [pnpm](https://pnpm.io/) v9 for package management (run in case of pnpm-related issues).
+  - We use [pnpm](https://pnpm.io/) for package management - please make sure to use the version mentioned in `package.json`
 
     ```bash
     corepack enable && corepack prepare


### PR DESCRIPTION
## 🎯 Changes

I noticed CONTRIBUTING.md mentions pnpm v9, while corepack (correctly) enabled v11 as that is what is configured in package.json. 

Should we refer to package.json in the documentation so single source of truth is kept for the pnpm version? Makes it similar to the instruction below about the Node version.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
