### PR TITLE
docs(lit): replace deprecated getValue() with state.value in quick-start

### DIFF
--- a/docs/framework/lit/quick-start.md
+++ b/docs/framework/lit/quick-start.md
@@ -63,7 +63,7 @@ export class TestForm extends LitElement {
               type="text"
               placeholder="First Name"
               @blur="${() => field.handleBlur()}"
-              .value="${field.getValue()}"
+              .value="${field.state.value}"
               @input="${(event: InputEvent) => {
                 if (event.currentTarget) {
                   const newValue = (event.currentTarget as HTMLInputElement)


### PR DESCRIPTION
## 🎯 Changes

Fix usage of deprecated API in the Lit quick-start guide:

- **Lit quick-start guide** (`docs/framework/lit/quick-start.md`): Replace `field.getValue()` with `field.state.value`. The `getValue()` method is marked `@deprecated` in `packages/form-core/src/FieldApi.ts` with the message "Use `field.state.value` instead". This update keeps the Lit guide consistent with the other framework guides (React, Vue, Svelte, Solid, Angular, Preact), which already use `field.state.value` in their examples.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Lit quick-start guide with revised field binding example.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/form/pull/2182)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->