### PR TITLE
fix(form-core): clear stale onMount error on linked-field revalidation

### DIFF
--- a/.changeset/clear-stale-onmount-linked-revalidation.md
+++ b/.changeset/clear-stale-onmount-linked-revalidation.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/form-core": patch
+---
+
+fix(form-core): clear a stale field-level `onMount` error when a linked-field revalidation (`onChangeListenTo`/`onBlurListenTo`) passes, so the field is no longer left permanently invalid

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -1292,6 +1292,7 @@ export class FieldApi<
       const validateFieldFn = (
         field: AnyFieldApi,
         validateObj: SyncValidator<any>,
+        isLinkedField = false,
       ) => {
         const errorMapKey = getErrorMapKey(validateObj.cause)
 
@@ -1334,6 +1335,32 @@ export class FieldApi<
         if (newErrorValue) {
           hasErrored = true
         }
+
+        // A direct value change clears the mount-time error in
+        // `setFieldValue`. When a field is revalidated indirectly via
+        // `onChangeListenTo`/`onBlurListenTo`, its own value never changed, so
+        // that clearing never ran and a now-stale `onMount` error would linger
+        // forever (leaving the field permanently invalid even though its
+        // validators now pass). Clear it once a passing linked revalidation
+        // supersedes it.
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (
+          isLinkedField &&
+          !newErrorValue &&
+          field.state.meta.errorMap?.onMount
+        ) {
+          field.setMeta((prev) => ({
+            ...prev,
+            errorMap: {
+              ...prev.errorMap,
+              onMount: undefined,
+            },
+            errorSourceMap: {
+              ...prev.errorSourceMap,
+              onMount: undefined,
+            },
+          }))
+        }
       }
 
       for (const validateObj of validates) {
@@ -1341,7 +1368,7 @@ export class FieldApi<
       }
       for (const fieldValitateObj of linkedFieldValidates) {
         if (!fieldValitateObj.validate) continue
-        validateFieldFn(fieldValitateObj.field, fieldValitateObj)
+        validateFieldFn(fieldValitateObj.field, fieldValitateObj, true)
       }
     })
 

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -2301,6 +2301,57 @@ describe('field api', () => {
     ])
   })
 
+  it('should clear a stale onMount error when a linked field revalidation passes', () => {
+    const form = new FormApi({
+      defaultValues: {
+        password: '',
+        confirm_password: 'password',
+      },
+    })
+
+    form.mount()
+
+    const passField = new FieldApi({
+      form,
+      name: 'password',
+    })
+
+    const passconfirmField = new FieldApi({
+      form,
+      name: 'confirm_password',
+      validators: {
+        onMount: ({ value, fieldApi }) =>
+          value !== fieldApi.form.getFieldValue('password')
+            ? 'Passwords do not match'
+            : undefined,
+        onChangeListenTo: ['password'],
+        onChange: ({ value, fieldApi }) =>
+          value !== fieldApi.form.getFieldValue('password')
+            ? 'Passwords do not match'
+            : undefined,
+      },
+    })
+
+    passField.mount()
+    passconfirmField.mount()
+
+    // onMount reports the mismatch (password === '', confirm === 'password').
+    expect(passconfirmField.state.meta.errorMap.onMount).toBe(
+      'Passwords do not match',
+    )
+    expect(passconfirmField.getMeta().isValid).toBe(false)
+
+    // Changing the linked field re-runs confirm's onChange (which now passes)
+    // without touching confirm's own value. The stale onMount error should
+    // clear, just as it would if the field's value had changed directly.
+    passField.setValue('password')
+
+    expect(passconfirmField.state.meta.errorMap.onMount).toBeUndefined()
+    expect(passconfirmField.state.meta.errors).toStrictEqual([])
+    expect(passconfirmField.getMeta().isValid).toBe(true)
+    expect(form.state.isValid).toBe(true)
+  })
+
   it('should run onBlur on a linked field', () => {
     const form = new FormApi({
       defaultValues: {


### PR DESCRIPTION
## Problem
A field-level `onMount` error is cleared when the field's own value changes, but not when the field is revalidated indirectly through `onChangeListenTo` / `onBlurListenTo`. After a passing cross-field revalidation the stale mount-time error lingers, so the field (and the whole form) stays permanently invalid (#2124).

## Root cause
`FormApi.setFieldValue` clears `errorMap.onMount` on a direct value change, treating onMount as a mount-time snapshot. Linked-field revalidation re-runs the field's validators without changing its value, so that clearing never runs.

## Fix
Thread an `isLinkedField` flag into `validateFieldFn`; on a passing linked-field revalidation, clear the stale `onMount` error/source slots. This mirrors the existing value-change clear and the adjacent "clear stale submit error on successful revalidation" logic in the same function.

## Testing
Added a regression test in `packages/form-core/tests/FieldApi.spec.ts` (red before, green after). Full form-core suite (504 tests) passes with no type errors. Changeset included.

Closes #2124


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed stale field errors that could remain after linked-field validation succeeds.
  - Fields now correctly clear outdated mount-time errors when related field changes trigger successful revalidation.
  - Form and field validity states now update correctly without requiring the affected field’s value to change.

- **Tests**
  - Added coverage for linked-field revalidation and stale error removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->