### PR TITLE
[v2] chore: remove sources from published `files`

### DIFF
--- a/packages/form-core/package.json
+++ b/packages/form-core/package.json
@@ -39,8 +39,7 @@
     "node": ">=18"
   },
   "files": [
-    "dist/",
-    "src"
+    "dist/"
   ],
   "dependencies": {
     "@tanstack/pacer-lite": "^0.2.2",

--- a/packages/form-devtools/package.json
+++ b/packages/form-devtools/package.json
@@ -55,8 +55,7 @@
     "node": ">=18"
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "dependencies": {
     "@ark-ui/solid": "^5.38.1",

--- a/packages/lit-form/package.json
+++ b/packages/lit-form/package.json
@@ -44,8 +44,7 @@
   },
   "sideEffects": false,
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "dependencies": {
     "@tanstack/form-core": "workspace:*",

--- a/packages/lit-form/tsconfig.build.json
+++ b/packages/lit-form/tsconfig.build.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "noEmit": false,
     "declaration": true,
-    "sourceMap": true
+    "sourceMap": false
   },
   "include": ["src"]
 }

--- a/packages/preact-form/package.json
+++ b/packages/preact-form/package.json
@@ -46,8 +46,7 @@
     "node": ">=18"
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "dependencies": {
     "@tanstack/form-core": "workspace:*",

--- a/packages/react-form-devtools/package.json
+++ b/packages/react-form-devtools/package.json
@@ -51,8 +51,7 @@
     "node": ">=18"
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "dependencies": {
     "@tanstack/devtools": "^0.12.2",

--- a/packages/react-form-nextjs/package.json
+++ b/packages/react-form-nextjs/package.json
@@ -39,8 +39,7 @@
     "node": ">=18"
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "dependencies": {
     "@tanstack/form-core": "workspace:*",

--- a/packages/react-form-start/package.json
+++ b/packages/react-form-start/package.json
@@ -39,8 +39,7 @@
     "node": ">=18"
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "dependencies": {
     "@tanstack/form-core": "workspace:*",

--- a/packages/react-form/package.json
+++ b/packages/react-form/package.json
@@ -40,7 +40,6 @@
   },
   "files": [
     "dist",
-    "src",
     "skills"
   ],
   "dependencies": {

--- a/packages/solid-form-devtools/package.json
+++ b/packages/solid-form-devtools/package.json
@@ -25,8 +25,7 @@
     "node": ">=18"
   },
   "files": [
-    "dist/",
-    "src"
+    "dist/"
   ],
   "scripts": {
     "clean": "premove ./build ./dist",

--- a/packages/solid-form/package.json
+++ b/packages/solid-form/package.json
@@ -38,8 +38,7 @@
     "node": ">=18"
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "dependencies": {
     "@tanstack/form-core": "workspace:*",

--- a/packages/svelte-form/package.json
+++ b/packages/svelte-form/package.json
@@ -36,8 +36,7 @@
   },
   "sideEffects": false,
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "dependencies": {
     "@tanstack/form-core": "workspace:*",

--- a/packages/vue-form/package.json
+++ b/packages/vue-form/package.json
@@ -31,8 +31,7 @@
   },
   "sideEffects": false,
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "dependencies": {
     "@tanstack/form-core": "workspace:*",


### PR DESCRIPTION
This removes `src` from the `files` array of each `package.json` where possible.

The following packages already have sourcemaps disabled, so the sources are not referenced:

- form-core
- form-devtools
- preact-form
- react-form-devtools
- react-form-nextjs
- react-form-start
- react-form
- solid-form-devtools
- solid-form
- svelte-form
- vue-form

The `lit-form` package currently has sourcemaps enabled. This change disables them and also removes sources from the `files` list.

Lastly, `angular-form` is untouched since `ng-packagr` hard codes sourcemaps to be enabled. The sources are therefore needed since they're referenced by the sourcemaps.

Closes #2316 

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined published package contents across the form libraries and developer tools by distributing compiled files only.
  - Removed source files from published package archives while retaining required distribution assets.
  - Disabled source map generation for one package build, reducing published build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->