### PR TITLE
fix(form-core): preserve prefix-matching sibling fields

### DIFF
--- a/.changeset/tidy-forms-keep.md
+++ b/.changeset/tidy-forms-keep.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/form-core': patch
+---
+
+Preserve sibling fields whose names share a prefix when deleting a field.

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -2691,7 +2691,7 @@ export class FormApi<
   deleteField = <TField extends DeepKeys<TFormData>>(field: TField) => {
     const subFieldsToDelete = Object.keys(this.fieldInfo).filter((f) => {
       const fieldStr = field.toString()
-      return f !== fieldStr && f.startsWith(fieldStr)
+      return f.startsWith(`${fieldStr}.`) || f.startsWith(`${fieldStr}[`)
     })
 
     const fieldsToDelete = [...subFieldsToDelete, field]

--- a/packages/form-core/tests/FieldApi.spec.ts
+++ b/packages/form-core/tests/FieldApi.spec.ts
@@ -3360,6 +3360,41 @@ describe('field api', () => {
       expect(form.fieldInfo.otherField).toBeDefined()
     })
 
+    it('should preserve sibling fields whose names share a prefix', () => {
+      const form = new FormApi({
+        defaultValues: {
+          email: 'user@example.com',
+          emailVerified: true,
+          items: [{ price: 10, priceCurrency: 'USD' }],
+        },
+      })
+
+      form.mount()
+
+      const email = new FieldApi({ form, name: 'email' })
+      const emailVerified = new FieldApi({ form, name: 'emailVerified' })
+      const price = new FieldApi({ form, name: 'items[0].price' })
+      const priceCurrency = new FieldApi({
+        form,
+        name: 'items[0].priceCurrency',
+      })
+
+      email.mount()
+      emailVerified.mount()
+      price.mount()
+      priceCurrency.mount()
+
+      form.deleteField('email')
+      form.deleteField('items[0].price')
+
+      expect(form.getFieldValue('emailVerified')).toBe(true)
+      expect(form.fieldInfo.emailVerified).toBeDefined()
+      expect(form.state.fieldMeta.emailVerified).toBeDefined()
+      expect(form.getFieldValue('items[0].priceCurrency')).toBe('USD')
+      expect(form.fieldInfo['items[0].priceCurrency']).toBeDefined()
+      expect(form.state.fieldMeta['items[0].priceCurrency']).toBeDefined()
+    })
+
     it('should remove field value and clean up fieldInfo entry', () => {
       const form = new FormApi({
         defaultValues: {


### PR DESCRIPTION
## 🎯 Changes

- Restrict `deleteField` descendant cleanup to dot- and bracket-delimited field paths.
- Preserve values, registrations, and metadata for sibling fields that only share a string prefix.
- Add regression coverage for object fields and nested array fields.

Fixes #2317

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed field deletion so it removes only the selected field and its true nested descendants.
  - Preserved sibling fields whose names share a prefix with the deleted field.
  - Improved handling for nested object and array field paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->