### PR TITLE
fix(solid-form): generate an SSR-safe default formId

### DIFF
--- a/.changeset/great-pugs-shave.md
+++ b/.changeset/great-pugs-shave.md
@@ -2,4 +2,4 @@
 '@tanstack/solid-form': patch
 ---
 
-Generate the default `formId` with Solid's `createUniqueId` so it is SSR-safe. Previously `createForm` never passed a `formId`, so `FormApi` fell back to a random uuid that differed between the server render and the client render, and binding it (`<form id={form.formId}>`) produced a hydration mismatch under SolidStart. Mirrors the existing behaviour of the react, preact and vue adapters.
+Generate the default `formId` with Solid's `createUniqueId` so it is SSR-safe. Previously, when no `formId` was configured, `createForm` did not provide a fallback, so `FormApi` generated a random UUID that differed between the server render and the client render. Binding that generated id (`<form id={form.formId}>`) produced a hydration mismatch under SolidStart. An explicitly provided `formId` was already forwarded and is unchanged. This mirrors the existing behaviour of the React, Preact, and Vue adapters.

--- a/.changeset/great-pugs-shave.md
+++ b/.changeset/great-pugs-shave.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-form': patch
+---
+
+Generate the default `formId` with Solid's `createUniqueId` so it is SSR-safe. Previously `createForm` never passed a `formId`, so `FormApi` fell back to a random uuid that differed between the server render and the client render, and binding it (`<form id={form.formId}>`) produced a hydration mismatch under SolidStart. Mirrors the existing behaviour of the react, preact and vue adapters.

--- a/packages/solid-form/src/createForm.tsx
+++ b/packages/solid-form/src/createForm.tsx
@@ -1,5 +1,5 @@
 import { FormApi, functionalUpdate } from '@tanstack/form-core'
-import { createComputed, onMount } from 'solid-js'
+import { createComputed, createUniqueId, onMount } from 'solid-js'
 import { useSelector } from '@tanstack/solid-store'
 import { Field, createField } from './createField'
 import { FormGroup } from './createFormGroup'
@@ -240,6 +240,14 @@ export function createForm<
   >,
 ) {
   const options = opts?.()
+  /**
+   * `FormApi` falls back to `uuid()` when no `formId` is given, which differs
+   * between the server render and the client render. `createUniqueId` is
+   * Solid's SSR-safe counterpart, so binding the id (`<form id={form.formId}>`)
+   * no longer produces a hydration mismatch. Mirrors `useFormId` in the react,
+   * preact and vue adapters.
+   */
+  const fallbackFormId = createUniqueId()
   const api = new FormApi<
     TParentData,
     TFormOnMount,
@@ -253,7 +261,7 @@ export function createForm<
     TFormOnDynamicAsync,
     TFormOnServer,
     TSubmitMeta
-  >(options)
+  >({ ...options, formId: options?.formId ?? fallbackFormId })
   const extendedApi: typeof api &
     SolidFormApi<
       TParentData,

--- a/packages/solid-form/src/createForm.tsx
+++ b/packages/solid-form/src/createForm.tsx
@@ -244,8 +244,8 @@ export function createForm<
    * `FormApi` falls back to `uuid()` when no `formId` is given, which differs
    * between the server render and the client render. `createUniqueId` is
    * Solid's SSR-safe counterpart, so binding the id (`<form id={form.formId}>`)
-   * no longer produces a hydration mismatch. Mirrors `useFormId` in the react,
-   * preact and vue adapters.
+   * no longer produces a hydration mismatch. Mirrors `useFormId` in the React,
+   * Preact, and Vue adapters.
    */
   const fallbackFormId = createUniqueId()
   const api = new FormApi<

--- a/packages/solid-form/tests/createFormId.test.tsx
+++ b/packages/solid-form/tests/createFormId.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '@solidjs/testing-library'
+import { createForm } from '../src/index'
+
+function Comp() {
+  const form = createForm(() => ({ defaultValues: { firstName: '' } }))
+  return <form id={form.formId} data-testid="form" />
+}
+
+describe('createForm formId', () => {
+  it('uses the provided formId when one is given', () => {
+    function WithId() {
+      const form = createForm(() => ({
+        defaultValues: { firstName: '' },
+        formId: 'my-form',
+      }))
+      return <form id={form.formId} data-testid="form" />
+    }
+
+    const { getByTestId } = render(() => <WithId />)
+
+    expect(getByTestId('form').getAttribute('id')).toBe('my-form')
+  })
+
+  it('derives the default formId from Solid so it survives hydration', () => {
+    // `form-core` falls back to `uuid()`, which is seeded from `Math.random()`
+    // and so differs between the server render and the client render. Solid's
+    // `createUniqueId()` is the adapter's SSR-safe counterpart: on the client
+    // it yields `cl-<n>`, and under hydration it derives the id from the
+    // hydration context so both renders agree. Asserting the id comes from
+    // that sequence is what pins the default to the hydration-safe source.
+    const { getByTestId } = render(() => <Comp />)
+
+    expect(getByTestId('form').getAttribute('id')).toMatch(/^cl-\d+$/)
+  })
+})


### PR DESCRIPTION
## Changes

When no `formId` is configured, `createForm` provides no fallback, so `FormApi` generates a random `uuid()` — seeded from `Math.random()`, and therefore different between the server render and the client render. Binding that generated id produces a hydration mismatch under SolidStart:

```tsx
const form = createForm(() => ({ defaultValues: { firstName: '' } }))

<form id={form.formId}>   {/* server: "d8efe189-…"   client: "4b1c07a2-…" */}
```

An explicitly provided `formId` was already forwarded and is unchanged by this PR.

This is the same bug as #2254, which #2259 fixed for Vue. Solid is the remaining adapter with an SSR story that hadn't had the treatment the others already have:

- `react-form/src/useFormId.ts` — `React.useId`, falling back to `useUUID` on React 17
- `preact-form/src/useFormId.ts` — `useId` from `preact/hooks`
- `vue-form/src/useFormId.ts` — Vue's `useId` (#2259)

Solid's counterpart is `createUniqueId()`, which derives the id from the hydration context when one is present, so both renders agree. `packages/solid-form/src/createForm.tsx` now uses it for the default.

## Test plan

`packages/solid-form/tests/createFormId.test.tsx` covers both branches — an explicit `formId` is returned unchanged, and the default comes from Solid's id sequence rather than a random uuid. Before the change the second test fails with:

```
expected 'd8efe189-c90f-4667-ac96-e9685217a6a4' to match /^cl-\d+$/
```

The first test passes both before and after, which is the evidence that explicit ids were never affected.

Full `@tanstack/solid-form` suite passes (46 tests, 5 files), `tsc --noEmit` is clean, and `eslint ./src ./tests` reports no new problems.

## One thing worth flagging

I wasn't able to assert the server/client round-trip directly the way `vue-form/tests/useFormId.test.tsx` does. Under solid-form's current vitest config, `solid-js/web` resolves to the client build — `isServer` is `false` and `renderToString()` returns `undefined` — so an SSR render can't be exercised without a second vitest project configured with server conditions and `solid({ ssr: true })`.

Rather than grow this PR into a test-infrastructure change, the test pins the default to Solid's id sequence, which is the property that makes hydration agree. Happy to add the SSR project setup here or in a follow-up if you'd prefer the stronger assertion — just say which.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering and hydration reliability for Solid forms with stable default form IDs.
  * Explicitly configured form IDs continue to work unchanged.

* **Tests**
  * Added coverage for custom form IDs and hydration-safe default IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->