### PR TITLE
chore: update pnpm to 11.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "type": "git",
     "url": "git+https://github.com/TanStack/form.git"
   },
-  "packageManager": "pnpm@11.3.0+sha512.2c403d6594527287672b1f7056343a1f7c3634036a67ffabfcc2b3d7595d843768f8787148d1b57cf7956c90606bbd192857c363af19e96d2d0ec9ec5741d215",
+  "packageManager": "pnpm@11.9.0",
   "engines": {
-    "pnpm": ">=11.0.0"
+    "pnpm": ">=11.9.0"
   },
   "type": "module",
   "scripts": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ cleanupUnusedCatalogs: true
 linkWorkspacePackages: true
 preferWorkspacePackages: true
 blockExoticSubdeps: true
+minimumReleaseAge: 1
 trustPolicy: 'no-downgrade'
 trustPolicyExclude:
   - 'ua-parser-js@1.0.41 || 0.7.41' # React Native Web & Expo Devices; UAP v2 is not MIT

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,7 @@ cleanupUnusedCatalogs: true
 linkWorkspacePackages: true
 preferWorkspacePackages: true
 blockExoticSubdeps: true
-minimumReleaseAge: 1
+minimumReleaseAge: 1440
 trustPolicy: 'no-downgrade'
 trustPolicyExclude:
   - 'ua-parser-js@1.0.41 || 0.7.41' # React Native Web & Expo Devices; UAP v2 is not MIT


### PR DESCRIPTION
Updates pnpm to 11.9.0 and enables minimumReleaseAge for workspace installs.

Verification:
- pnpm install --frozen-lockfile --ignore-scripts --trust-lockfile=false
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project’s package manager setup to use a newer pinned pnpm version.
  * Tightened the pnpm version requirement to align development environments.
  * Updated workspace configuration to include a minimum release age setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->