### PR TITLE
fix: require compatible withFieldGroup field types

### DIFF
--- a/packages/form-core/src/util-types.ts
+++ b/packages/form-core/src/util-types.ts
@@ -196,6 +196,60 @@ export type DeepKeysOfType<TData, TValue> = Extract<
   AnyDeepKeyAndValue<string, TValue>
 >['key']
 
+type IsEqual<TValue, TOther> = [TValue] extends [TOther]
+  ? [TOther] extends [TValue]
+    ? true
+    : false
+  : false
+
+/**
+ * Checks whether the form value can safely back a field group value.
+ * Extra form fields are allowed, but fields exposed by the field group must match exactly.
+ */
+type IsFieldGroupCompatible<TFormValue, TFieldGroupValue> = [
+  TFieldGroupValue,
+] extends [ReadonlyArray<infer TFieldGroupItem>]
+  ? [TFormValue] extends [ReadonlyArray<infer TFormItem>]
+    ? IsFieldGroupCompatible<TFormItem, TFieldGroupItem>
+    : false
+  : [TFieldGroupValue] extends [object]
+    ? [TFormValue] extends [object]
+      ? false extends {
+          [K in keyof TFieldGroupValue]-?: K extends keyof TFormValue
+            ? IsFieldGroupCompatible<TFormValue[K], TFieldGroupValue[K]>
+            : false
+        }[keyof TFieldGroupValue]
+        ? false
+        : true
+      : false
+    : IsEqual<TFormValue, TFieldGroupValue>
+
+/**
+ * The keys of an object or array, deeply nested and compatible with a field group value.
+ */
+export type DeepKeysOfFieldGroupType<TData, TValue> = unknown extends TData
+  ? string
+  : DeepKeysAndValues<TData> extends infer TDeepKeyAndValue
+    ? TDeepKeyAndValue extends AnyDeepKeyAndValue<infer TKey, infer TDeepValue>
+      ? IsFieldGroupCompatible<NonNullable<TDeepValue>, TValue> extends true
+        ? TKey
+        : never
+      : never
+    : never
+
+/**
+ * The keys of an object or array, deeply nested and compatible with a mapped field group value.
+ */
+export type DeepKeysOfFieldGroupFieldType<TData, TValue> = unknown extends TData
+  ? string
+  : DeepKeysAndValues<TData> extends infer TDeepKeyAndValue
+    ? TDeepKeyAndValue extends AnyDeepKeyAndValue<infer TKey, infer TDeepValue>
+      ? IsFieldGroupCompatible<TDeepValue, TValue> extends true
+        ? TKey
+        : never
+      : never
+    : never
+
 /**
  * Maps the deep keys of TFormData to the shallow keys of TFieldGroupData.
  *  Since using template strings as keys is impractical, it relies on shallow keys only.
@@ -207,6 +261,22 @@ export type FieldsMap<TFormData, TFieldGroupData> =
       ? never
       : {
           [K in keyof TFieldGroupData]: DeepKeysOfType<
+            TFormData,
+            TFieldGroupData[K]
+          >
+        }
+
+/**
+ * Maps the deep keys of TFormData to the shallow keys of TFieldGroupData with compatible field group value types.
+ *  Since using template strings as keys is impractical, it relies on shallow keys only.
+ */
+export type FieldGroupFieldsMap<TFormData, TFieldGroupData> =
+  TFieldGroupData extends any[]
+    ? never
+    : string extends keyof TFieldGroupData
+      ? never
+      : {
+          [K in keyof TFieldGroupData]: DeepKeysOfFieldGroupFieldType<
             TFormData,
             TFieldGroupData[K]
           >

--- a/packages/form-core/src/util-types.ts
+++ b/packages/form-core/src/util-types.ts
@@ -226,6 +226,8 @@ type IsFieldGroupCompatible<TFormValue, TFieldGroupValue> = [
 
 /**
  * The keys of an object or array, deeply nested and compatible with a field group value.
+ * This strips the container value's own nullability so `fields="key"` can target
+ * optional whole-object shapes.
  */
 export type DeepKeysOfFieldGroupType<TData, TValue> = unknown extends TData
   ? string
@@ -239,6 +241,8 @@ export type DeepKeysOfFieldGroupType<TData, TValue> = unknown extends TData
 
 /**
  * The keys of an object or array, deeply nested and compatible with a mapped field group value.
+ * This preserves leaf-value nullability so `fields={{ child: "key.child" }}`
+ * only accepts exact mapped field value compatibility.
  */
 export type DeepKeysOfFieldGroupFieldType<TData, TValue> = unknown extends TData
   ? string

--- a/packages/preact-form/src/createFormHook.tsx
+++ b/packages/preact-form/src/createFormHook.tsx
@@ -7,8 +7,9 @@ import type {
   AnyFieldApi,
   AnyFormApi,
   BaseFormOptions,
-  DeepKeysOfType,
+  DeepKeysOfFieldGroupType,
   FieldApi,
+  FieldGroupFieldsMap,
   FieldsMap,
   FormAsyncValidateOrFn,
   FormOptions,
@@ -468,8 +469,8 @@ export function createFormHook<
   >): <
     TFormData,
     TFields extends
-      | DeepKeysOfType<TFormData, TFieldGroupData | null | undefined>
-      | FieldsMap<TFormData, TFieldGroupData>,
+      | DeepKeysOfFieldGroupType<TFormData, TFieldGroupData>
+      | FieldGroupFieldsMap<TFormData, TFieldGroupData>,
     TOnMount extends undefined | FormValidateOrFn<TFormData>,
     TOnChange extends undefined | FormValidateOrFn<TFormData>,
     TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,

--- a/packages/preact-form/tests/createFormHook.test-d.tsx
+++ b/packages/preact-form/tests/createFormHook.test-d.tsx
@@ -821,6 +821,52 @@ describe('createFormHook', () => {
     const Component5 = <FieldGroup form={form} fields="nope2" />
   })
 
+  it('should require exact field value types for withFieldGroup fields', () => {
+    type PasswordFields = {
+      password: string | null
+    }
+
+    const FieldGroupPasswordFields = withFieldGroup({
+      defaultValues: { password: '' } as PasswordFields,
+      render: function Render() {
+        return <></>
+      },
+    })
+
+    const form = useAppForm({
+      defaultValues: {
+        reusable: { password: '' },
+        exact: { password: null as string | null },
+      },
+    })
+
+    const ExactComponent = (
+      <FieldGroupPasswordFields form={form} fields="exact" />
+    )
+    const ExactMappedComponent = (
+      <FieldGroupPasswordFields
+        form={form}
+        fields={{ password: 'exact.password' }}
+      />
+    )
+    const TooWideComponent = (
+      <FieldGroupPasswordFields
+        form={form}
+        // @ts-expect-error because the field group could write null into a string-only parent field
+        fields="reusable"
+      />
+    )
+    const TooWideMappedComponent = (
+      <FieldGroupPasswordFields
+        form={form}
+        fields={{
+          // @ts-expect-error because the field group could write null into a string-only parent field
+          password: 'reusable.password',
+        }}
+      />
+    )
+  })
+
   it('should allow interfaces without index signatures to be assigned to `props` in withForm and withFormGroup', () => {
     interface TestNoSignature {
       title: string

--- a/packages/react-form/src/createFormHook.tsx
+++ b/packages/react-form/src/createFormHook.tsx
@@ -7,8 +7,9 @@ import type {
   AnyFieldApi,
   AnyFormApi,
   BaseFormOptions,
-  DeepKeysOfType,
+  DeepKeysOfFieldGroupType,
   FieldApi,
+  FieldGroupFieldsMap,
   FieldsMap,
   FormAsyncValidateOrFn,
   FormOptions,
@@ -469,8 +470,8 @@ export function createFormHook<
   >): <
     TFormData,
     TFields extends
-      | DeepKeysOfType<TFormData, TFieldGroupData | null | undefined>
-      | FieldsMap<TFormData, TFieldGroupData>,
+      | DeepKeysOfFieldGroupType<TFormData, TFieldGroupData>
+      | FieldGroupFieldsMap<TFormData, TFieldGroupData>,
     TOnMount extends undefined | FormValidateOrFn<TFormData>,
     TOnChange extends undefined | FormValidateOrFn<TFormData>,
     TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,

--- a/packages/react-form/tests/createFormHook.test-d.tsx
+++ b/packages/react-form/tests/createFormHook.test-d.tsx
@@ -820,6 +820,52 @@ describe('createFormHook', () => {
     const Component5 = <FieldGroup form={form} fields="nope2" />
   })
 
+  it('should require exact field value types for withFieldGroup fields', () => {
+    type PasswordFields = {
+      password: string | null
+    }
+
+    const FieldGroupPasswordFields = withFieldGroup({
+      defaultValues: { password: '' } as PasswordFields,
+      render: function Render() {
+        return <></>
+      },
+    })
+
+    const form = useAppForm({
+      defaultValues: {
+        reusable: { password: '' },
+        exact: { password: null as string | null },
+      },
+    })
+
+    const ExactComponent = (
+      <FieldGroupPasswordFields form={form} fields="exact" />
+    )
+    const ExactMappedComponent = (
+      <FieldGroupPasswordFields
+        form={form}
+        fields={{ password: 'exact.password' }}
+      />
+    )
+    const TooWideComponent = (
+      <FieldGroupPasswordFields
+        form={form}
+        // @ts-expect-error because the field group could write null into a string-only parent field
+        fields="reusable"
+      />
+    )
+    const TooWideMappedComponent = (
+      <FieldGroupPasswordFields
+        form={form}
+        fields={{
+          // @ts-expect-error because the field group could write null into a string-only parent field
+          password: 'reusable.password',
+        }}
+      />
+    )
+  })
+
   it('should allow interfaces without index signatures to be assigned to `props` in withForm and withFormGroup', () => {
     interface TestNoSignature {
       title: string

--- a/packages/solid-form/src/createFormHook.tsx
+++ b/packages/solid-form/src/createFormHook.tsx
@@ -11,8 +11,9 @@ import type {
   AnyFieldApi,
   AnyFormApi,
   BaseFormOptions,
-  DeepKeysOfType,
+  DeepKeysOfFieldGroupType,
   FieldApi,
+  FieldGroupFieldsMap,
   FieldsMap,
   FormAsyncValidateOrFn,
   FormOptions,
@@ -493,8 +494,8 @@ export function createFormHook<
   >): <
     TFormData,
     TFields extends
-      | DeepKeysOfType<TFormData, TFieldGroupData | null | undefined>
-      | FieldsMap<TFormData, TFieldGroupData>,
+      | DeepKeysOfFieldGroupType<TFormData, TFieldGroupData>
+      | FieldGroupFieldsMap<TFormData, TFieldGroupData>,
     TOnMount extends undefined | FormValidateOrFn<TFormData>,
     TOnChange extends undefined | FormValidateOrFn<TFormData>,
     TOnChangeAsync extends undefined | FormAsyncValidateOrFn<TFormData>,

--- a/packages/solid-form/tests/createFormHook.test-d.tsx
+++ b/packages/solid-form/tests/createFormHook.test-d.tsx
@@ -10,7 +10,7 @@ function Test() {
   return null
 }
 
-const { useAppForm, withForm } = createFormHook({
+const { useAppForm, withForm, withFieldGroup } = createFormHook({
   fieldComponents: {
     Test,
   },
@@ -247,6 +247,52 @@ describe('createFormHook', () => {
     const IncorrectFormOptsComponent = (
       // @ts-expect-error Incorrect form opts
       <WithFormComponent form={incorrectAppForm} prop1="test" prop2={10} />
+    )
+  })
+
+  it('should require exact field value types for withFieldGroup fields', () => {
+    type PasswordFields = {
+      password: string | null
+    }
+
+    const FieldGroupPasswordFields = withFieldGroup({
+      defaultValues: { password: '' } as PasswordFields,
+      render: function Render() {
+        return <></>
+      },
+    })
+
+    const form = useAppForm(() => ({
+      defaultValues: {
+        reusable: { password: '' },
+        exact: { password: null as string | null },
+      },
+    }))
+
+    const ExactComponent = (
+      <FieldGroupPasswordFields form={form} fields="exact" />
+    )
+    const ExactMappedComponent = (
+      <FieldGroupPasswordFields
+        form={form}
+        fields={{ password: 'exact.password' }}
+      />
+    )
+    const TooWideComponent = (
+      <FieldGroupPasswordFields
+        form={form}
+        // @ts-expect-error because the field group could write null into a string-only parent field
+        fields="reusable"
+      />
+    )
+    const TooWideMappedComponent = (
+      <FieldGroupPasswordFields
+        form={form}
+        fields={{
+          // @ts-expect-error because the field group could write null into a string-only parent field
+          password: 'reusable.password',
+        }}
+      />
     )
   })
 })


### PR DESCRIPTION
Fixes #1855

## Changes
- Add field-group-specific deep key helpers that allow parent objects to have extra fields while requiring exposed field values to be compatible.
- Use the stricter helper for `withFieldGroup` component `fields` in React, Preact, and Solid.
- Document the intentional nullability asymmetry between whole-group field matching and mapped leaf-field matching.
- Add React, Preact, and Solid type regression coverage for reusable groups that can write `null` into string-only parent fields.

## Checklist
- [x] Added or updated type regression coverage.
- [x] Kept runtime behavior unchanged; this is a type-level compatibility fix.
- [x] Verified affected package type tests locally.

## Tests
- `pnpm prettier --check packages/form-core/src/util-types.ts packages/react-form/src/createFormHook.tsx packages/react-form/tests/createFormHook.test-d.tsx packages/preact-form/src/createFormHook.tsx packages/preact-form/tests/createFormHook.test-d.tsx packages/solid-form/src/createFormHook.tsx`
- `pnpm --filter @tanstack/react-form test:types`
- `pnpm --filter @tanstack/preact-form test:types`
- `pnpm --filter @tanstack/solid-form test:types`
- `pnpm --filter @tanstack/form-core test:types`

## Release Impact
TypeScript-only fix for `withFieldGroup` field compatibility. It should prevent unsafe nullable field-group mappings without changing runtime behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved TypeScript type checking for field-group field mappings across React, Preact, and Solid integrations.
  * Field-group mappings now support compatible nested object and array structures, while preventing unsafe parent/leaf type mismatches.
  * Mapping constraints are tightened to avoid cases where a field group could write `null`/other incompatible values into a non-compatible parent field.

* **Tests**
  * Added TypeScript type-tests covering accepted valid mappings and rejecting incompatible nullable/non-nullable and path-based vs object-based mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
