### PR TITLE
docs: fix sidebar 404s and validate config.json nav targets

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -468,16 +468,8 @@
           "to": "reference/type-aliases/DeepValue"
         },
         {
-          "label": "Types / FieldInfo",
-          "to": "reference/type-aliases/FieldInfo"
-        },
-        {
-          "label": "Types / FieldMeta",
-          "to": "reference/type-aliases/FieldMeta"
-        },
-        {
-          "label": "Types / FieldState",
-          "to": "reference/type-aliases/FieldState"
+          "label": "Types / AnyFieldMeta",
+          "to": "reference/type-aliases/AnyFieldMeta"
         },
         {
           "label": "Types / BaseFormState",
@@ -523,10 +515,6 @@
             {
               "label": "Functions / useForm",
               "to": "framework/react/reference/functions/useForm"
-            },
-            {
-              "label": "Functions / useTransform",
-              "to": "framework/react/reference/functions/useTransform"
             },
             {
               "label": "Types / FieldComponent",
@@ -589,10 +577,6 @@
             {
               "label": "Types / FieldComponent",
               "to": "framework/vue/reference/type-aliases/FieldComponent"
-            },
-            {
-              "label": "Types / UseField",
-              "to": "framework/vue/reference/type-aliases/UseField"
             }
           ]
         },
@@ -614,10 +598,6 @@
             {
               "label": "Functions / Field",
               "to": "framework/solid/reference/functions/Field"
-            },
-            {
-              "label": "Types / CreateField",
-              "to": "framework/solid/reference/type-aliases/CreateField"
             },
             {
               "label": "Types / FieldComponent",

--- a/scripts/verify-links.ts
+++ b/scripts/verify-links.ts
@@ -9,6 +9,7 @@ const errors: Array<{
   link: string
   resolvedPath: string
   reason: string
+  nav?: string
 }> = []
 
 function isRelativeLink(link: string) {
@@ -27,6 +28,29 @@ function stripExtension(p: string): string {
   return p.replace(`${extname(p)}`, '')
 }
 
+/**
+ * Map a resolved `/docs` path to the file or directory that actually serves it,
+ * and report whether that target exists.
+ */
+function resolveDocTarget(absPath: string): { path: string; exists: boolean } {
+  // Examples live outside /docs: /docs/framework/{framework}/examples/{name}
+  // is served from /examples/{framework}/{name}
+  if (absPath.includes('/examples/')) {
+    const examplePath = absPath.replace(
+      /\/docs\/framework\/([^/]+)\/examples\//,
+      '/examples/$1/',
+    )
+    return {
+      path: examplePath,
+      exists: existsSync(examplePath) && statSync(examplePath).isDirectory(),
+    }
+  }
+
+  // Everything else is a markdown page
+  const mdPath = absPath.endsWith('.md') ? absPath : `${absPath}.md`
+  return { path: mdPath, exists: existsSync(mdPath) }
+}
+
 function relativeLinkExists(link: string, file: string): boolean {
   // Remove hash if present
   const linkWithoutHash = link.split('#')[0]
@@ -39,7 +63,7 @@ function relativeLinkExists(link: string, file: string): boolean {
 
   // Resolve the path relative to the markdown file's directory
   // Nav up a level to simulate how links are resolved on the web
-  let absPath = resolve(filePath, '..', linkPath)
+  const absPath = resolve(filePath, '..', linkPath)
 
   // Ensure the resolved path is within /docs
   const docsRoot = resolve('docs')
@@ -53,32 +77,13 @@ function relativeLinkExists(link: string, file: string): boolean {
     return false
   }
 
-  // Check if this is an example path
-  const isExample = absPath.includes('/examples/')
-
-  let exists = false
-
-  if (isExample) {
-    // Transform /docs/framework/{framework}/examples/ to /examples/{framework}/
-    absPath = absPath.replace(
-      /\/docs\/framework\/([^/]+)\/examples\//,
-      '/examples/$1/',
-    )
-    // For examples, we want to check if the directory exists
-    exists = existsSync(absPath) && statSync(absPath).isDirectory()
-  } else {
-    // For non-examples, we want to check if the .md file exists
-    if (!absPath.endsWith('.md')) {
-      absPath = `${absPath}.md`
-    }
-    exists = existsSync(absPath)
-  }
+  const { path: resolvedPath, exists } = resolveDocTarget(absPath)
 
   if (!exists) {
     errors.push({
       link,
       file,
-      resolvedPath: absPath,
+      resolvedPath,
       reason: 'Not found',
     })
   }
@@ -108,12 +113,69 @@ async function verifyMarkdownLinks() {
       })
     }
   }
+}
+
+interface ConfigNode {
+  label?: string
+  to?: string
+  children?: Array<ConfigNode>
+  frameworks?: Array<ConfigNode>
+}
+
+/**
+ * Every `to` in docs/config.json becomes a sidebar link on tanstack.com, so an
+ * entry pointing at a page that no longer exists renders as a 404. These are
+ * invisible to the markdown scan above, which only reads links written inside
+ * .md files.
+ */
+function verifyConfigLinks() {
+  const configPath = 'docs/config.json'
+  const config = JSON.parse(readFileSync(configPath, 'utf-8')) as {
+    sections?: Array<ConfigNode>
+  }
+
+  const docsRoot = resolve('docs')
+  let checked = 0
+
+  function walk(node: ConfigNode, breadcrumb: Array<string>) {
+    const trail = node.label ? [...breadcrumb, node.label] : breadcrumb
+
+    if (node.to) {
+      checked++
+      const { path: resolvedPath, exists } = resolveDocTarget(
+        resolve(docsRoot, node.to),
+      )
+
+      if (!exists) {
+        errors.push({
+          file: configPath,
+          link: node.to,
+          resolvedPath,
+          reason: 'Not found',
+          nav: trail.join(' > '),
+        })
+      }
+    }
+
+    node.children?.forEach((child) => walk(child, trail))
+    node.frameworks?.forEach((framework) => walk(framework, trail))
+  }
+
+  const sections = config.sections ?? []
+  sections.forEach((section) => walk(section, []))
+
+  console.log(`Found ${checked} nav entries in ${configPath}\n`)
+}
+
+async function verifyLinks() {
+  await verifyMarkdownLinks()
+  verifyConfigLinks()
 
   if (errors.length > 0) {
     console.log(`\n❌ Found ${errors.length} broken links:`)
     errors.forEach((err) => {
       console.log(
-        `${err.file}\n  link:      ${err.link}\n  resolved:  ${err.resolvedPath}\n  why:       ${err.reason}\n`,
+        `${err.file}${err.nav ? `\n  nav:       ${err.nav}` : ''}\n  link:      ${err.link}\n  resolved:  ${err.resolvedPath}\n  why:       ${err.reason}\n`,
       )
     })
     process.exit(1)
@@ -122,4 +184,4 @@ async function verifyMarkdownLinks() {
   }
 }
 
-verifyMarkdownLinks().catch(console.error)
+verifyLinks().catch(console.error)

--- a/scripts/verify-links.ts
+++ b/scripts/verify-links.ts
@@ -184,4 +184,7 @@ async function verifyLinks() {
   }
 }
 
-verifyLinks().catch(console.error)
+verifyLinks().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary

`docs/config.json` contains sidebar entries pointing at reference pages that don't exist on disk, so those nav links render as 404s. This removes the dead entries and teaches `verify-links.ts` to catch them, so they can't come back.

Nothing in CI validated `config.json` before: `scripts/verify-links.ts` only extracts links written *inside* `.md` files, so entries in the nav config were never checked. That's how these drifted out of sync unnoticed.

### The 6 dead entries

Found by the new check, verified against the source and the generated docs:

| Nav entry | `to` | Why it 404s |
| --- | --- | --- |
| `API Reference > Types / FieldInfo` | `reference/type-aliases/FieldInfo` | `FieldInfo` is an `interface` (`packages/form-core/src/types.ts:1253`), so typedoc emits no `type-aliases/` page — and no `interfaces/FieldInfo.md` is generated either |
| `API Reference > Types / FieldMeta` | `reference/type-aliases/FieldMeta` | Type no longer exists in source |
| `API Reference > Types / FieldState` | `reference/type-aliases/FieldState` | Type no longer exists in source |
| `API Reference > react > Functions / useTransform` | `framework/react/reference/functions/useTransform` | Not exported from `@tanstack/react-form`; it lives in `react-form-{nextjs,remix,start}`, none of which are registered in `scripts/generate-docs.ts` |
| `API Reference > vue > Types / UseField` | `framework/vue/reference/type-aliases/UseField` | `vue-form` exports `UseFieldOptions` / `UseFieldOptionsBound`, no `UseField` |
| `API Reference > solid > Types / CreateField` | `framework/solid/reference/type-aliases/CreateField` | `solid-form` exports `CreateFieldOptions` / `CreateFieldOptionsBound`, no `CreateField` |

`FieldMeta.md`, `FieldState.md` and `FieldInfo.md` were dropped by the docs generator in 6a73479f (`ci: apply automated fixes and generate docs`), but `config.json` was never updated to match.

### Changes

- Removed the 5 entries with no valid target.
- Repointed `Types / FieldMeta` → `Types / AnyFieldMeta` (`packages/form-core/src/types.ts:834`), the surviving public field-metadata type. Its page already exists but wasn't reachable from the sidebar, so this keeps field metadata covered rather than just deleting the entry.
- `verify-links.ts` now walks every `to` in `config.json` (`children` and `frameworks`, recursively) and resolves it the same way markdown links are resolved — including the `framework/{fw}/examples/{name}` → `examples/{fw}/{name}` directory mapping. Failures report the nav breadcrumb so the offending entry is easy to find:

  ```
  docs/config.json
    nav:       API Reference > vue > Types / UseField
    link:      framework/vue/reference/type-aliases/UseField
    resolved:  .../docs/framework/vue/reference/type-aliases/UseField.md
    why:       Not found
  ```

The example-path and `.md` resolution logic is factored into a shared `resolveDocTarget()` used by both checks, so the two paths can't drift apart.

### Relationship to #2226 and other open PRs

Worth being explicit, since this looks adjacent to work already in flight:

- **This does not fix #2226.** That issue is about `reference/index` — and `docs/reference/index.md` **does** exist on disk, so the 404 there is a site-routing problem, not a missing page. The new check passes on those entries both before and after. #2253 handles that one.
- **One entry overlaps #2118**, which also removes the `useTransform` nav entry as part of splitting the SSR guide. If #2118 lands first this hunk conflicts trivially; happy to drop it here if that's preferred.

The remaining 5 entries aren't covered by any open PR or issue that I could find.

### Not included

The check only validates that nav entries resolve. It deliberately does not flag the reverse — generated pages that exist but aren't in the nav (currently ~150, including `revalidateLogic`, which every framework's `dynamic-validation` guide references). That's a larger judgment call about what belongs in the sidebar, and better as its own PR.

## Verification

```
pnpm test:pr                         # nx affected → sherif, knip, docs — all pass
pnpm run test:docs                   # 285 markdown files, 166 nav entries, no broken links
pnpm exec eslint scripts/verify-links.ts
pnpm exec tsc --noEmit               # root tsconfig includes scripts/
pnpm exec prettier --check docs/config.json scripts/verify-links.ts
```

Confirmed the check actually fails rather than silently passing: injecting a bogus `type-aliases/` entry and a bogus `examples/` entry makes it report both and exit `1`; removing them returns exit `0`. Before this change, the same bogus entries passed CI.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated API reference navigation to reflect the current documentation structure.
  * Removed outdated type and framework-specific reference links.
  * Improved navigation consistency across nested documentation sections.

* **Chores**
  * Expanded link validation to cover configuration-based and Markdown links.
  * Added clearer navigation breadcrumbs to link verification errors.
  * Improved detection and reporting of invalid documentation and example links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->