### PR TITLE
fix(form-core): reset stale validation counter when shifting array meta

### DIFF
--- a/.changeset/fix-array-removevalue-isvalidating-stuck.md
+++ b/.changeset/fix-array-removevalue-isvalidating-stuck.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/form-core': patch
+---
+
+Fix `isFieldsValidating` getting stuck `true` after `removeValue` on an array field while an async validation is in flight

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -1394,6 +1394,11 @@ export class FieldApi<
    * Ends tracking an async validation, decrementing the counter and clearing isValidating if no validations remain.
    */
   private endValidation() {
+    // The field may have been removed (e.g. via an array `removeValue`) while
+    // this async validation was still in flight. In that case its meta has
+    // already been deleted, so bail out instead of resurrecting empty meta.
+    // See https://github.com/TanStack/form/issues/2234
+    if (this.getInfo().instance !== this) return
     this.setMeta((prev) => {
       const newCount = Math.max(0, prev._pendingValidationsCount - 1)
       return {

--- a/packages/form-core/src/metaHelper.ts
+++ b/packages/form-core/src/metaHelper.ts
@@ -110,7 +110,10 @@ export function metaHelper<
 
         const fromMeta = fromFields.get(fromKey)
         if (fromMeta) {
-          formApi.setFieldMeta(fieldKey as DeepKeys<TFormData>, fromMeta)
+          formApi.setFieldMeta(
+            fieldKey as DeepKeys<TFormData>,
+            resetTransientValidationMeta(fromMeta),
+          )
         }
       })
   }
@@ -153,8 +156,10 @@ export function metaHelper<
         formApi.getFieldMeta(swappedKey),
       ]
 
-      if (meta1) formApi.setFieldMeta(swappedKey, meta1)
-      if (meta2) formApi.setFieldMeta(fieldKey, meta2)
+      if (meta1)
+        formApi.setFieldMeta(swappedKey, resetTransientValidationMeta(meta1))
+      if (meta2)
+        formApi.setFieldMeta(fieldKey, resetTransientValidationMeta(meta2))
     })
   }
 
@@ -239,22 +244,31 @@ export function metaHelper<
       const nextFieldKey = updateIndex(fieldKey.toString(), direction)
       const nextFieldMeta = formApi.getFieldMeta(nextFieldKey)
       if (nextFieldMeta) {
-        // Transient async-validation state is bound to the specific field
-        // instance that started the validation; that instance settles its own
-        // counter against the original index once the promise resolves.
-        // Carrying it over to a shifted index would orphan the counter and
-        // leave `isValidating` stuck true. Array mutations re-trigger
-        // validation on the shifted fields, so it is safe to reset here.
-        // See https://github.com/TanStack/form/issues/2234
-        formApi.setFieldMeta(fieldKey, {
-          ...nextFieldMeta,
-          isValidating: false,
-          _pendingValidationsCount: 0,
-        })
+        formApi.setFieldMeta(
+          fieldKey,
+          resetTransientValidationMeta(nextFieldMeta),
+        )
       } else {
         formApi.setFieldMeta(fieldKey, getEmptyFieldMeta())
       }
     })
+  }
+
+  function resetTransientValidationMeta(
+    meta: AnyFieldLikeMeta,
+  ): AnyFieldLikeMeta {
+    // Transient async-validation state is bound to the specific field instance
+    // that started the validation; that instance settles its own counter
+    // against the original index once the promise resolves. Carrying it over
+    // to a different array index would orphan the counter and leave
+    // `isValidating` stuck true. Array mutations re-trigger validation on the
+    // shifted fields, so it is safe to reset here.
+    // See https://github.com/TanStack/form/issues/2234
+    return {
+      ...meta,
+      isValidating: false,
+      _pendingValidationsCount: 0,
+    }
   }
 
   const getEmptyFieldMeta = (): AnyFieldLikeMeta => defaultFieldMeta

--- a/packages/form-core/src/metaHelper.ts
+++ b/packages/form-core/src/metaHelper.ts
@@ -75,6 +75,8 @@ export function metaHelper<
     toIndex: number,
   ) {
     bumpArrayVersion(field)
+    if (fromIndex === toIndex) return
+
     const affectedFields = getAffectedFields(field, fromIndex, 'move', toIndex)
 
     const startIndex = Math.min(fromIndex, toIndex)
@@ -137,6 +139,8 @@ export function metaHelper<
     secondIndex: number,
   ) {
     bumpArrayVersion(field)
+    if (index === secondIndex) return
+
     const affectedFields = getAffectedFields(field, index, 'swap', secondIndex)
 
     affectedFields.forEach((fieldKey) => {

--- a/packages/form-core/src/metaHelper.ts
+++ b/packages/form-core/src/metaHelper.ts
@@ -239,7 +239,18 @@ export function metaHelper<
       const nextFieldKey = updateIndex(fieldKey.toString(), direction)
       const nextFieldMeta = formApi.getFieldMeta(nextFieldKey)
       if (nextFieldMeta) {
-        formApi.setFieldMeta(fieldKey, nextFieldMeta)
+        // Transient async-validation state is bound to the specific field
+        // instance that started the validation; that instance settles its own
+        // counter against the original index once the promise resolves.
+        // Carrying it over to a shifted index would orphan the counter and
+        // leave `isValidating` stuck true. Array mutations re-trigger
+        // validation on the shifted fields, so it is safe to reset here.
+        // See https://github.com/TanStack/form/issues/2234
+        formApi.setFieldMeta(fieldKey, {
+          ...nextFieldMeta,
+          isValidating: false,
+          _pendingValidationsCount: 0,
+        })
       } else {
         formApi.setFieldMeta(fieldKey, getEmptyFieldMeta())
       }

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -719,6 +719,62 @@ describe('field api', () => {
     vi.useRealTimers()
   })
 
+  it('should reset transient async validation state when moving array field meta', () => {
+    const form = new FormApi({
+      defaultValues: {
+        list: [{ value: 'a' }, { value: 'b' }],
+      },
+    })
+    const arrayField = new FieldApi({ form, name: 'list' })
+    const value0 = new FieldApi({ form, name: 'list[0].value' })
+    const value1 = new FieldApi({ form, name: 'list[1].value' })
+
+    form.mount()
+    arrayField.mount()
+    value0.mount()
+    value1.mount()
+
+    form.setFieldMeta('list[0].value', (meta) => ({
+      ...meta,
+      isValidating: true,
+      _pendingValidationsCount: 1,
+    }))
+
+    arrayField.moveValue(0, 1, { dontValidate: true })
+
+    expect(form.getFieldMeta('list[1].value')?.isValidating).toBe(false)
+    expect(form.getFieldMeta('list[1].value')?._pendingValidationsCount).toBe(0)
+    expect(form.state.isFieldsValidating).toBe(false)
+  })
+
+  it('should reset transient async validation state when swapping array field meta', () => {
+    const form = new FormApi({
+      defaultValues: {
+        list: [{ value: 'a' }, { value: 'b' }],
+      },
+    })
+    const arrayField = new FieldApi({ form, name: 'list' })
+    const value0 = new FieldApi({ form, name: 'list[0].value' })
+    const value1 = new FieldApi({ form, name: 'list[1].value' })
+
+    form.mount()
+    arrayField.mount()
+    value0.mount()
+    value1.mount()
+
+    form.setFieldMeta('list[0].value', (meta) => ({
+      ...meta,
+      isValidating: true,
+      _pendingValidationsCount: 1,
+    }))
+
+    arrayField.swapValues(0, 1, { dontValidate: true })
+
+    expect(form.getFieldMeta('list[1].value')?.isValidating).toBe(false)
+    expect(form.getFieldMeta('list[1].value')?._pendingValidationsCount).toBe(0)
+    expect(form.state.isFieldsValidating).toBe(false)
+  })
+
   it('should swap a value from an array value correctly', () => {
     const form = new FormApi({
       defaultValues: {

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -747,6 +747,32 @@ describe('field api', () => {
     expect(form.state.isFieldsValidating).toBe(false)
   })
 
+  it('should preserve transient async validation state when moving array field meta to the same index', () => {
+    const form = new FormApi({
+      defaultValues: {
+        list: [{ value: 'a' }, { value: 'b' }],
+      },
+    })
+    const arrayField = new FieldApi({ form, name: 'list' })
+    const value0 = new FieldApi({ form, name: 'list[0].value' })
+
+    form.mount()
+    arrayField.mount()
+    value0.mount()
+
+    form.setFieldMeta('list[0].value', (meta) => ({
+      ...meta,
+      isValidating: true,
+      _pendingValidationsCount: 1,
+    }))
+
+    arrayField.moveValue(0, 0, { dontValidate: true })
+
+    expect(form.getFieldMeta('list[0].value')?.isValidating).toBe(true)
+    expect(form.getFieldMeta('list[0].value')?._pendingValidationsCount).toBe(1)
+    expect(form.state.isFieldsValidating).toBe(true)
+  })
+
   it('should reset transient async validation state when swapping array field meta', () => {
     const form = new FormApi({
       defaultValues: {
@@ -773,6 +799,32 @@ describe('field api', () => {
     expect(form.getFieldMeta('list[1].value')?.isValidating).toBe(false)
     expect(form.getFieldMeta('list[1].value')?._pendingValidationsCount).toBe(0)
     expect(form.state.isFieldsValidating).toBe(false)
+  })
+
+  it('should preserve transient async validation state when swapping array field meta at the same index', () => {
+    const form = new FormApi({
+      defaultValues: {
+        list: [{ value: 'a' }, { value: 'b' }],
+      },
+    })
+    const arrayField = new FieldApi({ form, name: 'list' })
+    const value0 = new FieldApi({ form, name: 'list[0].value' })
+
+    form.mount()
+    arrayField.mount()
+    value0.mount()
+
+    form.setFieldMeta('list[0].value', (meta) => ({
+      ...meta,
+      isValidating: true,
+      _pendingValidationsCount: 1,
+    }))
+
+    arrayField.swapValues(0, 0, { dontValidate: true })
+
+    expect(form.getFieldMeta('list[0].value')?.isValidating).toBe(true)
+    expect(form.getFieldMeta('list[0].value')?._pendingValidationsCount).toBe(1)
+    expect(form.state.isFieldsValidating).toBe(true)
   })
 
   it('should swap a value from an array value correctly', () => {

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -652,6 +652,73 @@ describe('field api', () => {
     expect(form.state.canSubmit).toBe(true)
   })
 
+  it('should not leave isFieldsValidating stuck true when removing an array item while an async validation is in flight', async () => {
+    vi.useFakeTimers()
+    let resolve!: () => void
+    let promise = new Promise<void>((r) => {
+      resolve = r as never
+    })
+
+    const form = new FormApi({
+      defaultValues: {
+        list: [
+          { operator: 'a', value: '1' },
+          { operator: 'b', value: '2' },
+        ],
+      },
+    })
+
+    const arrayField = new FieldApi({ form, name: 'list' })
+
+    const makeRow = (i: number) => {
+      const operator = new FieldApi({
+        form,
+        name: `list[${i}].operator` as const,
+      })
+      const value = new FieldApi({
+        form,
+        name: `list[${i}].value` as const,
+        validators: {
+          onChangeListenTo: [`list[${i}].operator`],
+          onChangeAsyncDebounceMs: 0,
+          onChangeAsync: async () => {
+            await promise
+            return undefined
+          },
+        },
+      })
+      return { operator, value }
+    }
+
+    form.mount()
+    arrayField.mount()
+    const row0 = makeRow(0)
+    const row1 = makeRow(1)
+    row0.operator.mount()
+    row0.value.mount()
+    row1.operator.mount()
+    row1.value.mount()
+
+    // Kick off an async validation on row 1's value via its listened-to field
+    row1.operator.setValue('changed')
+    await Promise.resolve()
+    expect(form.getFieldMeta('list[1].value')?.isValidating).toBe(true)
+
+    // Remove row 0 while row 1's async validation is still pending: row 1's
+    // meta (with its in-flight validation counter) shifts down into row 0.
+    await arrayField.removeValue(0)
+
+    // Resolve the pending validation and let everything settle
+    resolve()
+    await vi.runAllTimersAsync()
+
+    expect(form.getFieldMeta('list[0].value')?.isValidating).toBe(false)
+    expect(form.getFieldMeta('list[0].value')?._pendingValidationsCount).toBe(0)
+    expect(form.state.isFieldsValidating).toBe(false)
+
+    vi.useRealTimers()
+  })
+
   it('should swap a value from an array value correctly', () => {
     const form = new FormApi({
       defaultValues: {


### PR DESCRIPTION
## 🎯 Changes

Fixes #2234. When an array item is removed (or inserted/moved) while an async validator is in flight, `shiftMeta` copied the source field's transient `_pendingValidationsCount`/`isValidating` down to the shifted index. The pending promise is owned by the original field instance and settles its counter against the original index, so the shifted index's counter is orphaned and never decremented — leaving `form.state.isFieldsValidating` stuck `true` and blocking submission.

- `shiftMeta` now resets the transient validation state (`isValidating`, `_pendingValidationsCount`) when shifting meta between indices. Array mutations already re-trigger validation on the shifted fields, so this is safe.
- `endValidation` bails out if the field's instance is no longer registered, so a validation that resolves after its field was removed no longer resurrects deleted meta (previously threw a `TypeError`).

## ✅ Checklist

- [x] I have followed the steps in the Contributing guide.
- [x] I have tested this code locally.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where async validation state could remain stuck after removing an item from an array field during in-flight validation.
  - Ensured transient async-validation indicators are properly reset or preserved when array field metadata shifts due to move, swap, or shift operations.
- **Tests**
  - Added coverage for array remove/move/swap scenarios with in-flight async validation, verifying field-level and form-level validating status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->