### PR TITLE
fix(form-core): don't throw when a group validator errors an unmounted field

### DIFF
--- a/.changeset/fix-formgroup-distribute-unmounted-field.md
+++ b/.changeset/fix-formgroup-distribute-unmounted-field.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/form-core': patch
+---
+
+Fix `FormGroupApi.distributeFieldErrors` throwing `TypeError: Cannot read properties of undefined` when a group validator returns errors for a field that is not mounted yet

--- a/packages/form-core/src/FormGroupApi.ts
+++ b/packages/form-core/src/FormGroupApi.ts
@@ -1750,7 +1750,7 @@ export class FormGroupApi<
         continue
       }
 
-      this.form.setFieldMeta(fullName as never, (prev) => ({
+      this.form.setFieldMeta(fullName as never, (prev = defaultFieldMeta) => ({
         ...prev,
         errorMap: {
           ...prev.errorMap,

--- a/packages/form-core/tests/FormGroupApi.spec.ts
+++ b/packages/form-core/tests/FormGroupApi.spec.ts
@@ -542,6 +542,49 @@ describe('form group api', () => {
     expect(step1Group.state.meta.isValid).toBe(false)
   })
 
+  it('Should not throw when a group validator returns field errors for a field that is not mounted yet', () => {
+    const form = new FormApi({
+      defaultValues: {
+        step1: { name: '', unmountedField: '' },
+        step2: { name: 'test2' },
+      },
+    })
+
+    const step1Group = new FormGroupApi({
+      name: 'step1',
+      form,
+      validators: {
+        onMount: () => {
+          return {
+            fields: {
+              unmountedField: 'Unmounted field is required',
+            },
+          }
+        },
+      },
+    })
+
+    // Note: no FieldApi is ever created/mounted for `step1.unmountedField`,
+    // so it has no entry in `fieldMetaBase` when the group validates.
+    form.mount()
+
+    expect(() => step1Group.mount()).not.toThrow()
+
+    expect(step1Group.state.meta.isFieldsValid).toBe(false)
+
+    // Once the field mounts, the previously-distributed error should
+    // surface on it.
+    const unmountedField = new FieldApi({
+      name: 'step1.unmountedField',
+      form,
+    })
+    unmountedField.mount()
+
+    expect(unmountedField.state.meta.errorMap.onMount).toBe(
+      'Unmounted field is required',
+    )
+  })
+
   it('Should propagate manual function field errors from group validators to child fields', async () => {
     const onSubmit = vi.fn()
 


### PR DESCRIPTION
`FormGroupApi.distributeFieldErrors` throws `TypeError: Cannot read properties of undefined (reading 'errorMap')` when a `FormGroup` validator returns `{ fields }` errors for a sub-field that is not mounted yet (no `fieldMetaBase` entry). This happens in multi-step forms where each step is a `FormGroup` and fields render progressively.

`setFieldMeta`'s updater is invoked with `prev.fieldMetaBase[field]`, which is `undefined` for a never-mounted field. The fix defaults the updater parameter to `defaultFieldMeta` (`(prev = defaultFieldMeta) => ...`), mirroring the same fix already applied in `FormApi.ts` for this bug class (#1706, #2056). The distributed error is stored and surfaces correctly when the field later mounts.

Added a `FormGroupApi.spec.ts` case: a group validator returns errors for an unmounted field, validate runs, and it must not throw. It throws the reported TypeError without the fix and passes with it. Full form-core suite (499 tests) and type tests pass, eslint and tsc clean.

Closes #2231


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where form group validation could fail when errors were returned for a field that had not been mounted yet.
  - Error handling now works more reliably for fields that mount after validation, so previously hidden errors appear correctly once the field is available.

- **Tests**
  - Added coverage for mounting fields after group validation to ensure errors are distributed as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->