### PR TITLE
fix(form-core): prevent reset(newValues) being overwritten by subsequent update()

### DIFF
--- a/.changeset/fix-reset-update-race.md
+++ b/.changeset/fix-reset-update-race.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/form-core": patch
+---
+
+Fix `reset(newValues)` inside `onSubmit` being overwritten when a re-render calls `update()` with unchanged component props.

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -1066,6 +1066,8 @@ export class FormApi<
    * @private
    */
   private _devtoolsSubmissionOverride: boolean
+  /** @private */
+  private _componentDefaultValues?: TFormData
 
   /**
    * Constructs a new `FormApi` instance with the given form options.
@@ -1095,6 +1097,7 @@ export class FormApi<
     this._formId = opts?.formId ?? uuid()
 
     this._devtoolsSubmissionOverride = false
+    this._componentDefaultValues = opts?.defaultValues
 
     let baseStoreVal: BaseFormState<
       TFormData,
@@ -1747,14 +1750,27 @@ export class FormApi<
     if (!options) return
 
     const oldOptions = this.options
+    const prevComponentDefaultValues = this._componentDefaultValues
+    this._componentDefaultValues = options.defaultValues
 
     // Options need to be updated first so that when the store is updated, the state is correct for the derived state
     this.options = options
 
+    const componentDefaultsUnchanged = evaluate(
+      options.defaultValues,
+      prevComponentDefaultValues,
+    )
+
     const shouldUpdateValues =
       options.defaultValues &&
+      !componentDefaultsUnchanged &&
       !evaluate(options.defaultValues, oldOptions.defaultValues) &&
       !this.state.isTouched
+
+    // Preserve runtime defaultValues (e.g., from reset()) when the component's defaults haven't changed. Skip on the first update() call (constructor) where oldOptions is the empty class default and has no baseline to restore. Use a new object to avoid mutating the caller-supplied options reference.
+    if (oldOptions.defaultValues !== undefined && componentDefaultsUnchanged) {
+      this.options = { ...this.options, defaultValues: oldOptions.defaultValues }
+    }
 
     const shouldUpdateState =
       !evaluate(options.defaultState, oldOptions.defaultState) &&

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -1762,7 +1762,7 @@ export class FormApi<
     )
 
     const shouldUpdateValues =
-      options.defaultValues &&
+      options.defaultValues !== undefined &&
       !componentDefaultsUnchanged &&
       !evaluate(options.defaultValues, oldOptions.defaultValues) &&
       !this.state.isTouched

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -174,6 +174,32 @@ describe('form api', () => {
     expect(form.state.values).toEqual({ name: 'initial' })
   })
 
+  it('should not revert values when update() is called with unchanged component props after reset()', () => {
+    const originalValues = { name: 'original' }
+    const form = new FormApi({ defaultValues: originalValues })
+    form.mount()
+
+    form.reset({ name: 'after-submit' })
+    expect(form.state.values).toEqual({ name: 'after-submit' })
+
+    // Simulate framework re-render: update() called with original (unchanged) component props. Before the fix, reset() mutated this.options.defaultValues, causing a false delta that overwrote the reset values.
+    form.update({ defaultValues: originalValues })
+    expect(form.state.values).toEqual({ name: 'after-submit' })
+  })
+
+  it('should preserve the reset baseline when update() is called with unchanged component props', () => {
+    const originalValues = { name: 'original' }
+    const form = new FormApi({ defaultValues: originalValues })
+    form.mount()
+
+    form.reset({ name: 'after-submit' })
+    form.update({ defaultValues: originalValues })
+
+    // A subsequent reset() with no args uses the reset baseline, not the component default.
+    form.reset()
+    expect(form.state.values).toEqual({ name: 'after-submit' })
+  })
+
   it('should prioritize field-level defaultValue over form-level defaultValues on reset', () => {
     const form = new FormApi({
       defaultValues: {


### PR DESCRIPTION
Fixes #1681

Thanks for the detailed repro. It made this much easier to pin down.

## Problem

If you call `form.reset(newValues)` inside `onSubmit` and your framework re-renders the component immediately after, the reset values get silently overwritten.

`reset(newValues)` writes the new values into `this.options.defaultValues`. When the adapter calls `update()` on re-render with the same props it had before, `update()` compares the incoming `defaultValues` against `oldOptions.defaultValues` (which now holds the reset values rather than the original component defaults), sees a delta that isn't really a change, sets `shouldUpdateValues = true`, and reverts the form back to the original defaults.

There's a second issue: `this.options = options` runs on every re-render, replacing the whole options object. After a `reset()`, the runtime `defaultValues` is gone. A later no-arg `reset()` uses the stale component default instead of the post-submit baseline.

## Fix

The root problem is that `update()` has no way to tell "the component's `defaultValues` prop actually changed" apart from "someone called `reset()` and now `defaultValues` looks different." This adds a private `_componentDefaultValues` field that tracks what the adapter last explicitly provided, separate from the runtime `this.options.defaultValues` that `reset()` writes to.

In `update()`:

- `componentDefaultsUnchanged = evaluate(options.defaultValues, prevComponentDefaultValues)` is computed before the field is overwritten.
- `shouldUpdateValues` now requires `!componentDefaultsUnchanged`, so an unchanged re-render can't clobber a reset.
- When component defaults are unchanged and a prior baseline exists, `this.options` gets a fresh spread object with the runtime `defaultValues` preserved. The spread avoids mutating the caller-supplied reference, which matters when the adapter passes a memoized frozen object.

The constructor guard (`oldOptions.defaultValues !== undefined`) keeps the restoration block from firing on the very first `update()` call, where `oldOptions` is the empty class default `{}`. Initial form values come from `baseStoreVal` before that first call, so the guard is safe.

## Tests

Two regression tests in `FormApi.spec.ts`:

1. `update()` with unchanged props after `reset(newValues)` keeps values at the reset value, not the original default.
2. A follow-up no-arg `reset()` uses the post-submit baseline, not the original component default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition where calling `reset(newValues)` during submission could be overwritten by a later `update()` triggered by component re-renders when `defaultValues` props were unchanged.
  * Improved `reset()` consistency after updates: calling `reset()` without arguments now uses the reset baseline instead of reusing unchanged component-provided defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->