### PR TITLE
docs(vue): add Built-in Debouncing and Form listeners sections to listeners guide

### DIFF
--- a/docs/framework/vue/guides/listeners.md
+++ b/docs/framework/vue/guides/listeners.md
@@ -71,20 +71,23 @@ If you are making an API request inside a listener, you may want to debounce the
 We enable an easy method for debouncing your listeners by adding a `onChangeDebounceMs` or `onBlurDebounceMs`.
 
 ```vue
-<form.Field
-  name="country"
-  :listeners="{
-    onChangeDebounceMs: 500,
-    onChange: ({ value }) => {
-      console.log(`Country changed to: ${value} without a change within 500ms, resetting province`)
-      form.setFieldValue('province', '')
-    },
-  }"
->
-  <template v-slot="{ field }">
-    <!-- ... -->
-  </template>
-</form.Field>
+<template>
+  <!-- ... -->
+  <form.Field
+    name="country"
+    :listeners="{
+      onChangeDebounceMs: 500,
+      onChange: ({ value }) => {
+        console.log(`Country changed to: ${value} without a change within 500ms, resetting province`)
+        form.setFieldValue('province', '')
+      },
+    }"
+  >
+    <template v-slot="{ field }">
+      <!-- ... -->
+    </template>
+  </form.Field>
+</template>
 ```
 
 ### Form listeners

--- a/docs/framework/vue/guides/listeners.md
+++ b/docs/framework/vue/guides/listeners.md
@@ -64,3 +64,64 @@ const form = useForm({
   </div>
 </template>
 ```
+
+### Built-in Debouncing
+
+If you are making an API request inside a listener, you may want to debounce the calls as it can lead to performance issues.
+We enable an easy method for debouncing your listeners by adding a `onChangeDebounceMs` or `onBlurDebounceMs`.
+
+```vue
+<form.Field
+  name="country"
+  :listeners="{
+    onChangeDebounceMs: 500,
+    onChange: ({ value }) => {
+      console.log(`Country changed to: ${value} without a change within 500ms, resetting province`)
+      form.setFieldValue('province', '')
+    },
+  }"
+>
+  <template v-slot="{ field }">
+    <!-- ... -->
+  </template>
+</form.Field>
+```
+
+### Form listeners
+
+At a higher level, listeners are also available at the form level, allowing you access to the `onMount` and `onSubmit` events, and having `onChange` and `onBlur` propagated to all the form's children. Form-level listeners can also be debounced in the same way as previously discussed.
+
+`onMount` and `onSubmit` listeners have the following parameters:
+
+- `formApi`
+
+`onChange` and `onBlur` listeners have access to:
+
+- `fieldApi`
+- `formApi`
+
+```vue
+<script setup>
+import { useForm } from '@tanstack/vue-form'
+
+const form = useForm({
+  listeners: {
+    onMount: ({ formApi }) => {
+      // custom logging service
+      loggingService('mount', formApi.state.values)
+    },
+
+    onChange: ({ formApi, fieldApi }) => {
+      // autosave logic
+      if (formApi.state.isValid) {
+        formApi.handleSubmit()
+      }
+
+      // fieldApi represents the field that triggered the event.
+      console.log(fieldApi.name, fieldApi.state.value)
+    },
+    onChangeDebounceMs: 500,
+  },
+})
+</script>
+```


### PR DESCRIPTION
## 🎯 Changes

Bring the Vue listeners guide to parity with the React listeners guide:

- **Vue listeners guide** (`docs/framework/vue/guides/listeners.md`): Add two missing sections that already exist in the React and Preact guides but were absent from the Vue guide:
  - **`### Built-in Debouncing`** — documents `onChangeDebounceMs` / `onBlurDebounceMs` for field-level listeners.
  - **`### Form listeners`** — documents form-level listeners (`onMount`, `onSubmit`, `onChange`, `onBlur`). The form-level listener API is defined in `packages/form-core/src/FormApi.ts` and is re-exposed by `useForm` in `packages/vue-form/src/useForm.tsx` via `FormOptions`. Until now, Vue users had no documentation describing this capability (useful for autosave, mount-time logging, etc.).

The new content is adapted from the React guide to use Vue-idiomatic syntax (`:listeners="{ ... }"`, `<template v-slot="{ field }">`, `<script setup>`). No existing content was modified — the change is purely additive (+61 lines), bringing the Vue guide to the same length and section structure as the React guide.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Vue listener docs with guidance for debounced change and blur handlers, plus examples showing how to reset dependent fields after a delay.
  * Added a new section on form-level listeners detailing what data is available during initialization, submission, and interaction events, and a practical example configuring these listeners.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/form/pull/2184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->