### PR TITLE
fix(form-core): use equals() for value-type equality (Temporal, Decimal.js)

### DIFF
--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -498,6 +498,13 @@ export function evaluate<T>(objA: T, objB: T) {
     return objA.getTime() === objB.getTime()
   }
 
+  if (
+    typeof (objA as any).equals === 'function' &&
+    objA.constructor === objB.constructor
+  ) {
+    return (objA as any).equals(objB)
+  }
+
   if (objA instanceof Map && objB instanceof Map) {
     if (objA.size !== objB.size) return false
     for (const [k, v] of objA) {

--- a/packages/form-core/tests/utils.spec.ts
+++ b/packages/form-core/tests/utils.spec.ts
@@ -747,6 +747,18 @@ describe('evaluate', () => {
     expect(dateObjectFalse).toEqual(false)
   })
 
+  it('should test equality for objects with an equals() method (e.g. Temporal, Decimal.js)', () => {
+    class ValueType {
+      constructor(private val: number) {}
+      equals(other: ValueType) {
+        return this.val === other.val
+      }
+    }
+
+    expect(evaluate(new ValueType(1), new ValueType(1))).toEqual(true)
+    expect(evaluate(new ValueType(1), new ValueType(2))).toEqual(false)
+  })
+
   it('should test equality between Map objects', () => {
     const map1 = new Map([
       ['a', 1],


### PR DESCRIPTION
Fixes #2195

The `evaluate` function in form-core used key-based deep equality for all objects. This broke for value types like `Temporal` (TC39 Stage 4, now in browsers/Deno/Node) and `Decimal.js`, which have no enumerable properties — two instances with the same value would always be considered unequal.

This PR adds a duck-typed check: if both objects have the same constructor and the left-hand object has an `equals()` method, we delegate to it. This covers `Temporal.PlainDate`, `Temporal.Instant`, `Temporal.Duration`, `Decimal.js`, and similar value types.

The change is placed before the Map/Set checks and after the Date check, so more specific `instanceof` checks take precedence.

```ts
evaluate(Temporal.PlainDate.from('2026-01-01'), Temporal.PlainDate.from('2026-01-01'))
// was: false
// now: true
```

All 439 existing tests pass; 1 new test added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved equality comparison to properly handle custom objects with custom equality methods.

* **Tests**
  * Added test coverage for custom object equality comparison.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/form/pull/2197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->