### PR TITLE
fix(form-core): revalidate nested fields on parent setFieldValue

### DIFF
--- a/.changeset/nested-field-revalidate.md
+++ b/.changeset/nested-field-revalidate.md
@@ -1,0 +1,12 @@
+---
+'@tanstack/form-core': patch
+'@tanstack/react-form': patch
+'@tanstack/preact-form': patch
+'@tanstack/vue-form': patch
+'@tanstack/solid-form': patch
+'@tanstack/svelte-form': patch
+'@tanstack/angular-form': patch
+'@tanstack/lit-form': patch
+---
+
+Revalidate mounted nested fields when a parent object field value is updated via `setFieldValue`. Fixes #2113.

--- a/packages/form-core/CHANGELOG.md
+++ b/packages/form-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tanstack/form-core
 
+## 1.33.1
+
+### Patch Changes
+
+- Revalidate mounted nested fields when a parent object is updated via `setFieldValue` (fixes [#2113](https://github.com/TanStack/form/issues/2113)).
+
 ## 1.33.0
 
 ### Minor Changes

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -2671,6 +2671,17 @@ export class FormApi<
 
     if (!dontValidate) {
       this.validateField(field, 'change')
+
+      const fieldStr = field.toString()
+      for (const nestedField of Object.keys(this.fieldInfo)) {
+        if (
+          nestedField !== fieldStr &&
+          isFieldInGroup(fieldStr, nestedField) &&
+          this.getFieldInfo(nestedField as DeepKeys<TFormData>).instance
+        ) {
+          this.validateField(nestedField as DeepKeys<TFormData>, 'change')
+        }
+      }
     }
   }
 

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -1232,6 +1232,35 @@ describe('form api', () => {
     expect(form.getFieldValue('name')).toEqual('two')
   })
 
+  it('should revalidate nested fields when a parent object value is set', () => {
+    // Regression test for https://github.com/TanStack/form/issues/2113
+    const form = new FormApi({
+      defaultValues: {
+        a: { b: 0 },
+      },
+    })
+    form.mount()
+
+    const nestedField = new FieldApi({
+      form,
+      name: 'a.b',
+      validators: {
+        onChange: ({ value }) =>
+          value > 0 ? undefined : 'must be greater than 0',
+      },
+    })
+    nestedField.mount()
+
+    form.setFieldValue('a', { b: 0 })
+    expect(nestedField.state.meta.errors).toEqual(['must be greater than 0'])
+
+    form.setFieldValue('a', { b: 1 })
+
+    expect(nestedField.getValue()).toBe(1)
+    expect(nestedField.state.meta.errors).toEqual([])
+    expect(form.state.isValid).toBe(true)
+  })
+
   it('should delete field from the form', () => {
     const form = new FormApi({
       defaultValues: {


### PR DESCRIPTION
Revalidate mounted nested fields when a parent object updates via setFieldValue, clearing stale child validation errors. Adds regression test and changeset. Fixes #2113.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where nested fields were not being revalidated when parent object field values were updated through `setFieldValue`. This fix ensures all mounted nested fields properly revalidate when parent objects change, maintaining consistent validation behavior across all form libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->