### PR TITLE
fix: re-export useSelector and document useStore migration

### DIFF
--- a/.changeset/use-selector-export.md
+++ b/.changeset/use-selector-export.md
@@ -1,0 +1,9 @@
+---
+'@tanstack/react-form': patch
+'@tanstack/preact-form': patch
+'@tanstack/vue-form': patch
+'@tanstack/solid-form': patch
+'@tanstack/svelte-form': patch
+---
+
+Re-export `useSelector` from TanStack Store adapters and document migration from deprecated `useStore` (fixes #2203).

--- a/docs/framework/preact/guides/basic-concepts.md
+++ b/docs/framework/preact/guides/basic-concepts.md
@@ -236,7 +236,7 @@ function App() {
 
 ## Reactivity
 
-`@tanstack/preact-form` offers various ways to subscribe to form and field state changes, most notably the `useSelector(form.store)` hook and the `form.Subscribe` component. These methods allow you to optimize your form's rendering performance by only updating components when necessary.
+`@tanstack/preact-form` offers various ways to subscribe to form and field state changes, most notably the `useSelector(form.store, …)` hook and the `form.Subscribe` component. These methods allow you to optimize your form's rendering performance by only updating components when necessary.
 
 Example:
 
@@ -265,7 +265,7 @@ const errors = useSelector(form.store, (state) => state.errorMap)
 const store = useSelector(form.store)
 ```
 
-Note: The usage of the `useField` hook to achieve reactivity is discouraged since it is designed to be used thoughtfully within the `form.Field` component. You might want to use `useSelector(form.store)` instead.
+Note: The usage of the `useField` hook to achieve reactivity is discouraged since it is designed to be used thoughtfully within the `form.Field` component. You might want to use `useSelector(form.store, …)` instead.
 
 ## Listeners
 

--- a/docs/framework/preact/guides/basic-concepts.md
+++ b/docs/framework/preact/guides/basic-concepts.md
@@ -236,12 +236,14 @@ function App() {
 
 ## Reactivity
 
-`@tanstack/preact-form` offers various ways to subscribe to form and field state changes, most notably the `useStore(form.store)` hook and the `form.Subscribe` component. These methods allow you to optimize your form's rendering performance by only updating components when necessary.
+`@tanstack/preact-form` offers various ways to subscribe to form and field state changes, most notably the `useSelector(form.store)` hook and the `form.Subscribe` component. These methods allow you to optimize your form's rendering performance by only updating components when necessary.
 
 Example:
 
 ```tsx
-const firstName = useStore(form.store, (state) => state.values.firstName)
+import { useSelector } from '@tanstack/preact-form'
+
+const firstName = useSelector(form.store, (state) => state.values.firstName)
 //...
 <form.Subscribe
   selector={(state) => [state.canSubmit, state.isSubmitting]}
@@ -253,17 +255,17 @@ const firstName = useStore(form.store, (state) => state.values.firstName)
 />
 ```
 
-It is important to remember that while the `useStore` hook's `selector` prop is optional, it is strongly recommended to provide one, as omitting it will result in unnecessary re-renders.
+It is important to remember that while the `useSelector` hook's `selector` prop is optional, it is strongly recommended to provide one, as omitting it will result in unnecessary re-renders.
 
 ```tsx
 // Correct use
-const firstName = useStore(form.store, (state) => state.values.firstName)
-const errors = useStore(form.store, (state) => state.errorMap)
+const firstName = useSelector(form.store, (state) => state.values.firstName)
+const errors = useSelector(form.store, (state) => state.errorMap)
 // Incorrect use
-const store = useStore(form.store)
+const store = useSelector(form.store)
 ```
 
-Note: The usage of the `useField` hook to achieve reactivity is discouraged since it is designed to be used thoughtfully within the `form.Field` component. You might want to use `useStore(form.store)` instead.
+Note: The usage of the `useField` hook to achieve reactivity is discouraged since it is designed to be used thoughtfully within the `form.Field` component. You might want to use `useSelector(form.store)` instead.
 
 ## Listeners
 

--- a/docs/framework/preact/guides/form-composition.md
+++ b/docs/framework/preact/guides/form-composition.md
@@ -351,9 +351,9 @@ const FieldGroupPasswordFields = withFieldGroup({
   // Internally, you will have access to a `group` instead of a `form`
   render: function Render({ group, title }) {
     // access reactive values using the group store
-    const password = useStore(group.store, (state) => state.values.password)
+    const password = useSelector(group.store, (state) => state.values.password)
     // or the form itself
-    const isSubmitting = useStore(
+    const isSubmitting = useSelector(
       group.form.store,
       (state) => state.isSubmitting,
     )

--- a/docs/framework/preact/guides/reactivity.md
+++ b/docs/framework/preact/guides/reactivity.md
@@ -5,26 +5,24 @@ title: Reactivity
 
 Tanstack Form doesn't cause re-renders when interacting with the form. So, you might find yourself trying to use a form or field state value without success.
 
-If you would like to access reactive values, you will need to subscribe to them using one of two methods: `useStore` or the `form.Subscribe` component.
+If you would like to access reactive values, you will need to subscribe to them using one of two methods: `useSelector` or the `form.Subscribe` component.
 
 Some uses for these subscriptions are rendering up-to-date field values, determining what to render based on a condition, or using field values inside the logic of your component.
 
 > For situations where you want to "react" to triggers, check out the [listener](./listeners.md) API.
 
-## useStore
+## useSelector
 
-The `useStore` hook is perfect when you need to access form values within the logic of your component. `useStore` takes two parameters. First, the form store. Second, a selector to specify the piece of the form you wish to subscribe to.
+Import `useSelector` from `@tanstack/preact-form` when you need form values inside component logic.
 
 ```tsx
-const firstName = useStore(form.store, (state) => state.values.firstName)
-const errors = useStore(form.store, (state) => state.errorMap)
+import { useSelector } from '@tanstack/preact-form'
+
+const firstName = useSelector(form.store, (state) => state.values.firstName)
+const errors = useSelector(form.store, (state) => state.errorMap)
 ```
 
-You can access any piece of the form state in the selector.
-
-> Note, that `useStore` will cause a whole component re-render whenever the value subscribed to changes.
-
-While it IS possible to omit the selector, resist the urge as omitting it would result in many unnecessary re-renders whenever any of the form state changes.
+> **Migration:** `useStore` is still exported but deprecated; use `useSelector` with the same arguments.
 
 ## form.Subscribe
 
@@ -49,4 +47,4 @@ The `form.Subscribe` component is best suited when you need to react to somethin
 
 > The `form.Subscribe` component doesn't trigger component-level re-renders. Anytime the value subscribed to changes, only the `form.Subscribe` component re-renders.
 
-The choice between whether to use `useStore` or `form.Subscribe` mainly boils down to your use case. If you're aiming for direct UI updates based on form state, use `form.Subscribe` for its optimization perks. And if you need the reactivity within the logic, then `useStore` is the better choice.
+The choice between whether to use `useSelector` or `form.Subscribe` mainly boils down to your use case. If you're aiming for direct UI updates based on form state, use `form.Subscribe` for its optimization perks. And if you need the reactivity within the logic, then `useSelector` is the better choice.

--- a/docs/framework/preact/guides/validation.md
+++ b/docs/framework/preact/guides/validation.md
@@ -202,7 +202,7 @@ export default function App() {
 
   // Subscribe to the form's `errorMap` so that updates to it will cause re-renders
   // Alternatively, you can use `form.Subscribe`
-  const formErrorMap = useStore(form.store, (state) => state.errorMap)
+  const formErrorMap = useSelector(form.store, (state) => state.errorMap)
 
   return (
     <div>

--- a/docs/framework/preact/reference/index.md
+++ b/docs/framework/preact/reference/index.md
@@ -29,6 +29,7 @@ title: "@tanstack/preact-form"
 - [Field](variables/Field.md)
 - [FormGroup](variables/FormGroup.md)
 - [useIsomorphicLayoutEffect](variables/useIsomorphicLayoutEffect.md)
+- [useSelector](variables/useSelector.md)
 - [~~useStore~~](variables/useStore.md)
 
 ## Functions

--- a/docs/framework/preact/reference/variables/useSelector.md
+++ b/docs/framework/preact/reference/variables/useSelector.md
@@ -1,0 +1,25 @@
+---
+id: useSelector
+title: useSelector
+---
+
+# Variable: useSelector()
+
+```ts
+const useSelector: <TSource, TSelected>(source, selector?, options?) => TSelected;
+```
+
+Re-exported from `@tanstack/preact-store`. Use this hook to subscribe to slices of `form.store` inside component logic.
+
+## Example
+
+```tsx
+import { useForm, useSelector } from '@tanstack/preact-form'
+
+const form = useForm({ /* ... */ })
+const firstName = useSelector(form.store, (state) => state.values.firstName)
+```
+
+## Migration from useStore
+
+`useStore` is deprecated; import `useSelector` from `@tanstack/preact-form` instead. The API is the same aside from optional `options.compare` instead of a bare `compare` third argument.

--- a/docs/framework/preact/reference/variables/useStore.md
+++ b/docs/framework/preact/reference/variables/useStore.md
@@ -55,4 +55,8 @@ const count = useStore(counterStore, (state) => state.count)
 
 ## Deprecated
 
-Use `useSelector` instead.
+Use [`useSelector`](useSelector.md) instead. You can import it from `@tanstack/preact-form`:
+
+```tsx
+import { useSelector } from '@tanstack/preact-form'
+```

--- a/docs/framework/react/guides/basic-concepts.md
+++ b/docs/framework/react/guides/basic-concepts.md
@@ -236,12 +236,14 @@ function App() {
 
 ## Reactivity
 
-`@tanstack/react-form` offers various ways to subscribe to form and field state changes, most notably the `useStore(form.store)` hook and the `form.Subscribe` component. These methods allow you to optimize your form's rendering performance by only updating components when necessary.
+`@tanstack/react-form` offers various ways to subscribe to form and field state changes, most notably the `useSelector(form.store, …)` hook and the `form.Subscribe` component. These methods allow you to optimize your form's rendering performance by only updating components when necessary.
 
 Example:
 
 ```tsx
-const firstName = useStore(form.store, (state) => state.values.firstName)
+import { useSelector } from '@tanstack/react-form'
+
+const firstName = useSelector(form.store, (state) => state.values.firstName)
 //...
 <form.Subscribe
   selector={(state) => [state.canSubmit, state.isSubmitting]}
@@ -253,17 +255,19 @@ const firstName = useStore(form.store, (state) => state.values.firstName)
 />
 ```
 
-It is important to remember that while the `useStore` hook's `selector` prop is optional, it is strongly recommended to provide one, as omitting it will result in unnecessary re-renders.
+It is important to remember that while the `useSelector` hook's selector argument is optional, it is strongly recommended to provide one, as omitting it will result in unnecessary re-renders.
 
 ```tsx
+import { useSelector } from '@tanstack/react-form'
+
 // Correct use
-const firstName = useStore(form.store, (state) => state.values.firstName)
-const errors = useStore(form.store, (state) => state.errorMap)
+const firstName = useSelector(form.store, (state) => state.values.firstName)
+const errors = useSelector(form.store, (state) => state.errorMap)
 // Incorrect use
-const store = useStore(form.store)
+const store = useSelector(form.store)
 ```
 
-Note: The usage of the `useField` hook to achieve reactivity is discouraged since it is designed to be used thoughtfully within the `form.Field` component. You might want to use `useStore(form.store)` instead.
+Note: The usage of the `useField` hook to achieve reactivity is discouraged since it is designed to be used thoughtfully within the `form.Field` component. You might want to use `useSelector(form.store, …)` instead.
 
 ## Listeners
 

--- a/docs/framework/react/guides/form-composition.md
+++ b/docs/framework/react/guides/form-composition.md
@@ -424,9 +424,9 @@ const FieldGroupPasswordFields = withFieldGroup({
   // Internally, you will have access to a `group` instead of a `form`
   render: function Render({ group, title }) {
     // access reactive values using the group store
-    const password = useStore(group.store, (state) => state.values.password)
+    const password = useSelector(group.store, (state) => state.values.password)
     // or the form itself
-    const isSubmitting = useStore(
+    const isSubmitting = useSelector(
       group.form.store,
       (state) => state.isSubmitting,
     )

--- a/docs/framework/react/guides/reactivity.md
+++ b/docs/framework/react/guides/reactivity.md
@@ -5,26 +5,30 @@ title: Reactivity
 
 Tanstack Form doesn't cause re-renders when interacting with the form. So, you might find yourself trying to use a form or field state value without success.
 
-If you would like to access reactive values, you will need to subscribe to them using one of two methods: `useStore` or the `form.Subscribe` component.
+If you would like to access reactive values, you will need to subscribe to them using one of two methods: `useSelector` or the `form.Subscribe` component.
 
 Some uses for these subscriptions are rendering up-to-date field values, determining what to render based on a condition, or using field values inside the logic of your component.
 
 > For situations where you want to "react" to triggers, check out the [listener](./listeners.md) API.
 
-## useStore
+## useSelector
 
-The `useStore` hook is perfect when you need to access form values within the logic of your component. `useStore` takes two parameters. First, the form store. Second, a selector to specify the piece of the form you wish to subscribe to.
+The `useSelector` hook is perfect when you need to access form values within the logic of your component. Import it from `@tanstack/react-form`. It takes the form store as its first argument and a selector as its second.
 
 ```tsx
-const firstName = useStore(form.store, (state) => state.values.firstName)
-const errors = useStore(form.store, (state) => state.errorMap)
+import { useSelector } from '@tanstack/react-form'
+
+const firstName = useSelector(form.store, (state) => state.values.firstName)
+const errors = useSelector(form.store, (state) => state.errorMap)
 ```
 
 You can access any piece of the form state in the selector.
 
-> Note, that `useStore` will cause a whole component re-render whenever the value subscribed to changes.
+> Note, that `useSelector` will cause a whole component re-render whenever the value subscribed to changes.
 
 While it IS possible to omit the selector, resist the urge as omitting it would result in many unnecessary re-renders whenever any of the form state changes.
+
+> **Migration:** `useStore` is still exported but deprecated (it is an alias from `@tanstack/react-store`). Replace `useStore` with `useSelector` — same arguments, or pass `{ compare }` as the third argument instead of a bare `compare` function.
 
 ## form.Subscribe
 
@@ -49,4 +53,4 @@ The `form.Subscribe` component is best suited when you need to react to somethin
 
 > The `form.Subscribe` component doesn't trigger component-level re-renders. Anytime the value subscribed to changes, only the `form.Subscribe` component re-renders.
 
-The choice between whether to use `useStore` or `form.Subscribe` mainly boils down to your use case. If you're aiming for direct UI updates based on form state, use `form.Subscribe` for its optimization perks. And if you need the reactivity within the logic, then `useStore` is the better choice.
+The choice between whether to use `useSelector` or `form.Subscribe` mainly boils down to your use case. If you're aiming for direct UI updates based on form state, use `form.Subscribe` for its optimization perks. And if you need the reactivity within the logic, then `useSelector` is the better choice.

--- a/docs/framework/react/guides/ssr.md
+++ b/docs/framework/react/guides/ssr.md
@@ -110,7 +110,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import {
   mergeForm,
   useForm,
-  useStore,
+  useSelector,
   useTransform,
 } from '@tanstack/react-form-start'
 
@@ -128,7 +128,7 @@ function Home() {
     transform: useTransform((baseForm) => mergeForm(baseForm, state), [state]),
   })
 
-  const formErrors = useStore(form.store, (formState) => formState.errors)
+  const formErrors = useSelector(form.store, (formState) => formState.errors)
 
   return (
     <form action={handleForm.url} method="post" encType={'multipart/form-data'}>
@@ -259,7 +259,7 @@ import {
   initialFormState,
   mergeForm,
   useForm,
-  useStore,
+  useSelector,
   useTransform,
 } from '@tanstack/react-form-nextjs'
 import someAction from './action'
@@ -273,7 +273,7 @@ export const ClientComp = () => {
     transform: useTransform((baseForm) => mergeForm(baseForm, state!), [state]),
   })
 
-  const formErrors = useStore(form.store, (formState) => formState.errors)
+  const formErrors = useSelector(form.store, (formState) => formState.errors)
 
   return (
     <form action={action as never} onSubmit={() => form.handleSubmit()}>
@@ -414,7 +414,7 @@ import {
   mergeForm,
   useActionData,
   useForm,
-  useStore,
+  useSelector,
   useTransform,
 } from '@tanstack/react-form'
 import {
@@ -443,7 +443,7 @@ export default function Index() {
     ),
   })
 
-  const formErrors = useStore(form.store, (formState) => formState.errors)
+  const formErrors = useSelector(form.store, (formState) => formState.errors)
 
   return (
     <Form method="post" onSubmit={() => form.handleSubmit()}>

--- a/docs/framework/react/guides/validation.md
+++ b/docs/framework/react/guides/validation.md
@@ -202,7 +202,7 @@ export default function App() {
 
   // Subscribe to the form's `errorMap` so that updates to it will cause re-renders
   // Alternatively, you can use `form.Subscribe`
-  const formErrorMap = useStore(form.store, (state) => state.errorMap)
+  const formErrorMap = useSelector(form.store, (state) => state.errorMap)
 
   return (
     <div>

--- a/docs/framework/react/reference/index.md
+++ b/docs/framework/react/reference/index.md
@@ -28,6 +28,7 @@ title: "@tanstack/react-form"
 - [Field](variables/Field.md)
 - [FormGroup](variables/FormGroup.md)
 - [useIsomorphicLayoutEffect](variables/useIsomorphicLayoutEffect.md)
+- [useSelector](variables/useSelector.md)
 - [~~useStore~~](variables/useStore.md)
 
 ## Functions

--- a/docs/framework/react/reference/variables/useSelector.md
+++ b/docs/framework/react/reference/variables/useSelector.md
@@ -1,0 +1,53 @@
+---
+id: useSelector
+title: useSelector
+---
+
+# Variable: useSelector()
+
+```ts
+const useSelector: <TSource, TSelected>(source, selector?, options?) => TSelected;
+```
+
+Re-exported from `@tanstack/react-store`. Use this hook to subscribe to slices of `form.store` (or any TanStack Store source) inside component logic.
+
+## Parameters
+
+### source
+
+A store or atom with `get()` and `subscribe()`.
+
+### selector?
+
+`(snapshot) => TSelected` — strongly recommended; omitting it subscribes to the entire store and may cause extra re-renders.
+
+### options?
+
+- **compare?** — `(a, b) => boolean` custom equality check (defaults to `===`).
+
+## Returns
+
+`TSelected`
+
+## Example
+
+```tsx
+import { useForm, useSelector } from '@tanstack/react-form'
+
+const form = useForm({ /* ... */ })
+const firstName = useSelector(form.store, (state) => state.values.firstName)
+```
+
+## Migration from useStore
+
+`useStore` is a deprecated alias of `useSelector` with the same signature (the third argument is `compare` on `useStore`, or `options.compare` on `useSelector`):
+
+```tsx
+// Before
+import { useStore } from '@tanstack/react-form'
+const firstName = useStore(form.store, (state) => state.values.firstName)
+
+// After
+import { useSelector } from '@tanstack/react-form'
+const firstName = useSelector(form.store, (state) => state.values.firstName)
+```

--- a/docs/framework/react/reference/variables/useStore.md
+++ b/docs/framework/react/reference/variables/useStore.md
@@ -55,4 +55,8 @@ const count = useStore(counterStore, (state) => state.count)
 
 ## Deprecated
 
-Use `useSelector` instead.
+Use [`useSelector`](useSelector.md) instead. You can import it from `@tanstack/react-form`:
+
+```tsx
+import { useSelector } from '@tanstack/react-form'
+```

--- a/docs/framework/solid/guides/basic-concepts.md
+++ b/docs/framework/solid/guides/basic-concepts.md
@@ -220,12 +220,12 @@ import { z } from 'zod'
 
 ## Reactivity
 
-`@tanstack/solid-form` offers various ways to subscribe to form and field state changes, most notably the `form.useStore` hook and the `form.Subscribe` component. These methods allow you to optimize your form's rendering performance by only updating components when necessary.
+`@tanstack/solid-form` offers various ways to subscribe to form and field state changes, most notably the `form.useSelector` hook and the `form.Subscribe` component. These methods allow you to optimize your form's rendering performance by only updating components when necessary.
 
 Example:
 
 ```tsx
-const firstName = form.useStore((state) => state.values.firstName)
+const firstName = form.useSelector((state) => state.values.firstName)
 //...
 <form.Subscribe
   selector={(state) => ({

--- a/docs/framework/solid/guides/form-composition.md
+++ b/docs/framework/solid/guides/form-composition.md
@@ -264,12 +264,12 @@ const FieldGroupPasswordFields = withFieldGroup({
   // Internally, you will have access to a `group` instead of a `form`
   render: function Render(props) {
     // access reactive values using the group store
-    const password = useStore(
+    const password = useSelector(
       props.group.store,
       (state) => state.values.password,
     )
     // or the form itself
-    const isSubmitting = useStore(
+    const isSubmitting = useSelector(
       props.group.form.store,
       (state) => state.isSubmitting,
     )

--- a/docs/framework/solid/guides/validation.md
+++ b/docs/framework/solid/guides/validation.md
@@ -202,7 +202,7 @@ export default function App() {
 
   // Subscribe to the form's error map so that updates to it will render
   // alternately, you can use `form.Subscribe`
-  const formErrorMap = form.useStore((state) => state.errorMap)
+  const formErrorMap = form.useSelector((state) => state.errorMap)
 
   return (
     <div>

--- a/docs/framework/svelte/guides/basic-concepts.md
+++ b/docs/framework/svelte/guides/basic-concepts.md
@@ -220,14 +220,14 @@ Supported libraries include:
 
 ## Reactivity
 
-`@tanstack/svelte-form` offers various ways to subscribe to form and field state changes, most notably the `form.useStore` hook and the `form.Subscribe` component. These methods allow you to optimize your form's rendering performance by only updating components when necessary.
+`@tanstack/svelte-form` offers various ways to subscribe to form and field state changes, most notably the `form.useSelector` hook and the `form.Subscribe` component. These methods allow you to optimize your form's rendering performance by only updating components when necessary.
 
 Example:
 
 ```svelte
 <script>
   //...
-  const firstName = form.useStore((state) => state.values.firstName)
+  const firstName = form.useSelector((state) => state.values.firstName)
 </script>
 
 <form.Subscribe

--- a/docs/framework/svelte/guides/validation.md
+++ b/docs/framework/svelte/guides/validation.md
@@ -186,7 +186,7 @@ Example:
 
   // Subscribe to the form's error map so that updates to it will render
   // alternately, you can use `form.Subscribe`
-  const formErrorMap = form.useStore((state) => state.errorMap)
+  const formErrorMap = form.useSelector((state) => state.errorMap)
 </script>
 
 <div>

--- a/docs/framework/vue/guides/basic-concepts.md
+++ b/docs/framework/vue/guides/basic-concepts.md
@@ -240,14 +240,14 @@ const onChangeFirstName = z.string().refine(
 
 ## Reactivity
 
-`@tanstack/vue-form` offers various ways to subscribe to form and field state changes, most notably the `form.useStore` method and the `form.Subscribe` component. These methods allow you to optimize your form's rendering performance by only updating components when necessary.
+`@tanstack/vue-form` offers various ways to subscribe to form and field state changes, most notably the `form.useSelector` method and the `form.Subscribe` component. These methods allow you to optimize your form's rendering performance by only updating components when necessary.
 
 Example:
 
 ```vue
 <script setup lang="ts">
 // ...
-const firstName = form.useStore((state) => state.values.firstName)
+const firstName = form.useSelector((state) => state.values.firstName)
 </script>
 
 <template>
@@ -292,7 +292,7 @@ Example:
 
 More information can be found at [Listeners](./listeners.md)
 
-Note: The usage of the `form.useField` method to achieve reactivity is discouraged since it is designed to be used thoughtfully within the `form.Field` component. You might want to use `form.useStore` instead.
+Note: The usage of the `form.useField` method to achieve reactivity is discouraged since it is designed to be used thoughtfully within the `form.Field` component. You might want to use `form.useSelector` instead.
 
 ## Array Fields
 

--- a/docs/framework/vue/guides/validation.md
+++ b/docs/framework/vue/guides/validation.md
@@ -211,7 +211,7 @@ const form = useForm({
 
 // Subscribe to the form's error map so that updates to it will render
 // alternately, you can use `form.Subscribe`
-const formErrorMap = form.useStore((state) => state.errorMap)
+const formErrorMap = form.useSelector((state) => state.errorMap)
 </script>
 
 <template>

--- a/examples/react/large-form/src/components/text-fields.tsx
+++ b/examples/react/large-form/src/components/text-fields.tsx
@@ -1,10 +1,10 @@
-import { useStore } from '@tanstack/react-form'
+import { useSelector } from '@tanstack/react-form'
 import { useFieldContext } from '../hooks/form-context.tsx'
 
 export default function TextField({ label }: { label: string }) {
   const field = useFieldContext<string>()
 
-  const errors = useStore(field.store, (state) => state.meta.errors)
+  const errors = useSelector(field.store, (state) => state.meta.errors)
 
   return (
     <div>

--- a/examples/react/multi-step-wizard/src/components/text-fields.tsx
+++ b/examples/react/multi-step-wizard/src/components/text-fields.tsx
@@ -1,10 +1,10 @@
-import { useStore } from '@tanstack/react-form'
+import { useSelector } from '@tanstack/react-form'
 import { useFieldContext } from '../hooks/form-context.tsx'
 
 export function TextField({ label }: { label: string }) {
   const field = useFieldContext<string>()
 
-  const errors = useStore(field.store, (state) => state.meta.errors)
+  const errors = useSelector(field.store, (state) => state.meta.errors)
 
   return (
     <div>

--- a/packages/preact-form/CHANGELOG.md
+++ b/packages/preact-form/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tanstack/preact-form
 
+## 1.30.1
+
+### Patch Changes
+
+- Re-export `useSelector` from `@tanstack/preact-store` (fixes [#2203](https://github.com/TanStack/form/issues/2203)). `useStore` remains available but is deprecated.
+
 ## 1.30.0
 
 ### Minor Changes

--- a/packages/preact-form/src/index.ts
+++ b/packages/preact-form/src/index.ts
@@ -1,6 +1,6 @@
 export * from '@tanstack/form-core'
 
-export { useStore } from '@tanstack/preact-store'
+export { useSelector, useStore } from '@tanstack/preact-store'
 
 export * from './createFormHook'
 export * from './types'

--- a/packages/preact-form/src/useField.tsx
+++ b/packages/preact-form/src/useField.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'preact/hooks'
 import { FieldApi, functionalUpdate } from '@tanstack/form-core'
-import { useStore } from '@tanstack/preact-store'
+import { useSelector } from '@tanstack/preact-store'
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 import type {
   AnyFieldApi,
@@ -188,7 +188,7 @@ export function useField<
 
   // For array mode, only track length changes to avoid re-renders when child properties change
   // See: https://github.com/TanStack/form/issues/1925
-  const reactiveStateValue = useStore(
+  const reactiveStateValue = useSelector(
     fieldApi.store,
     (opts.mode === 'array'
       ? (state) => state.meta._arrayVersion || 0
@@ -196,27 +196,27 @@ export function useField<
       state: typeof fieldApi.state,
     ) => TData | number,
   )
-  const reactiveMetaIsTouched = useStore(
+  const reactiveMetaIsTouched = useSelector(
     fieldApi.store,
     (state) => state.meta.isTouched,
   )
-  const reactiveMetaIsBlurred = useStore(
+  const reactiveMetaIsBlurred = useSelector(
     fieldApi.store,
     (state) => state.meta.isBlurred,
   )
-  const reactiveMetaIsDirty = useStore(
+  const reactiveMetaIsDirty = useSelector(
     fieldApi.store,
     (state) => state.meta.isDirty,
   )
-  const reactiveMetaErrorMap = useStore(
+  const reactiveMetaErrorMap = useSelector(
     fieldApi.store,
     (state) => state.meta.errorMap,
   )
-  const reactiveMetaErrorSourceMap = useStore(
+  const reactiveMetaErrorSourceMap = useSelector(
     fieldApi.store,
     (state) => state.meta.errorSourceMap,
   )
-  const reactiveMetaIsValidating = useStore(
+  const reactiveMetaIsValidating = useSelector(
     fieldApi.store,
     (state) => state.meta.isValidating,
   )

--- a/packages/preact-form/src/useFieldGroup.tsx
+++ b/packages/preact-form/src/useFieldGroup.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'preact/hooks'
 import { FieldGroupApi, functionalUpdate } from '@tanstack/form-core'
-import { useStore } from '@tanstack/preact-store'
+import { useSelector } from '@tanstack/preact-store'
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 import type {
   AnyFieldGroupApi,
@@ -23,7 +23,7 @@ function LocalSubscribe({
   lens: AnyFieldGroupApi
   selector: (state: FieldGroupState<any>) => FieldGroupState<any>
 }>): ReturnType<FunctionComponent> {
-  const data = useStore(lens.store, selector)
+  const data = useSelector(lens.store, selector)
 
   return <>{functionalUpdate(children, data)}</>
 }

--- a/packages/preact-form/src/useForm.tsx
+++ b/packages/preact-form/src/useForm.tsx
@@ -1,6 +1,6 @@
 import { FormApi, functionalUpdate, mergeAndUpdate } from '@tanstack/form-core'
 import { useMemo, useRef, useState } from 'preact/hooks'
-import { useStore } from '@tanstack/preact-store'
+import { useSelector } from '@tanstack/preact-store'
 import { Field } from './useField'
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 import { useFormId } from './useFormId'
@@ -160,7 +160,7 @@ function LocalSubscribe({
   form: AnyFormApi
   selector: (state: AnyFormState) => AnyFormState
 }>): ReturnType<FunctionComponent> {
-  const data = useStore(form.store, selector)
+  const data = useSelector(form.store, selector)
 
   return <>{functionalUpdate(children, data)}</>
 }

--- a/packages/preact-form/src/useFormGroup.tsx
+++ b/packages/preact-form/src/useFormGroup.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'preact/hooks'
-import { useStore } from '@tanstack/preact-store'
+import { useSelector } from '@tanstack/preact-store'
 import { FormGroupApi, functionalUpdate } from '@tanstack/form-core'
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 import type {
@@ -201,71 +201,71 @@ export function useFormGroup<
     setPrevOptions({ form: opts.form, name: opts.name })
   }
 
-  const reactiveStateValue = useStore(
+  const reactiveStateValue = useSelector(
     formGroupApi.store,
     (state) => state.value,
   )
 
-  const reactiveMetaIsTouched = useStore(
+  const reactiveMetaIsTouched = useSelector(
     formGroupApi.store,
     (state) => state.meta.isTouched,
   )
-  const reactiveMetaIsBlurred = useStore(
+  const reactiveMetaIsBlurred = useSelector(
     formGroupApi.store,
     (state) => state.meta.isBlurred,
   )
-  const reactiveMetaIsDirty = useStore(
+  const reactiveMetaIsDirty = useSelector(
     formGroupApi.store,
     (state) => state.meta.isDirty,
   )
-  const reactiveMetaErrorMap = useStore(
+  const reactiveMetaErrorMap = useSelector(
     formGroupApi.store,
     (state) => state.meta.errorMap,
   )
-  const reactiveMetaErrorSourceMap = useStore(
+  const reactiveMetaErrorSourceMap = useSelector(
     formGroupApi.store,
     (state) => state.meta.errorSourceMap,
   )
-  const reactiveMetaIsValidating = useStore(
+  const reactiveMetaIsValidating = useSelector(
     formGroupApi.store,
     (state) => state.meta.isValidating,
   )
 
   // Submission lifecycle and aggregated validity now live on `state.meta`
   // (mirroring `FieldApi.state.meta`).
-  const reactiveMetaIsSubmitting = useStore(
+  const reactiveMetaIsSubmitting = useSelector(
     formGroupApi.store,
     (state) => state.meta.isSubmitting,
   )
-  const reactiveMetaIsSubmitted = useStore(
+  const reactiveMetaIsSubmitted = useSelector(
     formGroupApi.store,
     (state) => state.meta.isSubmitted,
   )
-  const reactiveMetaSubmissionAttempts = useStore(
+  const reactiveMetaSubmissionAttempts = useSelector(
     formGroupApi.store,
     (state) => state.meta.submissionAttempts,
   )
-  const reactiveMetaIsSubmitSuccessful = useStore(
+  const reactiveMetaIsSubmitSuccessful = useSelector(
     formGroupApi.store,
     (state) => state.meta.isSubmitSuccessful,
   )
-  const reactiveMetaCanSubmit = useStore(
+  const reactiveMetaCanSubmit = useSelector(
     formGroupApi.store,
     (state) => state.meta.canSubmit,
   )
-  const reactiveMetaIsValid = useStore(
+  const reactiveMetaIsValid = useSelector(
     formGroupApi.store,
     (state) => state.meta.isValid,
   )
-  const reactiveMetaIsFieldsValid = useStore(
+  const reactiveMetaIsFieldsValid = useSelector(
     formGroupApi.store,
     (state) => state.meta.isFieldsValid,
   )
-  const reactiveMetaIsFieldsValidating = useStore(
+  const reactiveMetaIsFieldsValidating = useSelector(
     formGroupApi.store,
     (state) => state.meta.isFieldsValidating,
   )
-  const reactiveMetaIsGroupValid = useStore(
+  const reactiveMetaIsGroupValid = useSelector(
     formGroupApi.store,
     (state) => state.meta.isGroupValid,
   )

--- a/packages/react-form/CHANGELOG.md
+++ b/packages/react-form/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tanstack/react-form
 
+## 1.33.1
+
+### Patch Changes
+
+- Re-export `useSelector` from `@tanstack/react-store` (fixes [#2203](https://github.com/TanStack/form/issues/2203)). `useStore` remains available but is deprecated; prefer `import { useSelector } from '@tanstack/react-form'`.
+
 ## 1.33.0
 
 ### Minor Changes

--- a/packages/react-form/src/index.ts
+++ b/packages/react-form/src/index.ts
@@ -1,6 +1,6 @@
 export * from '@tanstack/form-core'
 
-export { useStore } from '@tanstack/react-store'
+export { useSelector, useStore } from '@tanstack/react-store'
 
 export * from './createFormHook'
 export * from './types'

--- a/packages/react-form/src/useField.tsx
+++ b/packages/react-form/src/useField.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { useStore } from '@tanstack/react-store'
+import { useSelector } from '@tanstack/react-store'
 import { FieldApi, functionalUpdate } from '@tanstack/form-core'
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 import type {
@@ -190,7 +190,7 @@ export function useField<
 
   // For array mode, only track length changes to avoid re-renders when child properties change
   // See: https://github.com/TanStack/form/issues/1925
-  const reactiveStateValue = useStore(
+  const reactiveStateValue = useSelector(
     fieldApi.store,
     (opts.mode === 'array'
       ? (state) => state.meta._arrayVersion || 0
@@ -198,27 +198,27 @@ export function useField<
       state: typeof fieldApi.state,
     ) => TData | number,
   )
-  const reactiveMetaIsTouched = useStore(
+  const reactiveMetaIsTouched = useSelector(
     fieldApi.store,
     (state) => state.meta.isTouched,
   )
-  const reactiveMetaIsBlurred = useStore(
+  const reactiveMetaIsBlurred = useSelector(
     fieldApi.store,
     (state) => state.meta.isBlurred,
   )
-  const reactiveMetaIsDirty = useStore(
+  const reactiveMetaIsDirty = useSelector(
     fieldApi.store,
     (state) => state.meta.isDirty,
   )
-  const reactiveMetaErrorMap = useStore(
+  const reactiveMetaErrorMap = useSelector(
     fieldApi.store,
     (state) => state.meta.errorMap,
   )
-  const reactiveMetaErrorSourceMap = useStore(
+  const reactiveMetaErrorSourceMap = useSelector(
     fieldApi.store,
     (state) => state.meta.errorSourceMap,
   )
-  const reactiveMetaIsValidating = useStore(
+  const reactiveMetaIsValidating = useSelector(
     fieldApi.store,
     (state) => state.meta.isValidating,
   )

--- a/packages/react-form/src/useFieldGroup.tsx
+++ b/packages/react-form/src/useFieldGroup.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { useStore } from '@tanstack/react-store'
+import { useSelector } from '@tanstack/react-store'
 import { FieldGroupApi, functionalUpdate } from '@tanstack/form-core'
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 import type {
@@ -29,7 +29,7 @@ function LocalSubscribe({
   lens: AnyFieldGroupApi
   selector?: (state: FieldGroupState<any>) => FieldGroupState<any>
 }>): ReturnType<FunctionComponent> {
-  const data = useStore(lens.store, selector)
+  const data = useSelector(lens.store, selector)
 
   return <>{functionalUpdate(children, data)}</>
 }

--- a/packages/react-form/src/useForm.tsx
+++ b/packages/react-form/src/useForm.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { FormApi, functionalUpdate, mergeAndUpdate } from '@tanstack/form-core'
-import { useStore } from '@tanstack/react-store'
+import { useSelector } from '@tanstack/react-store'
 import { useMemo, useRef, useState } from 'react'
 import { Field } from './useField'
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
@@ -161,7 +161,7 @@ function LocalSubscribe({
   form: AnyFormApi
   selector?: (state: AnyFormState) => AnyFormState
 }>): ReturnType<FunctionComponent> {
-  const data = useStore(form.store, selector)
+  const data = useSelector(form.store, selector)
 
   return <>{functionalUpdate(children, data)}</>
 }

--- a/packages/react-form/src/useFormGroup.tsx
+++ b/packages/react-form/src/useFormGroup.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { useStore } from '@tanstack/react-store'
+import { useSelector } from '@tanstack/react-store'
 import { FormGroupApi, functionalUpdate } from '@tanstack/form-core'
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 import type {
@@ -203,32 +203,32 @@ export function useFormGroup<
     setPrevOptions({ form: opts.form, name: opts.name })
   }
 
-  const reactiveStateValue = useStore(
+  const reactiveStateValue = useSelector(
     formGroupApi.store,
     (state) => state.value,
   )
 
-  const reactiveMetaIsTouched = useStore(
+  const reactiveMetaIsTouched = useSelector(
     formGroupApi.store,
     (state) => state.meta.isTouched,
   )
-  const reactiveMetaIsBlurred = useStore(
+  const reactiveMetaIsBlurred = useSelector(
     formGroupApi.store,
     (state) => state.meta.isBlurred,
   )
-  const reactiveMetaIsDirty = useStore(
+  const reactiveMetaIsDirty = useSelector(
     formGroupApi.store,
     (state) => state.meta.isDirty,
   )
-  const reactiveMetaErrorMap = useStore(
+  const reactiveMetaErrorMap = useSelector(
     formGroupApi.store,
     (state) => state.meta.errorMap,
   )
-  const reactiveMetaErrorSourceMap = useStore(
+  const reactiveMetaErrorSourceMap = useSelector(
     formGroupApi.store,
     (state) => state.meta.errorSourceMap,
   )
-  const reactiveMetaIsValidating = useStore(
+  const reactiveMetaIsValidating = useSelector(
     formGroupApi.store,
     (state) => state.meta.isValidating,
   )
@@ -236,39 +236,39 @@ export function useFormGroup<
   // Submission lifecycle and aggregated validity now live on `state.meta`
   // (mirroring `FieldApi.state.meta`). Subscribe to the fields callers
   // typically read so React Compiler picks them up as dependencies.
-  const reactiveMetaIsSubmitting = useStore(
+  const reactiveMetaIsSubmitting = useSelector(
     formGroupApi.store,
     (state) => state.meta.isSubmitting,
   )
-  const reactiveMetaIsSubmitted = useStore(
+  const reactiveMetaIsSubmitted = useSelector(
     formGroupApi.store,
     (state) => state.meta.isSubmitted,
   )
-  const reactiveMetaSubmissionAttempts = useStore(
+  const reactiveMetaSubmissionAttempts = useSelector(
     formGroupApi.store,
     (state) => state.meta.submissionAttempts,
   )
-  const reactiveMetaIsSubmitSuccessful = useStore(
+  const reactiveMetaIsSubmitSuccessful = useSelector(
     formGroupApi.store,
     (state) => state.meta.isSubmitSuccessful,
   )
-  const reactiveMetaCanSubmit = useStore(
+  const reactiveMetaCanSubmit = useSelector(
     formGroupApi.store,
     (state) => state.meta.canSubmit,
   )
-  const reactiveMetaIsValid = useStore(
+  const reactiveMetaIsValid = useSelector(
     formGroupApi.store,
     (state) => state.meta.isValid,
   )
-  const reactiveMetaIsFieldsValid = useStore(
+  const reactiveMetaIsFieldsValid = useSelector(
     formGroupApi.store,
     (state) => state.meta.isFieldsValid,
   )
-  const reactiveMetaIsFieldsValidating = useStore(
+  const reactiveMetaIsFieldsValidating = useSelector(
     formGroupApi.store,
     (state) => state.meta.isFieldsValidating,
   )
-  const reactiveMetaIsGroupValid = useStore(
+  const reactiveMetaIsGroupValid = useSelector(
     formGroupApi.store,
     (state) => state.meta.isGroupValid,
   )

--- a/packages/react-form/tests/exports.test.ts
+++ b/packages/react-form/tests/exports.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+import { useSelector, useStore } from '../src'
+
+describe('package exports', () => {
+  it('exports useSelector and useStore from @tanstack/react-store', () => {
+    expect(useSelector).toBeTypeOf('function')
+    expect(useStore).toBeTypeOf('function')
+  })
+})

--- a/packages/solid-form/CHANGELOG.md
+++ b/packages/solid-form/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tanstack/solid-form
 
+## 1.33.1
+
+### Patch Changes
+
+- Re-export `useSelector` from `@tanstack/solid-store`. Add `form.useSelector`; `form.useStore` is deprecated (fixes [#2203](https://github.com/TanStack/form/issues/2203)).
+
 ## 1.33.0
 
 ### Minor Changes

--- a/packages/solid-form/src/createField.tsx
+++ b/packages/solid-form/src/createField.tsx
@@ -6,7 +6,7 @@ import {
   onCleanup,
   onMount,
 } from 'solid-js'
-import { useStore } from '@tanstack/solid-store'
+import { useSelector } from '@tanstack/solid-store'
 import type {
   DeepKeys,
   DeepValue,
@@ -173,30 +173,30 @@ function makeFieldReactive<
   // avoid re-renders when child properties change. Meta is tracked piece by
   // piece so that consumers re-render when any meta property updates.
   // See: https://github.com/TanStack/form/issues/1961
-  const reactiveStateValue = useStore(fieldApi.store, (state) =>
+  const reactiveStateValue = useSelector(fieldApi.store, (state) =>
     mode === 'array' ? state.meta._arrayVersion || 0 : state.value,
   )
-  const reactiveMetaIsTouched = useStore(
+  const reactiveMetaIsTouched = useSelector(
     fieldApi.store,
     (state) => state.meta.isTouched,
   )
-  const reactiveMetaIsBlurred = useStore(
+  const reactiveMetaIsBlurred = useSelector(
     fieldApi.store,
     (state) => state.meta.isBlurred,
   )
-  const reactiveMetaIsDirty = useStore(
+  const reactiveMetaIsDirty = useSelector(
     fieldApi.store,
     (state) => state.meta.isDirty,
   )
-  const reactiveMetaErrorMap = useStore(
+  const reactiveMetaErrorMap = useSelector(
     fieldApi.store,
     (state) => state.meta.errorMap,
   )
-  const reactiveMetaErrorSourceMap = useStore(
+  const reactiveMetaErrorSourceMap = useSelector(
     fieldApi.store,
     (state) => state.meta.errorSourceMap,
   )
-  const reactiveMetaIsValidating = useStore(
+  const reactiveMetaIsValidating = useSelector(
     fieldApi.store,
     (state) => state.meta.isValidating,
   )

--- a/packages/solid-form/src/createFieldGroup.tsx
+++ b/packages/solid-form/src/createFieldGroup.tsx
@@ -1,5 +1,5 @@
 import { FieldGroupApi, functionalUpdate } from '@tanstack/form-core'
-import { useStore } from '@tanstack/solid-store'
+import { useSelector } from '@tanstack/solid-store'
 import { onCleanup, onMount } from 'solid-js'
 import type { Component, JSX, ParentProps } from 'solid-js'
 import type {
@@ -201,7 +201,7 @@ export function createFieldGroup<
     <form.Field {...(api.getFormFieldOptions(props) as any)} />
   )
   extendedApi.Subscribe = (props) => {
-    const data = useStore(api.store, props.selector)
+    const data = useSelector(api.store, props.selector)
 
     return functionalUpdate(props.children, data()) as Element
   }

--- a/packages/solid-form/src/createForm.tsx
+++ b/packages/solid-form/src/createForm.tsx
@@ -1,6 +1,6 @@
 import { FormApi, functionalUpdate } from '@tanstack/form-core'
 import { createComputed, onMount } from 'solid-js'
-import { useStore } from '@tanstack/solid-store'
+import { useSelector } from '@tanstack/solid-store'
 import { Field, createField } from './createField'
 import { FormGroup } from './createFormGroup'
 import type {
@@ -55,6 +55,44 @@ export interface SolidFormApi<
     TFormOnServer,
     TSubmitMeta
   >
+  useSelector: <
+    TSelected = NoInfer<
+      FormState<
+        TParentData,
+        TFormOnMount,
+        TFormOnChange,
+        TFormOnChangeAsync,
+        TFormOnBlur,
+        TFormOnBlurAsync,
+        TFormOnSubmit,
+        TFormOnSubmitAsync,
+        TFormOnDynamic,
+        TFormOnDynamicAsync,
+        TFormOnServer
+      >
+    >,
+  >(
+    selector?: (
+      state: NoInfer<
+        FormState<
+          TParentData,
+          TFormOnMount,
+          TFormOnChange,
+          TFormOnChangeAsync,
+          TFormOnBlur,
+          TFormOnBlurAsync,
+          TFormOnSubmit,
+          TFormOnSubmitAsync,
+          TFormOnDynamic,
+          TFormOnDynamicAsync,
+          TFormOnServer
+        >
+      >,
+    ) => TSelected,
+  ) => () => TSelected
+  /**
+   * @deprecated Use `form.useSelector` instead.
+   */
   useStore: <
     TSelected = NoInfer<
       FormState<
@@ -234,9 +272,11 @@ export function createForm<
 
   extendedApi.Field = (props) => <Field {...props} form={api} />
   extendedApi.FormGroup = (props) => <FormGroup {...props} form={api} />
-  extendedApi.useStore = (selector) => useStore(api.store, selector)
+  extendedApi.useSelector = (selector) => useSelector(api.store, selector)
+  /** @deprecated Use `form.useSelector` instead. */
+  extendedApi.useStore = extendedApi.useSelector
   extendedApi.Subscribe = (props) =>
-    functionalUpdate(props.children, useStore(api.store, props.selector))
+    functionalUpdate(props.children, useSelector(api.store, props.selector))
 
   onMount(api.mount)
 

--- a/packages/solid-form/src/createFormGroup.tsx
+++ b/packages/solid-form/src/createFormGroup.tsx
@@ -6,7 +6,7 @@ import {
   onCleanup,
   onMount,
 } from 'solid-js'
-import { useStore } from '@tanstack/solid-store'
+import { useSelector } from '@tanstack/solid-store'
 import type {
   DeepKeys,
   DeepValue,
@@ -114,7 +114,7 @@ function makeFormGroupReactive<
 > {
   const [group, setGroup] = createSignal(formGroupApi, { equals: false })
   // Handle shallow comparison to make sure that Derived doesn't create a new setGroup call every time
-  const store = useStore(formGroupApi.store, (store) => store)
+  const store = useSelector(formGroupApi.store, (store) => store)
   // Run before initial render
   createComputed(() => {
     // Use the store to track dependencies

--- a/packages/solid-form/src/index.tsx
+++ b/packages/solid-form/src/index.tsx
@@ -1,6 +1,6 @@
 export * from '@tanstack/form-core'
 
-export { useStore } from '@tanstack/solid-store'
+export { useSelector, useStore } from '@tanstack/solid-store'
 
 export * from './createField'
 export * from './createForm'

--- a/packages/svelte-form/CHANGELOG.md
+++ b/packages/svelte-form/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tanstack/svelte-form
 
+## 1.33.1
+
+### Patch Changes
+
+- Re-export `useSelector` from `@tanstack/svelte-store`. Add `form.useSelector`; `form.useStore` is deprecated (fixes [#2203](https://github.com/TanStack/form/issues/2203)).
+
 ## 1.33.0
 
 ### Minor Changes

--- a/packages/svelte-form/src/Field.svelte
+++ b/packages/svelte-form/src/Field.svelte
@@ -8,7 +8,7 @@
     type FormAsyncValidateOrFn,
     type FormValidateOrFn,
   } from '@tanstack/form-core'
-  import { useStore } from '@tanstack/svelte-store'
+  import { useSelector } from '@tanstack/svelte-store'
   import { onMount, type Snippet } from 'svelte'
   import type { CreateFieldOptions } from './types.js'
 
@@ -96,26 +96,26 @@
       api.update(current)
     })
 
-    const storeSub = useStore(api.store, (state) =>
+    const storeSub = useSelector(api.store, (state) =>
       options.mode === 'array'
         ? state.meta._arrayVersion || 0
         : state.value,
     )
-    const metaIsTouchedSub = useStore(
+    const metaIsTouchedSub = useSelector(
       api.store,
       (state) => state.meta.isTouched,
     )
-    const metaIsBlurredSub = useStore(
+    const metaIsBlurredSub = useSelector(
       api.store,
       (state) => state.meta.isBlurred,
     )
-    const metaIsDirtySub = useStore(api.store, (state) => state.meta.isDirty)
-    const metaErrorMapSub = useStore(api.store, (state) => state.meta.errorMap)
-    const metaErrorSourceMapSub = useStore(
+    const metaIsDirtySub = useSelector(api.store, (state) => state.meta.isDirty)
+    const metaErrorMapSub = useSelector(api.store, (state) => state.meta.errorMap)
+    const metaErrorSourceMapSub = useSelector(
       api.store,
       (state) => state.meta.errorSourceMap,
     )
-    const metaIsValidatingSub = useStore(
+    const metaIsValidatingSub = useSelector(
       api.store,
       (state) => state.meta.isValidating,
     )

--- a/packages/svelte-form/src/FormGroup.svelte
+++ b/packages/svelte-form/src/FormGroup.svelte
@@ -9,7 +9,7 @@
     type FormAsyncValidateOrFn,
     type FormValidateOrFn,
   } from '@tanstack/form-core'
-  import { useStore } from '@tanstack/svelte-store'
+  import { useSelector } from '@tanstack/svelte-store'
   import { onMount, type Snippet } from 'svelte'
 
   export function createFormGroup<
@@ -108,7 +108,7 @@
       api.update(current)
     })
 
-    const storeSub = useStore(api.store)
+    const storeSub = useSelector(api.store)
     Object.defineProperty(extendedApi, 'state', {
       get() {
         return storeSub.current

--- a/packages/svelte-form/src/Subscribe.svelte
+++ b/packages/svelte-form/src/Subscribe.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { useStore } from '@tanstack/svelte-store'
+  import { useSelector } from '@tanstack/svelte-store'
 
   // Don't bother typing this out, this component is only usable through a wrapper
   interface Props {
@@ -10,7 +10,7 @@
 
   let { children, store, selector = (state) => state }: Props = $props()
 
-  const value = useStore(store, selector)
+  const value = useSelector(store, selector)
 </script>
 
 {@render children(value.current)}

--- a/packages/svelte-form/src/createForm.svelte.ts
+++ b/packages/svelte-form/src/createForm.svelte.ts
@@ -1,5 +1,5 @@
 import { FormApi } from '@tanstack/form-core'
-import { useStore } from '@tanstack/svelte-store'
+import { useSelector } from '@tanstack/svelte-store'
 import { onMount } from 'svelte'
 import Field from './Field.svelte'
 import FormGroup from './FormGroup.svelte'
@@ -64,6 +64,44 @@ export interface SvelteFormApi<
     TFormOnServer,
     TSubmitMeta
   >
+  useSelector: <
+    TSelected = NoInfer<
+      FormState<
+        TParentData,
+        TFormOnMount,
+        TFormOnChange,
+        TFormOnChangeAsync,
+        TFormOnBlur,
+        TFormOnBlurAsync,
+        TFormOnSubmit,
+        TFormOnSubmitAsync,
+        TFormOnDynamic,
+        TFormOnDynamicAsync,
+        TFormOnServer
+      >
+    >,
+  >(
+    selector?: (
+      state: NoInfer<
+        FormState<
+          TParentData,
+          TFormOnMount,
+          TFormOnChange,
+          TFormOnChangeAsync,
+          TFormOnBlur,
+          TFormOnBlurAsync,
+          TFormOnSubmit,
+          TFormOnSubmitAsync,
+          TFormOnDynamic,
+          TFormOnDynamicAsync,
+          TFormOnServer
+        >
+      >,
+    ) => TSelected,
+  ) => { current: TSelected }
+  /**
+   * @deprecated Use `form.useSelector` instead.
+   */
   useStore: <
     TSelected = NoInfer<
       FormState<
@@ -295,7 +333,9 @@ export function createForm<
   // @ts-expect-error constructor definition exists only on a type level
   extendedApi.FormGroup = (internal, props) =>
     FormGroup(internal, { ...props, form: api as never } as never)
-  extendedApi.useStore = (selector) => useStore(api.store, selector)
+  extendedApi.useSelector = (selector) => useSelector(api.store, selector)
+  /** @deprecated Use `form.useSelector` instead. */
+  extendedApi.useStore = extendedApi.useSelector
   // @ts-expect-error constructor definition exists only on a type level
   extendedApi.Subscribe = (internal, props) =>
     Subscribe(internal, { ...props, store: api.store })

--- a/packages/svelte-form/src/index.ts
+++ b/packages/svelte-form/src/index.ts
@@ -1,6 +1,6 @@
 export * from '@tanstack/form-core'
 
-export { useStore } from '@tanstack/svelte-store'
+export { useSelector, useStore } from '@tanstack/svelte-store'
 
 export { createForm, type SvelteFormApi } from './createForm.svelte.js'
 

--- a/packages/vue-form/CHANGELOG.md
+++ b/packages/vue-form/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tanstack/vue-form
 
+## 1.33.1
+
+### Patch Changes
+
+- Re-export `useSelector` from `@tanstack/vue-store`. Add `form.useSelector`; `form.useStore` is deprecated (fixes [#2203](https://github.com/TanStack/form/issues/2203)).
+
 ## 1.33.0
 
 ### Minor Changes

--- a/packages/vue-form/src/index.ts
+++ b/packages/vue-form/src/index.ts
@@ -1,5 +1,5 @@
 export * from '@tanstack/form-core'
-export { useStore } from '@tanstack/vue-store'
+export { useSelector, useStore } from '@tanstack/vue-store'
 export * from './useField'
 export * from './useForm'
 export * from './useFormGroup'

--- a/packages/vue-form/src/useField.tsx
+++ b/packages/vue-form/src/useField.tsx
@@ -1,5 +1,5 @@
 import { FieldApi } from '@tanstack/form-core'
-import { useStore } from '@tanstack/vue-store'
+import { useSelector } from '@tanstack/vue-store'
 import { computed, defineComponent, onMounted, onUnmounted, watch } from 'vue'
 import type {
   AnyFieldApi,
@@ -257,7 +257,7 @@ export function useField<
 
   // For array mode, only track length changes to avoid re-renders when child properties change
   // See: https://github.com/TanStack/form/issues/1925
-  const reactiveStateValue = useStore(
+  const reactiveStateValue = useSelector(
     fieldApi.store,
     (opts.mode === 'array'
       ? (state) => state.meta._arrayVersion || 0
@@ -265,27 +265,27 @@ export function useField<
       state: typeof fieldApi.state,
     ) => TData | number,
   )
-  const reactiveMetaIsTouched = useStore(
+  const reactiveMetaIsTouched = useSelector(
     fieldApi.store,
     (state) => state.meta.isTouched,
   )
-  const reactiveMetaIsBlurred = useStore(
+  const reactiveMetaIsBlurred = useSelector(
     fieldApi.store,
     (state) => state.meta.isBlurred,
   )
-  const reactiveMetaIsDirty = useStore(
+  const reactiveMetaIsDirty = useSelector(
     fieldApi.store,
     (state) => state.meta.isDirty,
   )
-  const reactiveMetaErrorMap = useStore(
+  const reactiveMetaErrorMap = useSelector(
     fieldApi.store,
     (state) => state.meta.errorMap,
   )
-  const reactiveMetaErrorSourceMap = useStore(
+  const reactiveMetaErrorSourceMap = useSelector(
     fieldApi.store,
     (state) => state.meta.errorSourceMap,
   )
-  const reactiveMetaIsValidating = useStore(
+  const reactiveMetaIsValidating = useSelector(
     fieldApi.store,
     (state) => state.meta.isValidating,
   )

--- a/packages/vue-form/src/useForm.tsx
+++ b/packages/vue-form/src/useForm.tsx
@@ -1,5 +1,5 @@
 import { FormApi } from '@tanstack/form-core'
-import { useStore } from '@tanstack/vue-store'
+import { useSelector } from '@tanstack/vue-store'
 import { defineComponent, h, onMounted } from 'vue'
 import { Field } from './useField'
 import { FormGroup } from './useFormGroup'
@@ -151,6 +151,44 @@ export interface VueFormApi<
     TFormOnServer,
     TSubmitMeta
   >
+  useSelector: <
+    TSelected = NoInfer<
+      FormState<
+        TParentData,
+        TFormOnMount,
+        TFormOnChange,
+        TFormOnChangeAsync,
+        TFormOnBlur,
+        TFormOnBlurAsync,
+        TFormOnSubmit,
+        TFormOnSubmitAsync,
+        TFormOnDynamic,
+        TFormOnDynamicAsync,
+        TFormOnServer
+      >
+    >,
+  >(
+    selector?: (
+      state: NoInfer<
+        FormState<
+          TParentData,
+          TFormOnMount,
+          TFormOnChange,
+          TFormOnChangeAsync,
+          TFormOnBlur,
+          TFormOnBlurAsync,
+          TFormOnSubmit,
+          TFormOnSubmitAsync,
+          TFormOnDynamic,
+          TFormOnDynamicAsync,
+          TFormOnServer
+        >
+      >,
+    ) => TSelected,
+  ) => Readonly<Ref<TSelected>>
+  /**
+   * @deprecated Use `form.useSelector` instead.
+   */
   useStore: <
     TSelected = NoInfer<
       FormState<
@@ -289,14 +327,16 @@ export function useForm<
         inheritAttrs: false,
       },
     ) as never
-    extendedApi.useStore = (selector) => {
-      return useStore(api.store as never, selector as never) as never
-    }
+    const subscribeToStore = (selector?: (state: never) => unknown) =>
+      useSelector(api.store as never, selector as never) as never
+    extendedApi.useSelector = subscribeToStore
+    /** @deprecated Use `form.useSelector` instead. */
+    extendedApi.useStore = subscribeToStore
     extendedApi.Subscribe = defineComponent(
       (props, context) => {
         const allProps = { ...props, ...context.attrs }
         const selector = allProps.selector ?? ((state: never) => state)
-        const data = useStore(api.store as never, selector as never)
+        const data = useSelector(api.store as never, selector as never)
         return () => context.slots.default!(data.value)
       },
       {

--- a/packages/vue-form/src/useFormGroup.tsx
+++ b/packages/vue-form/src/useFormGroup.tsx
@@ -1,5 +1,5 @@
 import { FormGroupApi } from '@tanstack/form-core'
-import { useStore } from '@tanstack/vue-store'
+import { useSelector } from '@tanstack/vue-store'
 import { defineComponent, onMounted, onUnmounted, watch } from 'vue'
 import type {
   DeepKeys,
@@ -293,7 +293,7 @@ export function useFormGroup<
     return api
   })()
 
-  const groupState = useStore(formGroupApi.store, (state) => state)
+  const groupState = useSelector(formGroupApi.store, (state) => state)
 
   let cleanup!: () => void
   onMounted(() => {


### PR DESCRIPTION
- Re-export `useSelector` from TanStack Store in react/preact/vue/solid/svelte form packages
- Keep deprecated `useStore` export for backward compatibility
- Add `form.useSelector` on Vue, Solid, and Svelte (deprecate `form.useStore`)
- Update docs, examples, changeset, and add `exports.test.ts` for react-form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selector-based subscriptions via `form.useSelector` across React, Preact, Vue, Solid, and Svelte adapters, and re-exported `useSelector` at the package level where applicable.

* **Deprecations**
  * `form.useStore` is deprecated and remains as an alias; use `form.useSelector` instead.

* **Documentation**
  * Updated reactivity, validation, SSR, and reference guides/examples to use `useSelector`, including migration notes and selector/compare guidance.

* **Tests**
  * Added coverage to verify `useSelector`/`useStore` export surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->