### PR TITLE
fix(form-core): don't auto-touch shifted siblings on array mutation

### DIFF
--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -1917,7 +1917,24 @@ export class FormApi<
     batch(() => {
       fieldsToValidate.forEach((nestedField) => {
         fieldValidationPromises.push(
-          Promise.resolve().then(() => this.validateField(nestedField, cause)),
+          Promise.resolve().then(() => {
+            // These fields were merely shifted by an array mutation, the user
+            // never interacted with them. Their value did change, so they
+            // still need to be validated, but `validateField` auto-touches as
+            // a side-effect — which would spuriously mark untouched siblings
+            // as touched. Remember the prior touched state and restore it for
+            // fields that weren't touched before.
+            const fieldInstance = this.fieldInfo[nestedField]?.instance
+            const wasTouched = fieldInstance?.store.state.meta.isTouched ?? true
+
+            const result = this.validateField(nestedField, cause)
+
+            if (fieldInstance && !wasTouched) {
+              fieldInstance.setMeta((prev) => ({ ...prev, isTouched: false }))
+            }
+
+            return result
+          }),
         )
       })
     })

--- a/packages/form-core/tests/FieldGroupApi.spec.ts
+++ b/packages/form-core/tests/FieldGroupApi.spec.ts
@@ -401,6 +401,9 @@ describe('field group api', () => {
     const field1 = new FieldApi({
       form,
       name: 'people.names[1].name',
+      validators: {
+        onChange: () => 'validated',
+      },
     })
     const field2 = new FieldApi({
       form,
@@ -423,9 +426,13 @@ describe('field group api', () => {
 
     await vi.runAllTimersAsync()
 
+    // The call was forwarded to the form and validation reached the shifted
+    // field (field1's validator ran), but validating a shifted field must not
+    // mark it — or its untouched siblings — as touched (issue #2131).
+    expect(field1.getMeta().errors).toStrictEqual(['validated'])
     expect(field0.getMeta().isTouched).toBe(false)
-    expect(field1.getMeta().isTouched).toBe(true)
-    expect(field2.getMeta().isTouched).toBe(true)
+    expect(field1.getMeta().isTouched).toBe(false)
+    expect(field2.getMeta().isTouched).toBe(false)
   })
 
   it('should forward handleSubmit to the form', async () => {
@@ -562,9 +569,10 @@ describe('field group api', () => {
 
     await vi.runAllTimersAsync()
 
+    // Shifted fields must not be marked as touched (issue #2131)
     expect(field0.getMeta().isTouched).toBe(false)
-    expect(field1.getMeta().isTouched).toBe(true)
-    expect(field2.getMeta().isTouched).toBe(true)
+    expect(field1.getMeta().isTouched).toBe(false)
+    expect(field2.getMeta().isTouched).toBe(false)
 
     fieldGroup.pushFieldValue('names', { name: 'Push' })
 

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -682,6 +682,40 @@ describe('form api', () => {
     expect(field3.state.meta.errors).toStrictEqual([])
   })
 
+  it('should not mark shifted siblings as touched when removing array values', async () => {
+    const form = new FormApi({
+      defaultValues: {
+        names: ['a', 'b', 'c', 'd', 'e'],
+      },
+    })
+    form.mount()
+    // Since validation runs through the field, a field must be mounted for that array
+    new FieldApi({ form, name: 'names' }).mount()
+
+    const fields = [0, 1, 2, 3, 4].map((i) => {
+      const field = new FieldApi({ form, name: `names[${i}]` as const })
+      field.mount()
+      return field
+    })
+
+    // The user never interacts with any field
+    expect(fields.map((f) => f.state.meta.isTouched)).toStrictEqual([
+      false,
+      false,
+      false,
+      false,
+      false,
+    ])
+
+    await form.removeFieldValue('names', 2)
+
+    expect(form.getFieldValue('names')).toStrictEqual(['a', 'b', 'd', 'e'])
+    // Removing a value must not touch the siblings that merely shifted
+    expect(fields.slice(0, 4).map((f) => f.state.meta.isTouched)).toStrictEqual(
+      [false, false, false, false],
+    )
+  })
+
   it('should shift meta (nested) when removing array values', async () => {
     const form = new FormApi({
       defaultValues: {


### PR DESCRIPTION
Closes #2131

### Problem

`form.removeValue(index)` (and `insertValue`/`replaceValue`) flips `isTouched` to `true` on every sibling that shifts, even when the user never interacted with them. Because the bug is in `form-core`, every adapter is affected. The maintainer confirmed the touch "makes little sense" in #2131.

### Cause

After an array mutation, `validateArrayFieldsStartingFrom` re-validates the shifted items. It routes each one through `validateField`, which auto-touches the field as a side-effect (so that `FieldApi.validate`'s pristine guard doesn't short-circuit). The shifted siblings genuinely need re-validating — their *value* changed — but they should not be marked touched.

### Fix

A prior attempt (#2133) was closed as overcomplicated; the maintainer hinted the fix should target a different function. This keeps it entirely inside `validateArrayFieldsStartingFrom` (the function that owns the shift-revalidation), with no new option threading: remember each mounted field's prior `isTouched`, still call `validateField` so validation runs, then restore `isTouched: false` for the fields that weren't touched before. Fields that *were* touched, and form-level validation for unmounted fields, are unchanged.

### Tests

- New `form-core` regression test: removing an item from a 5-element array leaves all remaining siblings `isTouched: false`. Fails without the fix (`[false, false, true, true]`).
- Updated two `FieldGroupApi` forwarding tests that previously asserted the buggy auto-touch. The dedicated one now also asserts the shifted field's validator actually ran (`errors === ['validated']`), so it still proves forwarding while verifying no spurious touch.

`form-core` (499) and `react-form` (123) suites pass; eslint, prettier and type checks (TS 5.4–5.9) clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved array field validation so shifting items no longer marks untouched fields as touched.
  * Preserved touch state when validating nested fields after removing an array item.
  * Kept validation errors working as expected while preventing unintended touch updates on sibling fields.
* **Tests**
  * Updated and added coverage for array field shifting and removal scenarios to verify touch state remains unchanged for untouched fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->