### PR TITLE
fix(form-core): bump _arrayVersion when async defaultValues update array fields

### DIFF
--- a/.changeset/nine-beds-shout.md
+++ b/.changeset/nine-beds-shout.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/form-core': patch
+---
+
+Fix array async default values not updating

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -1512,6 +1512,17 @@ export class FormApi<
       )
     })
 
+    if (shouldUpdateValues) {
+      const helper = metaHelper(this)
+      for (const fieldKey of Object.keys(
+        this.fieldInfo,
+      ) as DeepKeys<TFormData>[]) {
+        if (Array.isArray(this.getFieldValue(fieldKey))) {
+          helper.bumpArrayVersion(fieldKey)
+        }
+      }
+    }
+
     formEventClient.emit('form-api', {
       id: this._formId,
       state: this.store.state,

--- a/packages/react-form/tests/useField.test.tsx
+++ b/packages/react-form/tests/useField.test.tsx
@@ -1526,6 +1526,42 @@ describe('useField', () => {
     expect(getByTestId('item-1')).toHaveTextContent('John')
   })
 
+  it('should rerender array field when async defaultValues resolve', async () => {
+    // Regression test for https://github.com/TanStack/form/issues/2178
+    // When async defaultValues arrive after initial render, array fields in
+    // mode="array" must re-render because _arrayVersion is used as the
+    // reactivity signal (not value length).
+    type Person = { name: string }
+    type FormData = { people: Person[] }
+
+    function Comp({ defaultValues }: { defaultValues?: FormData }) {
+      const form = useForm({ defaultValues })
+
+      return (
+        <form.Field name="people" mode="array">
+          {(field) => (
+            <ol data-testid="list">
+              {(field.state.value ?? []).map((person, i) => (
+                <li key={i} data-testid={`item-${i}`}>
+                  {person.name}
+                </li>
+              ))}
+            </ol>
+          )}
+        </form.Field>
+      )
+    }
+
+    const { getByTestId, rerender } = render(<Comp />)
+    expect(getByTestId('list').children).toHaveLength(0)
+
+    rerender(<Comp defaultValues={{ people: [{ name: 'Alice' }] }} />)
+    await waitFor(() =>
+      expect(getByTestId('list').children).toHaveLength(1),
+    )
+    expect(getByTestId('item-0')).toHaveTextContent('Alice')
+  })
+
   it('should handle defaultValue without setstate-in-render error', async () => {
     // Spy on console.error before rendering
     const consoleErrorSpy = vi.spyOn(console, 'error')

--- a/packages/react-form/tests/useField.test.tsx
+++ b/packages/react-form/tests/useField.test.tsx
@@ -1556,9 +1556,7 @@ describe('useField', () => {
     expect(getByTestId('list').children).toHaveLength(0)
 
     rerender(<Comp defaultValues={{ people: [{ name: 'Alice' }] }} />)
-    await waitFor(() =>
-      expect(getByTestId('list').children).toHaveLength(1),
-    )
+    await waitFor(() => expect(getByTestId('list').children).toHaveLength(1))
     expect(getByTestId('item-0')).toHaveTextContent('Alice')
   })
 

--- a/packages/react-form/tests/useField.test.tsx
+++ b/packages/react-form/tests/useField.test.tsx
@@ -1543,7 +1543,7 @@ describe('useField', () => {
             // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
             const val = field.state.value ?? []
             return (
-              <ol data-mtestid="list">
+              <ol data-testid="list">
                 {val.map((person, i) => (
                   <li key={i} data-testid={`item-${i}`}>
                     {person.name}

--- a/packages/react-form/tests/useField.test.tsx
+++ b/packages/react-form/tests/useField.test.tsx
@@ -1539,15 +1539,19 @@ describe('useField', () => {
 
       return (
         <form.Field name="people" mode="array">
-          {(field) => (
-            <ol data-testid="list">
-              {(field.state.value ?? []).map((person, i) => (
-                <li key={i} data-testid={`item-${i}`}>
-                  {person.name}
-                </li>
-              ))}
-            </ol>
-          )}
+          {(field) => {
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+            const val = field.state.value ?? []
+            return (
+              <ol data-mtestid="list">
+                {val.map((person, i) => (
+                  <li key={i} data-testid={`item-${i}`}>
+                    {person.name}
+                  </li>
+                ))}
+              </ol>
+            )
+          }}
         </form.Field>
       )
     }


### PR DESCRIPTION
Fixes #2178

When async `defaultValues` resolve and update the form, array fields rendered with `mode="array"` were not re-rendering. This is a regression from #2172 which changed the array field reactivity signal from `Object.keys(value ?? []).length` to `state.meta._arrayVersion`. The `_arrayVersion` counter is bumped on explicit mutations (push/insert/remove/swap/move) but not when `defaultValues` change asynchronously.

The fix: after the store update in `FormApi.update()`, iterate over registered fields and bump `_arrayVersion` for any whose current value is an array. Added a regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Array-mode fields now reliably update and re-render when their values change (including when async/default values are applied), fixing stale array renders.

* **Tests**
  * Added a regression test verifying array fields re-render when default values are provided after initial render.

* **Chores**
  * Added a patch changeset recording the fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/form/pull/2190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->