### PR TITLE
fix: bump array version on reset so array fields re-render

### DIFF
--- a/.changeset/fix-array-reset-rerender.md
+++ b/.changeset/fix-array-reset-rerender.md
@@ -1,0 +1,8 @@
+---
+'@tanstack/form-core': patch
+'@tanstack/react-form': patch
+---
+
+Bump `_arrayVersion` when resetting array fields so adapters re-render after `form.reset()` or `form.resetField()` changes array length.
+
+Fixes #2228

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -1847,6 +1847,15 @@ export class FormApi<
         fieldMetaBase,
       })
     })
+
+    const helper = metaHelper(this)
+    for (const fieldKey of Object.keys(
+      this.fieldInfo,
+    ) as DeepKeys<TFormData>[]) {
+      if (Array.isArray(this.getFieldValue(fieldKey))) {
+        helper.bumpArrayVersion(fieldKey)
+      }
+    }
   }
 
   /**
@@ -2954,6 +2963,10 @@ export class FormApi<
             : prev.values,
       }
     })
+
+    if (Array.isArray(this.getFieldValue(field))) {
+      metaHelper(this).bumpArrayVersion(field)
+    }
   }
 
   /**

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -125,6 +125,23 @@ describe('form api', () => {
     })
   })
 
+  it('should bump array version when resetting to a shorter array', () => {
+    const form = new FormApi({
+      defaultValues: {
+        items: [1, 2, 3],
+      },
+    })
+    form.mount()
+
+    const field = new FieldApi({ form, name: 'items' })
+    field.mount()
+
+    form.reset({ items: [4] })
+
+    expect(form.getFieldValue('items')).toEqual([4])
+    expect(form.getFieldMeta('items')?._arrayVersion).toBe(1)
+  })
+
   it('form should reset default value when resetting in onSubmit', async () => {
     const defaultValues = {
       name: '',

--- a/packages/react-form/tests/useField.test.tsx
+++ b/packages/react-form/tests/useField.test.tsx
@@ -1644,6 +1644,48 @@ describe('useField', () => {
     expect(getByTestId('item-0')).toHaveTextContent('Alice')
   })
 
+  it('should rerender array field when reset to a shorter array', async () => {
+    // Regression test for https://github.com/TanStack/form/issues/2228
+    function Comp() {
+      const form = useForm({
+        defaultValues: {
+          items: [1, 2, 3],
+        },
+      })
+
+      return (
+        <>
+          <button
+            data-testid="reset"
+            type="button"
+            onClick={() => form.reset({ items: [4] })}
+          >
+            Reset
+          </button>
+          <form.Field name="items" mode="array">
+            {(field) => (
+              <ol data-testid="list">
+                {field.state.value.map((item, i) => (
+                  <li key={i} data-testid={`item-${i}`}>
+                    {item}
+                  </li>
+                ))}
+              </ol>
+            )}
+          </form.Field>
+        </>
+      )
+    }
+
+    const { getByTestId } = render(<Comp />)
+    expect(getByTestId('list').children).toHaveLength(3)
+
+    await user.click(getByTestId('reset'))
+
+    expect(getByTestId('list').children).toHaveLength(1)
+    expect(getByTestId('item-0')).toHaveTextContent('4')
+  })
+
   it('should handle defaultValue without setstate-in-render error', async () => {
     // Spy on console.error before rendering
     const consoleErrorSpy = vi.spyOn(console, 'error')


### PR DESCRIPTION
## Summary

- Bump `_arrayVersion` after `form.reset()` and `form.resetField()` when the target field is an array.
- Fix React array fields not re-rendering when a reset shortens the array (e.g. `[1,2,3]` → `[4]` previously still rendered 3 items).
- Fixes #2228.

## Test Plan

- `pnpm run test:lib` in `packages/form-core`
- `pnpm run test:lib` in `packages/react-form`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed array-based form fields not re-rendering correctly after resetting the form or an individual field.
  * Array fields now immediately reflect changes in length and updated values after a reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->