### PR TITLE
docs(philosophy): clarify 'Three.js framework adapters' to 'Three.js renderers'

### DIFF
--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -33,7 +33,7 @@ This comes with a number of advantages:
 
 - **Predictable**: You can predict the state of your form at any point in time.
 - **Easier testing**: You can easily test your forms by passing in values and asserting on the output.
-- **Non-DOM support**: You can use TanStack Form with React Native, Three.js framework adapters, or any other framework renderer.
+- **Non-DOM support**: You can use TanStack Form with React Native, Three.js renderers, or any other framework renderer.
 - **Enhanced conditional logic**: You can easily conditionally show/hide fields based on the form state.
 - **Debugging**: You can easily log the form state to the console to debug issues.
 


### PR DESCRIPTION
Three.js framework adapters → Three.js renderers. Three.js is a WebGL renderer, not a framework, and the surrounding sentence uses enderer for everything else.