### PR TITLE
chore: add npm bugs metadata to all published packages

### DIFF
--- a/packages/angular-form/package.json
+++ b/packages/angular-form/package.json
@@ -63,5 +63,8 @@
   },
   "peerDependencies": {
     "@angular/core": ">=19.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/form/issues"
   }
 }

--- a/packages/form-core/package.json
+++ b/packages/form-core/package.json
@@ -60,5 +60,8 @@
     "arktype": "^2.1.22",
     "valibot": "^1.1.0",
     "zod": "^3.25.76"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/form/issues"
   }
 }

--- a/packages/react-form/package.json
+++ b/packages/react-form/package.json
@@ -71,5 +71,8 @@
     "@tanstack/react-start": {
       "optional": true
     }
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/form/issues"
   }
 }

--- a/packages/solid-form/package.json
+++ b/packages/solid-form/package.json
@@ -66,5 +66,8 @@
   },
   "peerDependencies": {
     "solid-js": ">=1.9.9"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/form/issues"
   }
 }

--- a/packages/svelte-form/package.json
+++ b/packages/svelte-form/package.json
@@ -52,5 +52,8 @@
   },
   "peerDependencies": {
     "svelte": "^5.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/form/issues"
   }
 }

--- a/packages/vue-form/package.json
+++ b/packages/vue-form/package.json
@@ -63,5 +63,8 @@
   },
   "peerDependencies": {
     "vue": "^3.4.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/form/issues"
   }
 }


### PR DESCRIPTION
## Problem

All `@tanstack/form-*` packages are missing the `bugs` field in their `package.json` files.

```sh
npm view @tanstack/react-form bugs   # empty
npm view @tanstack/vue-form bugs     # empty
npm view @tanstack/form-core bugs    # empty
# etc.
```

## Fix

Add `bugs.url` pointing to the GitHub issue tracker in all six published packages:
- `@tanstack/form-core`
- `@tanstack/react-form`
- `@tanstack/vue-form`
- `@tanstack/solid-form`
- `@tanstack/svelte-form`
- `@tanstack/angular-form`

Metadata-only change — no runtime behaviour is affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added bug reporting metadata to package information across all form packages for improved issue tracking discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->