### PR TITLE
fix(form-core): create complete field meta on setFieldValue for uninitialized fields

### DIFF
--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -2659,13 +2659,12 @@ export class FormApi<
 
     batch(() => {
       if (!dontUpdateMeta) {
-        this.setFieldMeta(field, (prev) => ({
+        this.setFieldMeta(field, (prev = defaultFieldMeta) => ({
           ...prev,
           isTouched: true,
           isDirty: true,
           errorMap: {
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-            ...prev?.errorMap,
+            ...prev.errorMap,
             onMount: undefined,
           },
         }))

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -83,6 +83,33 @@ describe('form api', () => {
     })
   })
 
+  it('should create complete meta when setFieldValue targets an uninitialized field', () => {
+    const form = new FormApi({
+      defaultValues: {
+        availableFor: 'longStay',
+      } as { availableFor: string; fees?: number },
+    })
+    form.mount()
+
+    // `fees` is rendered conditionally and has not been mounted yet, so its
+    // meta is created for the first time by this call.
+    form.setFieldValue('fees', 1)
+
+    const meta = form.getFieldMeta('fees')
+
+    // Every documented meta field must be present (not `undefined`), matching
+    // the meta of a field that has been mounted normally.
+    expect(meta).toMatchObject({
+      isValidating: false,
+      isBlurred: false,
+      errors: [],
+      errorSourceMap: {},
+    })
+    expect(meta?.isValidating).not.toBeUndefined()
+    expect(meta?.isBlurred).not.toBeUndefined()
+    expect(meta?.errorSourceMap).not.toBeUndefined()
+  })
+
   it('should reset with provided custom default values', () => {
     const defaultValues = {
       name: 'test',

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -102,6 +102,9 @@ describe('form api', () => {
     expect(meta).toMatchObject({
       isValidating: false,
       isBlurred: false,
+      // `setFieldValue` marks the newly created meta as touched and dirty.
+      isTouched: true,
+      isDirty: true,
       errors: [],
       errorSourceMap: {},
     })


### PR DESCRIPTION
## What & why

`FormApi.setFieldValue` on a field that has never mounted built its meta with `(prev) => ({ ...prev, isTouched, isDirty, errorMap })` where `prev` is `undefined`, producing a **partial** meta object missing required fields declared on `AnyFieldLikeMetaBase` (`isValidating`, `isBlurred`, `errorSourceMap`, `_arrayVersion`, `_pendingValidationsCount`). This is the incomplete-meta problem reported in #1078.

## Fix

Default the updater argument to the shared `defaultFieldMeta`:

```ts
(prev = defaultFieldMeta) => ({ ...prev, isTouched, isDirty, errorMap })
```

in `packages/form-core/src/FormApi.ts`, mirroring the exact pattern already used at the two other `setFieldMeta` call sites in the same file. The meta created for a never-mounted field is now structurally identical to a mounted field's.

## Tests

`packages/form-core/tests/FormApi.spec.ts` — added a failing-first test asserting the created meta is complete (`isValidating: false`, `isBlurred: false`, `errors: []`, `errorSourceMap: {}`, no `undefined` fields) after `setFieldValue` on an uninitialized field. Confirmed red on original code → green after the fix.

Full `@tanstack/form-core` suite: **504 passed / 3 todo**, no type errors.

Closes #1078


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated field value handling so unmounted (conditional) fields receive fully initialized metadata.
  * Ensured validation and interaction state (including error tracking) are no longer left unset when updating field values before mounting.

* **Tests**
  * Added a test covering `setFieldValue` on an unmounted field, verifying default error arrays/maps and related flags are consistently populated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->