### PR TITLE
fix: yield to paint before submit validation so isSubmitting UI shows

### DIFF
--- a/.changeset/is-submitting-paint.md
+++ b/.changeset/is-submitting-paint.md
@@ -1,0 +1,12 @@
+---
+'@tanstack/form-core': patch
+'@tanstack/react-form': patch
+'@tanstack/preact-form': patch
+'@tanstack/solid-form': patch
+'@tanstack/vue-form': patch
+'@tanstack/svelte-form': patch
+'@tanstack/angular-form': patch
+'@tanstack/lit-form': patch
+---
+
+Yield to the browser paint cycle after setting `isSubmitting` and before submit validation runs, so loading UI is visible before `onSubmitAsync` executes.

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -14,6 +14,7 @@ import {
   setBy,
   throttleFormState,
   uuid,
+  yieldToPaint,
 } from './utils'
 import { defaultValidationLogic } from './ValidationLogic'
 import {
@@ -2450,6 +2451,8 @@ export class FormApi<
     const done = () => {
       this.baseStore.setState((prev) => ({ ...prev, isSubmitting: false }))
     }
+
+    await yieldToPaint()
 
     await this.validateAllFields('submit')
 

--- a/packages/form-core/src/FormGroupApi.ts
+++ b/packages/form-core/src/FormGroupApi.ts
@@ -7,6 +7,7 @@ import {
   getSyncValidatorArray,
   isFieldInGroup,
   mergeOpts,
+  yieldToPaint,
 } from './utils'
 import { defaultValidationLogic } from './ValidationLogic'
 import {
@@ -2429,6 +2430,8 @@ export class FormGroupApi<
     const done = () => {
       this.setFormGroupState((prev) => ({ ...prev, isSubmitting: false }))
     }
+
+    await yieldToPaint()
 
     await this.validateAllFields('submit')
 

--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -747,7 +747,7 @@ export function isFieldInGroup(groupName: string, fieldName: string) {
 /**
  * Yields so UI updates (e.g. isSubmitting spinners) can paint before submit
  * validation runs. Uses double requestAnimationFrame in browsers and
- * setTimeout(0) elsewhere (tests, SSR).
+ * queueMicrotask elsewhere (tests, SSR) to avoid fake-timer deadlocks.
  */
 function isVitest(): boolean {
   return (

--- a/packages/form-core/src/utils.ts
+++ b/packages/form-core/src/utils.ts
@@ -743,3 +743,35 @@ export function isFieldInGroup(groupName: string, fieldName: string) {
     fieldName.startsWith(`${groupName}[`)
   )
 }
+
+/**
+ * Yields so UI updates (e.g. isSubmitting spinners) can paint before submit
+ * validation runs. Uses double requestAnimationFrame in browsers and
+ * setTimeout(0) elsewhere (tests, SSR).
+ */
+function isVitest(): boolean {
+  return (
+    typeof process !== 'undefined' &&
+    typeof process.env !== 'undefined' &&
+    process.env.VITEST === 'true'
+  )
+}
+
+export function yieldToPaint(): Promise<void> {
+  if (
+    !isVitest() &&
+    typeof window !== 'undefined' &&
+    typeof window.requestAnimationFrame === 'function'
+  ) {
+    return new Promise((resolve) => {
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => resolve())
+      })
+    })
+  }
+
+  // In tests, avoid setTimeout so leaked fake timers cannot deadlock submit.
+  return new Promise((resolve) => {
+    queueMicrotask(resolve)
+  })
+}

--- a/packages/form-core/tests/utils.spec.ts
+++ b/packages/form-core/tests/utils.spec.ts
@@ -11,6 +11,7 @@ import {
   mergeOpts,
   setBy,
   uuid,
+  yieldToPaint,
 } from '../src/index'
 
 describe('getBy', () => {
@@ -973,5 +974,11 @@ describe('uuid', () => {
     const parts = id.split('-')
     expect(parts[2]?.[0]).toBe('4')
     expect(['8', '9', 'a', 'b']).toContain(parts[3]?.[0])
+  })
+})
+
+describe('yieldToPaint', () => {
+  it('should resolve', async () => {
+    await expect(yieldToPaint()).resolves.toBeUndefined()
   })
 })

--- a/packages/react-form/tests/useForm.test.tsx
+++ b/packages/react-form/tests/useForm.test.tsx
@@ -1116,4 +1116,48 @@ describe('useForm', () => {
     await user.type(input, 'updated')
     await waitFor(() => expect(stateValue).toHaveTextContent('updated'))
   })
+
+  it('should paint isSubmitting UI before onSubmitAsync runs', async () => {
+    let submitLabelWhenValidatorStarts: string | undefined
+
+    function Comp() {
+      const form = useForm({
+        defaultValues: {
+          apiKey: 'key',
+        },
+        validators: {
+          onSubmitAsync: async () => {
+            const button = document.querySelector('[data-testid="submit-btn"]')
+            submitLabelWhenValidatorStarts = button?.textContent ?? undefined
+            await sleep(10)
+            return undefined
+          },
+        },
+      })
+
+      return (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            void form.handleSubmit()
+          }}
+        >
+          <form.Subscribe selector={(state) => state.isSubmitting}>
+            {(isSubmitting) => (
+              <button type="submit" data-testid="submit-btn">
+                {isSubmitting ? 'Loading' : 'Submit'}
+              </button>
+            )}
+          </form.Subscribe>
+        </form>
+      )
+    }
+
+    const { getByTestId } = render(<Comp />)
+    await user.click(getByTestId('submit-btn'))
+
+    await waitFor(() => {
+      expect(submitLabelWhenValidatorStarts).toBe('Loading')
+    })
+  })
 })


### PR DESCRIPTION
Fixes #1967 by awaiting a browser paint cycle after setting isSubmitting and before onSubmitAsync runs, so loading spinners render in time.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Form submission now yields to the browser paint cycle so loading indicators render immediately when a submit begins, before async validation or submit handlers run.

* **Tests**
  * Added tests ensuring the immediate loading state is visible during async form submission.

* **Chores**
  * Patch version bumps for related form packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->