### PR TITLE
perf(form-core): extract meta markers to state object (v2)

### DIFF
--- a/.changeset/easy-rice-live.md
+++ b/.changeset/easy-rice-live.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/form-core': patch
+---
+
+Improve field snapshot and metadata re-use strategy.

--- a/packages/form-core/src/FieldApi/FieldApi.lib.ts
+++ b/packages/form-core/src/FieldApi/FieldApi.lib.ts
@@ -61,6 +61,7 @@ import type {
 } from '../validation.public'
 import type {
   ChildContributionStates,
+  DerivedMetaMarkers,
   FieldAtoms,
   InternalBaseFieldMeta,
   InternalFieldMeta,
@@ -348,11 +349,21 @@ export class InternalFieldApi<
       metaAtom = createAtom(defaultInternalBaseFieldMeta)
     }
     if (!storeAtom) {
+      const markers: DerivedMetaMarkers = {
+        source: undefined,
+        canDisplayErrors: undefined,
+      }
       storeAtom = createAtom<InternalFieldState>((prev) => {
         const newMeta = metaAtom.get()
         const value = this._getValue()
 
-        const meta = deriveFromBaseFieldMeta(newMeta, prev?.meta, this, value)
+        const meta = deriveFromBaseFieldMeta(
+          newMeta,
+          prev?.meta,
+          this,
+          value,
+          markers,
+        )
 
         if (prev?.meta === meta && prev.value === value) {
           return prev

--- a/packages/form-core/src/FieldApi/fieldState.lib.ts
+++ b/packages/form-core/src/FieldApi/fieldState.lib.ts
@@ -49,14 +49,13 @@ export interface FormGroupFieldErrorMeta {
 export interface InternalBaseFieldMeta extends BaseFieldMeta, MetaExtension {}
 export interface InternalFieldMeta extends AnyPublicFieldMeta, MetaExtension {}
 
-const derivedMetaSourceKey = Symbol('tanstack-form-derived-meta-source')
-const derivedMetaCanDisplayErrorsKey = Symbol(
-  'tanstack-form-derived-meta-can-display-errors',
-)
-
-type DerivedMetaMarkers = {
-  [derivedMetaCanDisplayErrorsKey]?: boolean
-  [derivedMetaSourceKey]?: InternalBaseFieldMeta
+/**
+ * @private
+ * Used to track the prev meta for a field
+ */
+export interface DerivedMetaMarkers {
+  source: InternalBaseFieldMeta | undefined
+  canDisplayErrors: boolean | undefined
 }
 
 export interface InternalFieldState extends PublicFieldState<any, any> {
@@ -118,6 +117,7 @@ export function deriveFromBaseFieldMeta(
   previousMeta: InternalFieldMeta | undefined,
   field: AnyInternalFieldApi | undefined,
   value?: any,
+  markers?: DerivedMetaMarkers,
 ): InternalFieldMeta {
   const isDefaultValue = field ? field._getIsDefaultValue(value) : true
   const errorVisibility = getErrorVisibility(field)
@@ -152,10 +152,12 @@ export function deriveFromBaseFieldMeta(
 
   if (
     previousMeta &&
+    markers &&
     canReusePreviousMeta({
       baseMeta,
       canDisplayErrors,
       isDefaultValue,
+      markers,
       originalErrors,
       previousMeta,
     })
@@ -184,55 +186,32 @@ export function deriveFromBaseFieldMeta(
     subfields,
     isPristine: !isDirty,
   }
-  return markDerivedMeta(result, baseMeta, canDisplayErrors)
-}
 
-function markDerivedMeta(
-  meta: InternalFieldMeta,
-  baseMeta: InternalBaseFieldMeta,
-  canDisplayErrors: boolean,
-): InternalFieldMeta {
-  Object.defineProperties(meta, {
-    [derivedMetaCanDisplayErrorsKey]: {
-      value: canDisplayErrors,
-    },
-    [derivedMetaSourceKey]: {
-      value: baseMeta,
-    },
-  })
+  if (markers) {
+    markers.source = baseMeta
+    markers.canDisplayErrors = canDisplayErrors
+  }
 
-  return meta
-}
-
-function getDerivedMetaSource(
-  meta: (InternalFieldMeta & DerivedMetaMarkers) | undefined,
-): InternalBaseFieldMeta | undefined {
-  return meta?.[derivedMetaSourceKey]
-}
-
-function getDerivedMetaCanDisplayErrors(
-  meta: (InternalFieldMeta & DerivedMetaMarkers) | undefined,
-): boolean | undefined {
-  return meta?.[derivedMetaCanDisplayErrorsKey]
+  return result
 }
 
 function canReusePreviousMeta({
   baseMeta,
   canDisplayErrors,
   isDefaultValue,
+  markers,
   originalErrors,
   previousMeta,
 }: {
   baseMeta: InternalBaseFieldMeta
   canDisplayErrors: boolean
   isDefaultValue: boolean
+  markers: DerivedMetaMarkers
   originalErrors: Array<ValidationIssue>
   previousMeta: InternalFieldMeta
 }): boolean {
-  if (getDerivedMetaSource(previousMeta) !== baseMeta) return false
-  if (getDerivedMetaCanDisplayErrors(previousMeta) !== canDisplayErrors) {
-    return false
-  }
+  if (markers.source !== baseMeta) return false
+  if (markers.canDisplayErrors !== canDisplayErrors) return false
   if (previousMeta.isDefaultValue !== isDefaultValue) return false
   if (previousMeta.original.errors !== originalErrors) return false
 

--- a/packages/form-core/src/utils.lib.ts
+++ b/packages/form-core/src/utils.lib.ts
@@ -29,30 +29,27 @@ export function nameToFieldNodeSegments(
   if (typeof nameOrSegments !== 'string') return nameOrSegments.slice()
 
   const result: NameSegments = []
-  let s = ''
+  let start = 0
 
   for (let i = 0; i < nameOrSegments.length; i++) {
     switch (nameOrSegments.charCodeAt(i)) {
       case 0x2e: // '.'
       case 0x5b: // '['
-        if (s.length > 0) {
-          result.push(s)
-          s = ''
+        if (i > start) {
+          result.push(nameOrSegments.slice(start, i))
         }
+        start = i + 1
         break
       case 0x5d: // ']'
-        if (s.length > 0) {
-          result.push(parseInt(s, 10))
-          s = ''
+        if (i > start) {
+          result.push(parseInt(nameOrSegments.slice(start, i), 10))
         }
-        break
-      default:
-        s += nameOrSegments.charAt(i)
+        start = i + 1
         break
     }
   }
-  if (s.length > 0) {
-    result.push(s)
+  if (start < nameOrSegments.length) {
+    result.push(nameOrSegments.slice(start))
   }
 
   return result


### PR DESCRIPTION
In order to compute if we can re-use the previous meta, we currently tag
two properties onto the meta (`derivedMetaSourceKey`,
`derivedMetaCanDisplayErrorsKey`).

This is fairly expensive because it means we change the shape of an
otherwise consistently structured object each time the value changes.

We only make use of this when the value changes, so this change switches
to using a `markers` object which transitions between values.

Basically this pattern:

```ts
const markers = { ... };

createAtom((prev) => {
  // in here, mutate `markers` when prev != curr
});
```

This means the underlying meta object never changes shape.

Also important to note, this now means `getFieldSnapshot` doesn't even
pass through this code path anymore.

NOTE: there's also a bit of a drive-by in here. I updated
`nameToFieldNodeSegments` to slice between separators instead of
appending characters one-by-one. Much faster, but can be split into its
own PR if needed.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
