### PR TITLE
fix(form-core): keep onSubmit error when blurring an unchanged field

### DIFF
--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -1347,14 +1347,17 @@ export class FieldApi<
 
     /**
      *  when we have an error for onSubmit in the state, we want
-     *  to clear the error as soon as the user enters a valid value in the field
+     *  to clear the error as soon as the user enters a valid value in the field.
+     *  This must only happen on a value `change` - clearing it on `blur` (or any
+     *  other non-value cause) would wrongly drop the submit error when the user
+     *  focuses and leaves the field without editing it.
      */
     const submitErrKey = getErrorMapKey('submit')
 
     if (
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       this.state.meta.errorMap?.[submitErrKey] &&
-      cause !== 'submit' &&
+      cause === 'change' &&
       !hasErrored
     ) {
       this.setMeta((prev) => ({

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -2098,6 +2098,64 @@ describe('field api', () => {
     expect(field.getMeta().errors).toStrictEqual(['first name is required'])
   })
 
+  it('should not clear onSubmit errors on blur when the value did not change', async () => {
+    const form = new FormApi({
+      defaultValues: {
+        firstName: '',
+      },
+    })
+
+    form.mount()
+
+    const field = new FieldApi({
+      form,
+      name: 'firstName',
+      validators: {
+        onSubmit: ({ value }) =>
+          value.length > 0 ? undefined : 'first name is required',
+      },
+    })
+
+    field.mount()
+
+    await form.handleSubmit()
+    expect(field.getMeta().errors).toStrictEqual(['first name is required'])
+
+    // Blurring the field without changing its value must keep the submit error
+    field.handleBlur()
+    expect(field.getMeta().errors).toStrictEqual(['first name is required'])
+    expect(field.getMeta().isValid).toBe(false)
+  })
+
+  it('should clear onSubmit errors once a valid value is entered', async () => {
+    const form = new FormApi({
+      defaultValues: {
+        firstName: '',
+      },
+    })
+
+    form.mount()
+
+    const field = new FieldApi({
+      form,
+      name: 'firstName',
+      validators: {
+        onSubmit: ({ value }) =>
+          value.length > 0 ? undefined : 'first name is required',
+      },
+    })
+
+    field.mount()
+
+    await form.handleSubmit()
+    expect(field.getMeta().errors).toStrictEqual(['first name is required'])
+
+    // Entering a valid value clears the stale submit error
+    field.handleChange('John')
+    expect(field.getMeta().errors).toStrictEqual([])
+    expect(field.getMeta().isValid).toBe(true)
+  })
+
   it('should show onMount errors', async () => {
     const form = new FormApi({
       defaultValues: {


### PR DESCRIPTION
Closes #1242

## Problem

A field-level `onSubmit` error is wrongly cleared when the user focuses and blurs the field **without changing its value**. The submit error should only disappear once the user actually enters a (valid) value.

## Root cause

In `FieldApi`, the logic that clears a stored `submit` error fired for any cause other than `'submit'`:

```ts
this.state.meta.errorMap?.[submitErrKey] &&
cause !== 'submit' &&
!hasErrored
```

`handleBlur` runs validation with `cause: 'blur'`, which satisfied `cause !== 'submit'`, so a plain blur (no edit) cleared the submit error.

## Fix

Clear the stored submit error only on an actual value `change`:

```ts
cause === 'change' &&
```

A `blur` (or any non-value cause) no longer drops the submit error. Entering a valid value still clears it as documented.

## Tests

Two tests added to `packages/form-core/tests/FieldApi.spec.ts`:
- `should not clear onSubmit errors on blur when the value did not change` — **fails on `main`**, passes with the fix
- `should clear onSubmit errors once a valid value is entered` — guards the documented clear-on-change path

Full `form-core` suite green (107 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed form validation to properly preserve submit errors during blur and non-value interactions. Submit errors are now cleared only when valid values are entered, improving form error feedback accuracy.

* **Tests**
  * Extended test coverage for submit error behavior, verifying errors persist on blur without changes and clear when valid values are entered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->