### PR TITLE
docs: fix API tab 404 by removing broken reference/index links

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -420,10 +420,6 @@
       "label": "API Reference",
       "children": [
         {
-          "label": "JavaScript Reference",
-          "to": "reference/index"
-        },
-        {
           "label": "Classes / FieldApi",
           "to": "reference/classes/FieldApi"
         },
@@ -509,10 +505,6 @@
           "label": "react",
           "children": [
             {
-              "label": "React Reference",
-              "to": "framework/react/reference/index"
-            },
-            {
               "label": "Variables / Field",
               "to": "framework/react/reference/variables/Field"
             },
@@ -542,10 +534,6 @@
           "label": "preact",
           "children": [
             {
-              "label": "Preact Reference",
-              "to": "framework/preact/reference/index"
-            },
-            {
               "label": "Variables / Field",
               "to": "framework/preact/reference/variables/Field"
             },
@@ -570,10 +558,6 @@
         {
           "label": "vue",
           "children": [
-            {
-              "label": "Vue Reference",
-              "to": "framework/vue/reference/index"
-            },
             {
               "label": "Variables / Field",
               "to": "framework/vue/reference/variables/Field"
@@ -600,10 +584,6 @@
           "label": "solid",
           "children": [
             {
-              "label": "Solid Reference",
-              "to": "framework/solid/reference/index"
-            },
-            {
               "label": "Functions / createField",
               "to": "framework/solid/reference/functions/createField"
             },
@@ -629,10 +609,6 @@
           "label": "lit",
           "children": [
             {
-              "label": "Lit Reference",
-              "to": "framework/lit/reference/index"
-            },
-            {
               "label": "Classes / TanStackFormController",
               "to": "framework/lit/reference/classes/TanStackFormController"
             }
@@ -641,10 +617,6 @@
         {
           "label": "angular",
           "children": [
-            {
-              "label": "Angular Reference",
-              "to": "framework/angular/reference/index"
-            },
             {
               "label": "Classes / TanStackField",
               "to": "framework/angular/reference/classes/TanStackField"


### PR DESCRIPTION
## Summary
- Fixes the docs **API** tab 404 reported in #2226 by removing sidebar entries that pointed at `reference/index` (and the framework equivalents).
- Those links resolve to https://tanstack.com/form/latest/docs/reference/index, which currently 404 page.
- After this change, the API tab lands on the first concrete reference page that already works (e.g. `FieldApi` / framework-specific APIs).

Fixes #2226

---

## Note
If `docs/reference/index.md` and `docs/framework/*/reference/index.md` should actually be shown in the docs UI, more changes will likely be needed.

Please feel free to suggest edits! Thanks!

---

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).