### PR TITLE
test(form-core): fix duplicate-word typo in test description

### DIFF
--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -610,7 +610,7 @@ describe('field api', () => {
     ).toBe('world')
   })
 
-  it('should remove remove the last subfield from an array field correctly', async () => {
+  it('should remove the last subfield from an array field correctly', async () => {
     const form = new FormApi({
       defaultValues: {
         people: [{ name: '' }],


### PR DESCRIPTION
## Changes

Fix a duplicate "remove" in a test description (`packages/form-core/tests/FieldApi.spec.ts`).

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## Release Impact

- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Fixed test naming inconsistency in field API tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/form/pull/2199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->