### PR TITLE
docs: correct withFieldGroup props runtime note

### DIFF
--- a/docs/framework/preact/guides/form-composition.md
+++ b/docs/framework/preact/guides/form-composition.md
@@ -345,7 +345,7 @@ const FieldGroupPasswordFields = withFieldGroup({
 
   // Optional, but adds props to the `render` function in addition to `form`
   props: {
-    // These default values are also for type-checking and are not used at runtime
+    // These props are set as default values for the `render` function
     title: 'Password',
   },
   // Internally, you will have access to a `group` instead of a `form`

--- a/docs/framework/react/guides/form-composition.md
+++ b/docs/framework/react/guides/form-composition.md
@@ -418,7 +418,7 @@ const FieldGroupPasswordFields = withFieldGroup({
 
   // Optional, but adds props to the `render` function in addition to `form`
   props: {
-    // These default values are also for type-checking and are not used at runtime
+    // These props are set as default values for the `render` function
     title: 'Password',
   },
   // Internally, you will have access to a `group` instead of a `form`

--- a/docs/framework/solid/guides/form-composition.md
+++ b/docs/framework/solid/guides/form-composition.md
@@ -258,7 +258,7 @@ const FieldGroupPasswordFields = withFieldGroup({
 
   // Optional, but adds props to the `render` function in addition to `form`
   props: {
-    // These default values are also for type-checking and are not used at runtime
+    // These props are set as default values for the `render` function
     title: 'Password',
   },
   // Internally, you will have access to a `group` instead of a `form`


### PR DESCRIPTION
## 🎯 Changes

The `withFieldGroup` docs say the `props` passed to it are "not used at runtime", but they are. In `createFormHook` the returned render component spreads them into the render call:

```ts
return render({ ...props, ...innerProps, group: fieldGroupApi as any })
```

So `props` act as default values that the runtime `innerProps` can override. This is the same thing `withForm` does (`render({ ...props, ...innerProps })`), and the `withForm` docs already describe it correctly as "set as default values for the render function". This just brings the `withFieldGroup` note in line with that wording across the react, solid and preact guides.

The `defaultValues` note above it is left as-is, since those really are type-only.

Closes #2099

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified explanations in form composition guides across Preact, React, and Solid frameworks, improving the documentation for handling default values in field grouping examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->