### PR TITLE
fix(vue-form): generate an SSR-safe default formId

### DIFF
--- a/.changeset/lucky-donkeys-shout.md
+++ b/.changeset/lucky-donkeys-shout.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/vue-form': patch
+---
+
+Generate the default `formId` with Vue's `useId` so it is SSR-safe, falling back to a random uuid on `vue@3.4` (where `useId` does not exist) and outside of a component instance.
+
+Fixes #2254

--- a/packages/vue-form/src/useForm.tsx
+++ b/packages/vue-form/src/useForm.tsx
@@ -3,6 +3,7 @@ import { useSelector } from '@tanstack/vue-store'
 import { defineComponent, h, onMounted } from 'vue'
 import { Field } from './useField'
 import { FormGroup } from './useFormGroup'
+import { useFormId } from './useFormId'
 import type {
   FormAsyncValidateOrFn,
   FormOptions,
@@ -268,6 +269,8 @@ export function useForm<
     TSubmitMeta
   >,
 ) {
+  const fallbackFormId = useFormId()
+
   const formApi = (() => {
     const api = new FormApi<
       TParentData,
@@ -282,7 +285,7 @@ export function useForm<
       TFormOnDynamicAsync,
       TFormOnServer,
       TSubmitMeta
-    >(opts)
+    >({ ...opts, formId: opts?.formId ?? fallbackFormId })
 
     const extendedApi: typeof api &
       VueFormApi<

--- a/packages/vue-form/src/useFormId.ts
+++ b/packages/vue-form/src/useFormId.ts
@@ -1,0 +1,24 @@
+import * as Vue from 'vue'
+import { uuid } from '@tanstack/form-core'
+
+/**
+ * `useId` was added in vue@3.5, but this package supports `vue@^3.4.0`. It is
+ * read off the namespace, typed as optional, rather than imported by name: a
+ * named import would make bundlers fail to resolve it on 3.4.
+ * Read more: https://github.com/webpack/webpack/issues/14814
+ */
+const vueUseId: { useId?: () => string } = Vue
+
+/**
+ * Returns an SSR-safe id for the form, so the server-rendered markup and the
+ * client hydration agree on it. Falls back to a random uuid when `useId` is
+ * unavailable, or when called outside of a component instance, where `useId`
+ * cannot produce a stable value.
+ */
+export function useFormId(): string {
+  const useId = vueUseId.useId
+  if (useId && Vue.getCurrentInstance()) {
+    return useId()
+  }
+  return uuid()
+}

--- a/packages/vue-form/tests/useFormId.test.tsx
+++ b/packages/vue-form/tests/useFormId.test.tsx
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { render } from '@testing-library/vue'
-import { createSSRApp, defineComponent, h } from 'vue'
+import { createSSRApp, defineComponent, h, nextTick } from 'vue'
 import { renderToString } from 'vue/server-renderer'
 import { useForm } from '../src'
 
@@ -45,5 +45,27 @@ describe('useFormId', () => {
 
     expect(serverId).toBeTruthy()
     expect(clientId).toBe(serverId)
+  })
+
+  it('hydrates server-rendered markup without a mismatch', async () => {
+    const container = document.createElement('div')
+    container.innerHTML = await renderToString(createSSRApp(Comp))
+    document.body.appendChild(container)
+
+    const serverId = container.querySelector('form')?.id
+
+    // Vue reports hydration mismatches through `console.error`, so actually
+    // hydrate the server markup and assert none were raised.
+    const errors: Array<string> = []
+    const spy = vi
+      .spyOn(console, 'error')
+      .mockImplementation((...args) => void errors.push(args.join(' ')))
+
+    createSSRApp(Comp).mount(container)
+    await nextTick()
+    spy.mockRestore()
+
+    expect(errors.filter((e) => /hydration/i.test(e))).toEqual([])
+    expect(container.querySelector('form')?.id).toBe(serverId)
   })
 })

--- a/packages/vue-form/tests/useFormId.test.tsx
+++ b/packages/vue-form/tests/useFormId.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/vue'
+import { createSSRApp, defineComponent, h } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import { useForm } from '../src'
+
+const Comp = defineComponent(() => {
+  const form = useForm({ defaultValues: { firstName: '' } })
+
+  return () => <form id={form.formId} data-testid="form" />
+})
+
+describe('useFormId', () => {
+  it('uses the provided formId when one is given', () => {
+    const WithId = defineComponent(() => {
+      const form = useForm({
+        defaultValues: { firstName: '' },
+        formId: 'my-form',
+      })
+
+      return () => <form id={form.formId} data-testid="form" />
+    })
+
+    const { getByTestId } = render(WithId)
+
+    expect(getByTestId('form').getAttribute('id')).toBe('my-form')
+  })
+
+  it('generates the same default formId across identical renders', () => {
+    // Scoped to each render's own container: both mount into `document.body`,
+    // so a document-wide query would find each other's form too.
+    const first = render(Comp).container.querySelector('form')?.id
+    const second = render(Comp).container.querySelector('form')?.id
+
+    expect(first).toBeTruthy()
+    expect(second).toBe(first)
+  })
+
+  it('generates a default formId that matches between server and client', async () => {
+    const html = await renderToString(createSSRApp(Comp))
+    // `\s` so this doesn't match the `id="` inside `data-testid="..."`
+    const serverId = html.match(/\sid="([^"]*)"/)?.[1]
+
+    const clientId = render(Comp).getByTestId('form').getAttribute('id')
+
+    expect(serverId).toBeTruthy()
+    expect(clientId).toBe(serverId)
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Fixes #2254.

`FormApi` falls back to `uuid()` when no `formId` is passed, and the Vue adapter never passes one — so the id differs between the server render and the client render, and binding it (`<form :id="form.formId">`) produces a hydration mismatch.

This uses Vue's `useId` for the default instead, which is exactly what the other adapters already do:

- `react-form/src/useFormId.ts` — `React.useId`, falling back to `useUUID` on React 17
- `preact-form/src/useFormId.ts` — `useId` from `preact/hooks`

Vue had no equivalent, so `packages/vue-form/src/useFormId.ts` adds one and `useForm` now passes `formId: opts?.formId ?? fallbackFormId`, mirroring `react-form/src/useForm.tsx`.

### The version constraint

`useId` was added in **vue@3.5**, but `@tanstack/vue-form` declares `peerDependencies: { "vue": "^3.4.0" }`. So a straight `import { useId } from 'vue'` would break 3.4 consumers — and a named import of a missing export is a bundler resolution error, not a runtime `undefined`. It is therefore read off the namespace and typed as optional, with the same reasoning as the existing React comment (webpack/webpack#14814):

```ts
const vueUseId: { useId?: () => string } = Vue

export function useFormId(): string {
  const useId = vueUseId.useId
  if (useId && Vue.getCurrentInstance()) {
    return useId()
  }
  return uuid()
}
```

The `getCurrentInstance()` guard matters too: outside a component instance `useId` cannot produce a stable value and warns in dev, so `useForm` called outside `setup` keeps the old uuid behaviour rather than emitting a warning.

If you would rather bump the peer range to `^3.5.0` and call `useId` unconditionally, happy to switch — this way keeps 3.4 working.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Verification

`packages/vue-form/tests/useFormId.test.tsx` covers this. Run against `main` with only the test applied (i.e. reverting `useForm.tsx`), it fails on the two default-id cases while the explicit-id control still passes:

| Test | Without the fix | With the fix |
| --- | --- | --- |
| uses the provided `formId` when one is given | ✅ (control) | ✅ |
| same default `formId` across identical renders | ❌ `2902fb86-…` vs `752902fb-…` | ✅ |
| default `formId` matches between server and client | ❌ `fb8639db-…` vs `02fb8639-…` | ✅ |

The server/client case renders through `renderToString` from `vue/server-renderer` (reached via the `vue` subpath export, so it adds no new dependency) and compares against a client render.

Also run locally:

- `pnpm test:pr` → **passes** (`test:sherif`, `test:knip`, `test:docs`, `test:eslint`, `test:lib`, `test:types`, `test:build`, `build`)
- full `@tanstack/vue-form` suite → **31 passed**, no type errors

---

Disclosure: I used an AI assistant while investigating and preparing this change, including running the verification above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `useFormId` composable for generating SSR-safe, stable form identifiers.
  * `useForm` now defaults to an auto-generated `formId` when none is provided.
* **Bug Fixes**
  * Prevented mismatches between server-rendered and client-hydrated form IDs.
  * Ensured safe ID generation when `useId` isn’t available (including non-component usage).
* **Tests**
  * Added Vitest coverage for provided IDs, deterministic defaults, and SSR/client consistency (including hydration without warnings).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->