### PR TITLE
fix(react-form-start): align createServerValidate info param with Nex…

### DIFF
--- a/.changeset/fix-start-server-validate-types.md
+++ b/.changeset/fix-start-server-validate-types.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/react-form-start': patch
+---
+
+Fix `createServerValidate` second parameter type to use `FormDataInfo` instead of `Parameters<typeof decode>[1]`, matching `@tanstack/react-form-nextjs` and fixing TypeScript errors when passing `booleans`, `dates`, etc.
+
+Fixes #2239

--- a/packages/react-form-start/src/createServerValidate.tsx
+++ b/packages/react-form-start/src/createServerValidate.tsx
@@ -166,5 +166,5 @@ export const createServerValidate =
       TSubmitMeta
     >,
   ) =>
-  (formData: FormData, info?: Parameters<typeof decode>[1]) =>
+  (formData: FormData, info?: FormDataInfo) =>
     serverFn({ data: { defaultOpts, formData, info } })

--- a/packages/react-form-start/tests/createServerValidate.test-d.ts
+++ b/packages/react-form-start/tests/createServerValidate.test-d.ts
@@ -1,0 +1,23 @@
+import { expectTypeOf, it } from 'vitest'
+import { createServerValidate } from '../src/createServerValidate'
+
+it('should accept FormDataInfo options like booleans', () => {
+  const serverValidate = createServerValidate({
+    onServerValidate: async () => undefined,
+  })
+
+  expectTypeOf(serverValidate).parameter(1).toEqualTypeOf<
+    | {
+        arrays?: string[]
+        booleans?: string[]
+        dates?: string[]
+        files?: string[]
+        numbers?: string[]
+      }
+    | undefined
+  >()
+
+  void serverValidate(new FormData(), {
+    booleans: ['rememberMe'],
+  })
+})


### PR DESCRIPTION
## Summary
- Fix `createServerValidate` second parameter type in `@tanstack/react-form-start` to use `FormDataInfo` instead of `Parameters<typeof decode>[1]`
- Aligns with `@tanstack/react-form-nextjs` and `@tanstack/react-form-remix`
- Fixes TypeScript errors when passing `{ booleans, dates, arrays, files, numbers }` to server validate

Fixes #2239

## Test plan
- [x] `pnpm run test:types` in `packages/react-form-start`
- [x] `pnpm run test:lib` in `packages/react-form-start`
- [x] `pnpm run test:eslint` in `packages/react-form-start`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the TypeScript type for the optional validation information parameter.
  * Resolved type errors when passing boolean, date, array, file, or number form values to server validation.

* **Tests**
  * Added type coverage confirming boolean form data is accepted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->