### PR TITLE
fix(form-core): prioritize StandardSchemaV1 check over FieldValidateFn for callable schemas (fixes #2221)

### DIFF
--- a/packages/form-core/src/types.ts
+++ b/packages/form-core/src/types.ts
@@ -452,17 +452,17 @@ export type UnwrapFieldValidateOrFn<
             : undefined
           : undefined
       : never)
-  | ([TValidateOrFn] extends [FieldValidateFn<any, any, any>]
-      ? ReturnType<TValidateOrFn>
-      : [TValidateOrFn] extends [StandardSchemaV1<any, any>]
-        ? // TODO: Check if `disableErrorFlat` is enabled, if so, return StandardSchemaV1Issue[][]
-          StandardSchemaV1Issue[]
+  | ([TValidateOrFn] extends [StandardSchemaV1<any, any>]
+      ? // TODO: Check if `disableErrorFlat` is enabled, if so, return StandardSchemaV1Issue[][]
+        StandardSchemaV1Issue[]
+      : [TValidateOrFn] extends [FieldValidateFn<any, any, any>]
+        ? ReturnType<TValidateOrFn>
         : undefined)
-  | ([TValidateOrFn] extends [FormGroupValidateFn<any, any, any>]
-      ? ReturnType<TValidateOrFn>
-      : [TValidateOrFn] extends [StandardSchemaV1<any, any>]
-        ? // TODO: Check if `disableErrorFlat` is enabled, if so, return StandardSchemaV1Issue[][]
-          StandardSchemaV1Issue[]
+  | ([TValidateOrFn] extends [StandardSchemaV1<any, any>]
+      ? // TODO: Check if `disableErrorFlat` is enabled, if so, return StandardSchemaV1Issue[][]
+        StandardSchemaV1Issue[]
+      : [TValidateOrFn] extends [FormGroupValidateFn<any, any, any>]
+        ? ReturnType<TValidateOrFn>
         : undefined)
 
 /**

--- a/packages/form-core/tests/standardSchemaValidator.test-d.ts
+++ b/packages/form-core/tests/standardSchemaValidator.test-d.ts
@@ -1,5 +1,6 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { z } from 'zod'
+import { type } from 'arktype'
 import { FieldApi, FormApi, standardSchemaValidators } from '../src/index'
 import type { StandardSchemaV1Issue } from '../src/index'
 
@@ -77,6 +78,27 @@ describe('standard schema validator', () => {
     >()
     expectTypeOf(fieldSourceError).toEqualTypeOf<
       StandardSchemaV1Issue[] | undefined
+    >()
+  })
+
+  it('Should infer StandardSchemaV1Issue[] for arktype field validators (issue #2221)', () => {
+    const schema = type({ firstName: 'string>0' })
+    const form = new FormApi({
+      defaultValues: {
+        firstName: '',
+      },
+    })
+
+    const field = new FieldApi({
+      form,
+      name: 'firstName',
+      validators: {
+        onChange: type('string>0'),
+      },
+    })
+
+    expectTypeOf(field.getMeta().errorMap.onChange).toEqualTypeOf<
+      undefined | StandardSchemaV1Issue[]
     >()
   })
 


### PR DESCRIPTION
## Root cause

`UnwrapFieldValidateOrFn` checked `FieldValidateFn` **before** `StandardSchemaV1`. For any callable schema (arktype, and potentially other future StandardSchema implementations), this caused the wrong branch to be taken.

Arktype's `Type` uses `Callable<fn extends Fn>` from `@ark/util`, which makes `Type` **structurally extend** its call signature `(data: unknown) => TOut | ArkErrors`. TypeScript's contravariant parameter check then evaluates:

```
[ArkType] extends [FieldValidateFn<any, any, any>]
// FieldValidateFn = (props: { value: any, fieldApi: ... }) => unknown
// Contravariance: need  { value: any, fieldApi: ... } extends unknown  ← true
// Return:         need  TOut | ArkErrors extends unknown               ← true
// → true
```

So the `StandardSchemaV1` branch (line 457) was unreachable and `errors` resolved to `ReturnType<ArkType>` (`string | ArkErrors` for a string schema) instead of `StandardSchemaV1Issue[]`.

## Fix

Swap the check order in both the field and form-group branches of `UnwrapFieldValidateOrFn`:

```ts
// Before
| ([TValidateOrFn] extends [FieldValidateFn<any, any, any>]   // ← arktype hits this
    ? ReturnType<TValidateOrFn>
    : [TValidateOrFn] extends [StandardSchemaV1<any, any>]     // ← never reached
      ? StandardSchemaV1Issue[]
      : undefined)

// After
| ([TValidateOrFn] extends [StandardSchemaV1<any, any>]        // ← arktype now hits this
    ? StandardSchemaV1Issue[]
    : [TValidateOrFn] extends [FieldValidateFn<any, any, any>] // ← plain functions still work
      ? ReturnType<TValidateOrFn>
      : undefined)
```

Plain function validators (non-schema) are unaffected — they don't implement `StandardSchemaV1` so they fall through to `FieldValidateFn` as before.

## Test

Added a type-level test in `standardSchemaValidator.test-d.ts` asserting that an arktype `type('string>0')` field validator produces `StandardSchemaV1Issue[] | undefined` for `errorMap.onChange`, not an arktype output type.

Fixes #2221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved type inference for schema-based form validation, so validation errors are recognized more accurately in supported setups.

* **Bug Fixes**
  * Fixed an issue where certain validation results could infer the wrong error type, leading to less precise editor feedback.

* **Tests**
  * Added coverage for schema validation to ensure the updated inference behavior stays consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->