### PR TITLE
docs(preact): add missing onUnmount to listeners event list

### DIFF
--- a/docs/framework/preact/guides/listeners.md
+++ b/docs/framework/preact/guides/listeners.md
@@ -19,6 +19,7 @@ Events that can be "listened" to are:
 - `onBlur`
 - `onMount`
 - `onSubmit`
+- `onUnmount`
 
 ```tsx
 function App() {


### PR DESCRIPTION
## 🎯 Changes

Add missing event to the Preact listeners guide:

- **Preact listeners guide** (`docs/framework/preact/guides/listeners.md`): Add `onUnmount` to the list of events that can be "listened" to. The `onUnmount` field listener is defined in `packages/form-core/src/FieldApi.ts` alongside `onChange`, `onBlur`, `onMount`, and `onSubmit`, and is already documented in the Angular listeners guide. This update makes the Preact guide consistent with Angular and accurately reflects the events available in the API.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Preact form listeners documentation to include `onUnmount` as an available event option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/form/pull/2183)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->