### PR TITLE
fix(vue-form): keep field slot state reactive

### DIFF
--- a/.changeset/vue-form-field-slot-state.md
+++ b/.changeset/vue-form-field-slot-state.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/vue-form': patch
+---
+
+Fix `Field` scoped slot `state` reactivity after field value and meta updates.

--- a/packages/vue-form/src/useField.tsx
+++ b/packages/vue-form/src/useField.tsx
@@ -375,7 +375,12 @@ export function useField<
     },
   )
 
-  return { api: extendedFieldApi.value, state: fieldState.value } as const
+  return {
+    api: extendedFieldApi.value,
+    get state() {
+      return fieldState.value
+    },
+  } as const
 }
 
 export type FieldComponentProps<

--- a/packages/vue-form/tests/useField.test.tsx
+++ b/packages/vue-form/tests/useField.test.tsx
@@ -225,6 +225,84 @@ describe('useField', () => {
     expect(getByText(error)).toBeInTheDocument()
   })
 
+  it('should keep field slot state reactive', async () => {
+    type Person = {
+      firstName: string
+    }
+
+    const serverError = 'First name is already taken'
+
+    const Comp = defineComponent(() => {
+      const form = useForm({
+        defaultValues: {
+          firstName: '',
+        } as Person,
+      })
+
+      function setServerError() {
+        form.setFieldMeta('firstName', (meta) => ({
+          ...meta,
+          errorMap: {
+            ...meta.errorMap,
+            onServer: serverError,
+          },
+          errorSourceMap: {
+            ...meta.errorSourceMap,
+            onServer: 'form',
+          },
+        }))
+      }
+
+      return () => (
+        <div>
+          <button onClick={() => form.reset({ firstName: 'Ada' })}>
+            Reset
+          </button>
+          <button onClick={setServerError}>Set server error</button>
+          <form.Field name="firstName">
+            {({
+              field,
+              state,
+            }: {
+              field: AnyFieldApi
+              state: AnyFieldApi['state']
+            }) => (
+              <div>
+                <input
+                  data-testid="fieldinput"
+                  value={state.value}
+                  onBlur={field.handleBlur}
+                  onInput={(e) =>
+                    field.handleChange((e.target as HTMLInputElement).value)
+                  }
+                />
+                <p data-testid="slotvalue">{state.value}</p>
+                <p data-testid="sloterror">{state.meta.errorMap.onServer}</p>
+              </div>
+            )}
+          </form.Field>
+        </div>
+      )
+    })
+
+    const { getByTestId, getByText } = render(Comp)
+    const input = getByTestId('fieldinput')
+
+    await user.type(input, 'Grace')
+    await waitFor(() =>
+      expect(getByTestId('slotvalue')).toHaveTextContent('Grace'),
+    )
+
+    await user.click(getByText('Reset'))
+    await waitFor(() => expect(input).toHaveValue('Ada'))
+    expect(getByTestId('slotvalue')).toHaveTextContent('Ada')
+
+    await user.click(getByText('Set server error'))
+    await waitFor(() =>
+      expect(getByTestId('sloterror')).toHaveTextContent(serverError),
+    )
+  })
+
   it('should handle arrays with subvalues', async () => {
     const fn = vi.fn()
 


### PR DESCRIPTION
## Summary

- Keep `useField().state` as a getter so Vue renders read the latest computed field state
- Add a `vue-form` regression test for the `Field` scoped slot `state`
- Add a patch changeset for `@tanstack/vue-form`

## Root cause

`useField` returned `state: fieldState.value`, which captured the field state object once during setup. `field.state` stayed reactive through its getter, but the `state` value passed to the `Field` scoped slot could become stale after value or meta updates.

Fixes #2191

## Checks

- `pnpm --filter @tanstack/vue-form test:lib -- --run`
- `pnpm --filter @tanstack/vue-form test:eslint`
- `pnpm --filter @tanstack/vue-form build`

I also verified that the new regression test fails on `main` before this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the Field component's scoped slot state wasn't updating reactively when field values or metadata changed. The slot state now properly reflects all field updates in real-time.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/form/pull/2192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->