### PR TITLE
docs(installation): list all framework adapters in intro

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@ id: installation
 title: Installation
 ---
 
-TanStack Form is compatible with various front-end frameworks, including React, Vue, and Solid. Install the corresponding adapter for your framework using your preferred package manager:
+TanStack Form is compatible with various front-end frameworks, including React, Vue, Angular, Solid, Lit, and Svelte. Install the corresponding adapter for your framework using your preferred package manager:
 
 <!-- ::start:tabs variant="package-managers" -->
 


### PR DESCRIPTION
The installation intro listed only React, Vue, Solid — but the adapter table below includes Angular, Lit, and Svelte too. Updated the intro to match.