### PR TITLE
[v2] perf(devtools): avoid lucide barrel file

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,15 @@ export default defineConfig([
       '@typescript-eslint/require-await': 'off',
       'no-async-promise-executor': 'off',
       'no-empty': 'off',
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "ImportDeclaration[source.value='lucide-solid'][importKind!='type'] > ImportSpecifier[importKind!='type'][imported.name=/Icon$/]",
+          message:
+            "Import icons from 'lucide-solid/icons/{name}' instead of the 'lucide-solid' barrel.",
+        },
+      ],
     },
   },
 ])

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.3",
     "@types/node": "^25.0.7",
+    "@vitest/browser-playwright": "^4.0.17",
     "@vitest/coverage-istanbul": "4.1.10",
     "eslint": "^10.8.1",
     "jsdom": "^27.2.0",

--- a/packages/form-devtools/src/components/fields/fieldDetails/FieldDetailSettingsActions.tsx
+++ b/packages/form-devtools/src/components/fields/fieldDetails/FieldDetailSettingsActions.tsx
@@ -1,9 +1,7 @@
-import {
-  PenIcon,
-  PlayIcon,
-  RotateCcwIcon,
-  SquareArrowRightExitIcon,
-} from 'lucide-solid'
+import PenIcon from 'lucide-solid/icons/pen'
+import PlayIcon from 'lucide-solid/icons/play'
+import RotateCcwIcon from 'lucide-solid/icons/rotate-ccw'
+import SquareArrowRightExitIcon from 'lucide-solid/icons/square-arrow-right-exit'
 import type { FieldId, FormId } from '@/types/branded'
 import type { MenuSelectionDetails } from '@ark-ui/solid'
 import { Button } from '@/components/ui/button'

--- a/packages/form-devtools/src/components/fields/fieldDetails/FieldDetailSettingsMenu.tsx
+++ b/packages/form-devtools/src/components/fields/fieldDetails/FieldDetailSettingsMenu.tsx
@@ -1,4 +1,4 @@
-import { EllipsisIcon } from 'lucide-solid'
+import EllipsisIcon from 'lucide-solid/icons/ellipsis'
 import type { FieldDetailSettings } from '@/eventClientTypes'
 import type { FieldId } from '@/types/branded'
 import { Button } from '@/components/ui/button'

--- a/packages/form-devtools/src/components/fields/fieldDetails/fieldErrors/ErrorExtraInfoPopover.tsx
+++ b/packages/form-devtools/src/components/fields/fieldDetails/fieldErrors/ErrorExtraInfoPopover.tsx
@@ -1,5 +1,6 @@
 import { Show } from 'solid-js'
-import { EyeDashedIcon, TimerIcon } from 'lucide-solid'
+import EyeDashedIcon from 'lucide-solid/icons/eye-dashed'
+import TimerIcon from 'lucide-solid/icons/timer'
 import { FieldDetailErrorSourceText } from './FieldDetailErrorSourceText'
 import type { Accessor } from 'solid-js'
 import type { DevtoolsFieldError } from '@/eventClientTypes'

--- a/packages/form-devtools/src/components/fields/fieldDetails/fieldErrors/FieldDetailErrorItem.tsx
+++ b/packages/form-devtools/src/components/fields/fieldDetails/fieldErrors/FieldDetailErrorItem.tsx
@@ -1,4 +1,5 @@
-import { BugIcon, InfoIcon } from 'lucide-solid'
+import BugIcon from 'lucide-solid/icons/bug'
+import InfoIcon from 'lucide-solid/icons/info'
 import { Match, Switch, createSignal } from 'solid-js'
 import { FieldDetailErrorSourceText } from './FieldDetailErrorSourceText'
 import { ErrorExtraInfoPopover } from './ErrorExtraInfoPopover'

--- a/packages/form-devtools/src/components/fields/fieldDetails/fieldErrors/FieldDetailErrorSourceText.tsx
+++ b/packages/form-devtools/src/components/fields/fieldDetails/fieldErrors/FieldDetailErrorSourceText.tsx
@@ -1,4 +1,4 @@
-import { DotIcon } from 'lucide-solid'
+import DotIcon from 'lucide-solid/icons/dot'
 import { Show } from 'solid-js'
 import type { DevtoolsFieldErrorSource } from '@/eventClientTypes'
 

--- a/packages/form-devtools/src/components/fields/fieldDetails/fieldErrors/FieldNoErrorsItem.tsx
+++ b/packages/form-devtools/src/components/fields/fieldDetails/fieldErrors/FieldNoErrorsItem.tsx
@@ -1,4 +1,4 @@
-import { BugIcon } from 'lucide-solid'
+import BugIcon from 'lucide-solid/icons/bug'
 import { createSignal } from 'solid-js'
 import { FieldDebugInfo } from '../fieldDebug/FieldDebugInfoPopover'
 import type { FieldDebugSuspicion } from '@/eventClientTypes'

--- a/packages/form-devtools/src/components/fields/leftPanel/FieldListItems.tsx
+++ b/packages/form-devtools/src/components/fields/leftPanel/FieldListItems.tsx
@@ -1,6 +1,6 @@
 import { Listbox } from '@ark-ui/solid'
 import { For } from 'solid-js'
-import { BookmarkIcon } from 'lucide-solid'
+import BookmarkIcon from 'lucide-solid/icons/bookmark'
 import {
   Item,
   ItemContent,

--- a/packages/form-devtools/src/components/fields/leftPanel/listSearch/FieldFilterChip.tsx
+++ b/packages/form-devtools/src/components/fields/leftPanel/listSearch/FieldFilterChip.tsx
@@ -1,5 +1,5 @@
 import { TagsInput } from '@ark-ui/solid'
-import { XIcon } from 'lucide-solid'
+import XIcon from 'lucide-solid/icons/x'
 import type { FieldListFilter } from '@/hooks/createFieldListSearch'
 import { Button } from '@/components/ui/button'
 

--- a/packages/form-devtools/src/components/fields/leftPanel/listSearch/FieldListSearch.tsx
+++ b/packages/form-devtools/src/components/fields/leftPanel/listSearch/FieldListSearch.tsx
@@ -1,6 +1,7 @@
 import { TagsInput } from '@ark-ui/solid'
 import { For, Show } from 'solid-js'
-import { FunnelXIcon, SearchIcon } from 'lucide-solid'
+import FunnelXIcon from 'lucide-solid/icons/funnel-x'
+import SearchIcon from 'lucide-solid/icons/search'
 import { InputGroupAddon, InputGroupButton } from '../../../ui/input-group'
 import { FieldSearchControl } from './FieldSearchControl'
 import { FieldFilterChip } from './FieldFilterChip'

--- a/packages/form-devtools/src/components/header/Header.tsx
+++ b/packages/form-devtools/src/components/header/Header.tsx
@@ -1,4 +1,4 @@
-import { RefreshCcwIcon } from 'lucide-solid'
+import RefreshCcwIcon from 'lucide-solid/icons/refresh-ccw'
 import { InternalFormApi } from '@tanstack/form-core/internals'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { Button } from '../ui/button'

--- a/packages/form-devtools/src/components/ui/accordion.tsx
+++ b/packages/form-devtools/src/components/ui/accordion.tsx
@@ -1,5 +1,6 @@
 import { Accordion as AccordionPrimitive } from '@ark-ui/solid'
-import { ChevronDownIcon, ChevronUpIcon } from 'lucide-solid'
+import ChevronDownIcon from 'lucide-solid/icons/chevron-down'
+import ChevronUpIcon from 'lucide-solid/icons/chevron-up'
 import { splitProps } from 'solid-js'
 import { cn } from '@/utils'
 

--- a/packages/form-devtools/src/components/ui/copy-button.tsx
+++ b/packages/form-devtools/src/components/ui/copy-button.tsx
@@ -1,6 +1,7 @@
 import { useClipboard } from '@ark-ui/solid'
 import { Show, splitProps } from 'solid-js'
-import { CheckIcon, CopyIcon } from 'lucide-solid'
+import CheckIcon from 'lucide-solid/icons/check'
+import CopyIcon from 'lucide-solid/icons/copy'
 import { Button } from './button'
 import type { ButtonProps } from './button'
 import { cn } from '@/utils'

--- a/packages/form-devtools/src/components/ui/dropdown-menu.tsx
+++ b/packages/form-devtools/src/components/ui/dropdown-menu.tsx
@@ -1,5 +1,6 @@
 import { Menu as DropdownMenuPrimitive } from '@ark-ui/solid'
-import { CheckIcon, ChevronRightIcon } from 'lucide-solid'
+import CheckIcon from 'lucide-solid/icons/check'
+import ChevronRightIcon from 'lucide-solid/icons/chevron-right'
 import { createUniqueId, splitProps } from 'solid-js'
 import type { JSX } from 'solid-js'
 import { Portal } from '@/components/ui/portal'

--- a/packages/form-devtools/src/components/ui/json-tree.tsx
+++ b/packages/form-devtools/src/components/ui/json-tree.tsx
@@ -1,5 +1,5 @@
 import { JsonTreeView } from '@ark-ui/solid'
-import { ChevronRightIcon } from 'lucide-solid'
+import ChevronRightIcon from 'lucide-solid/icons/chevron-right'
 import { Show, splitProps } from 'solid-js'
 import { ScrollArea } from './scroll-area'
 import { CopyButton } from './copy-button'

--- a/packages/form-devtools/src/components/ui/select.tsx
+++ b/packages/form-devtools/src/components/ui/select.tsx
@@ -1,5 +1,7 @@
 import { Select as SelectPrimitive, createListCollection } from '@ark-ui/solid'
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-solid'
+import CheckIcon from 'lucide-solid/icons/check'
+import ChevronDownIcon from 'lucide-solid/icons/chevron-down'
+import ChevronUpIcon from 'lucide-solid/icons/chevron-up'
 import {
   createContext,
   createEffect,

--- a/packages/form-devtools/src/hooks/createFieldListSearch.tsx
+++ b/packages/form-devtools/src/hooks/createFieldListSearch.tsx
@@ -6,22 +6,20 @@ import {
   useTagsInput,
 } from '@ark-ui/solid'
 import fuzzysort from 'fuzzysort'
-import {
-  BookmarkIcon,
-  CheckIcon,
-  EqualIcon,
-  EqualNotIcon,
-  EyeClosedIcon,
-  EyeIcon,
-  ListTreeIcon,
-  PencilIcon,
-  PencilSparklesIcon,
-  PointerIcon,
-  PointerOffIcon,
-  SquareArrowRightExitIcon,
-  SquareIcon,
-  XIcon,
-} from 'lucide-solid'
+import BookmarkIcon from 'lucide-solid/icons/bookmark'
+import CheckIcon from 'lucide-solid/icons/check'
+import EqualIcon from 'lucide-solid/icons/equal'
+import EqualNotIcon from 'lucide-solid/icons/equal-not'
+import EyeClosedIcon from 'lucide-solid/icons/eye-closed'
+import EyeIcon from 'lucide-solid/icons/eye'
+import ListTreeIcon from 'lucide-solid/icons/list-tree'
+import PencilIcon from 'lucide-solid/icons/pencil'
+import PencilSparklesIcon from 'lucide-solid/icons/pencil-sparkles'
+import PointerIcon from 'lucide-solid/icons/pointer'
+import PointerOffIcon from 'lucide-solid/icons/pointer-off'
+import SquareArrowRightExitIcon from 'lucide-solid/icons/square-arrow-right-exit'
+import SquareIcon from 'lucide-solid/icons/square'
+import XIcon from 'lucide-solid/icons/x'
 import {
   createEffect,
   createMemo,

--- a/packages/form-devtools/tests/test-setup.ts
+++ b/packages/form-devtools/tests/test-setup.ts
@@ -1,3 +1,0 @@
-import ResizeObserver from 'resize-observer-polyfill'
-
-global.ResizeObserver = ResizeObserver

--- a/packages/form-devtools/vite.config.ts
+++ b/packages/form-devtools/vite.config.ts
@@ -70,7 +70,11 @@ export default defineConfig({
     globals: true,
     browser: {
       enabled: true,
-      provider: playwright(),
+      // CI runners (ubuntu-latest) ship with Google Chrome preinstalled, so
+      // use it rather than downloading playwright's own browser build
+      provider: playwright(
+        process.env.CI ? { launchOptions: { channel: 'chrome' } } : {},
+      ),
       instances: [{ browser: 'chromium', headless: true }],
     },
   },

--- a/packages/form-devtools/vite.config.ts
+++ b/packages/form-devtools/vite.config.ts
@@ -8,7 +8,7 @@ const normalizeChunkPath = (id: string | null | undefined) =>
   id?.replaceAll(path.sep, '/')
 
 const componentsEntry = normalizeChunkPath(
-  path.resolve(__dirname, './src/components/index.tsx'),
+  path.resolve(import.meta.dirname, './src/components/index.tsx'),
 )
 
 const isBareImport = (id: string) =>
@@ -41,7 +41,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': path.resolve(import.meta.dirname, './src'),
     },
   },
   build: {

--- a/packages/form-devtools/vite.config.ts
+++ b/packages/form-devtools/vite.config.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import { defineConfig } from 'vitest/config'
 import solid from 'vite-plugin-solid'
 import tailwindcss from '@tailwindcss/vite'
+import { playwright } from '@vitest/browser-playwright'
 import packageJson from './package.json' with { type: 'json' }
 
 const normalizeChunkPath = (id: string | null | undefined) =>
@@ -66,8 +67,11 @@ export default defineConfig({
     name: packageJson.name,
     dir: './tests',
     watch: false,
-    environment: 'jsdom',
-    setupFiles: ['tests/test-setup.ts'],
     globals: true,
+    browser: {
+      enabled: true,
+      provider: playwright(),
+      instances: [{ browser: 'chromium', headless: true }],
+    },
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@types/node':
         specifier: ^25.0.7
         version: 25.9.5
+      '@vitest/browser-playwright':
+        specifier: ^4.0.17
+        version: 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/coverage-istanbul':
         specifier: 4.1.10
         version: 4.1.10(vitest@4.1.10)
@@ -100,7 +103,7 @@ importers:
         version: 8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.0.17
-        version: 4.1.10(@types/node@25.9.5)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))
 
   examples/angular/array:
     dependencies:
@@ -3175,6 +3178,9 @@ packages:
     resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@blazediff/core@1.9.1':
+    resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
+
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
 
@@ -5065,6 +5071,9 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
   '@preact/preset-vite@2.10.6':
     resolution: {integrity: sha512-ZZ5RIT2ZVXg8UxRA8VZpoT8CdpDG7RFIqOT4bELqNBp85+HKvQBbgmh3gsoW1UOQXx26TLe+ZRNKI7q281Kckw==}
@@ -7442,6 +7451,17 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
+  '@vitest/browser-playwright@4.1.10':
+    resolution: {integrity: sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==}
+    peerDependencies:
+      playwright: '*'
+      vitest: 4.1.10
+
+  '@vitest/browser@4.1.10':
+    resolution: {integrity: sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==}
+    peerDependencies:
+      vitest: 4.1.10
+
   '@vitest/coverage-istanbul@4.1.10':
     resolution: {integrity: sha512-AyNJ5pQRFqCX7pwB9PSTmoVKPaZ4H5IEVJfJsT+q1DYkXvZMEFYgJlyk5sfStmt9rVYRyYYRRsuBeImCOc39ww==}
     peerDependencies:
@@ -9732,6 +9752,11 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -11488,6 +11513,16 @@ packages:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
 
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   plist@3.1.1:
     resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
     engines: {node: '>=10.4.0'}
@@ -11495,6 +11530,10 @@ packages:
   pngjs@3.4.0:
     resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
     engines: {node: '>=4.0.0'}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -12255,6 +12294,10 @@ packages:
   simple-swizzle@0.2.4:
     resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -12611,6 +12654,10 @@ packages:
 
   toqr@0.1.1:
     resolution: {integrity: sha512-FWAPzCIHZHnrE/5/w9MPk0kK25hSQSH2IKhYh9PyjS3SG/+IEMvlwIHbhz+oF7xl54I+ueZlVnMjyzdSwLmAwA==}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
 
   tough-cookie@6.0.2:
     resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
@@ -13612,7 +13659,7 @@ snapshots:
       '@analogjs/vite-plugin-angular': 2.6.4(@angular/build@22.1.3(@angular/compiler-cli@22.1.1(@angular/compiler@22.1.1)(typescript@6.0.3))(@angular/compiler@22.1.1)(@angular/core@22.1.1(@angular/compiler@22.1.1)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.1.1(@angular/common@22.1.1(@angular/core@22.1.1(@angular/compiler@22.1.1)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.1.1(@angular/compiler@22.1.1)(rxjs@7.8.2)(zone.js@0.16.2)))(@types/node@25.9.5)(chokidar@5.0.0)(jiti@2.7.0)(less@4.8.1)(ng-packagr@22.1.1(@angular/compiler-cli@22.1.1(@angular/compiler@22.1.1)(typescript@6.0.3))(tailwindcss@4.3.3)(tslib@2.8.1)(typescript@6.0.3))(postcss@8.5.26)(rollup@4.62.4)(tailwindcss@4.3.3)(terser@5.49.0)(tslib@2.8.1)(typescript@6.0.3)(vitest@4.1.10)(yaml@2.9.0))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0))
       '@angular-devkit/architect': 0.2201.3(chokidar@5.0.0)
       '@angular-devkit/schematics': 22.1.2(chokidar@5.0.0)
-      vitest: 4.1.10(@types/node@25.9.5)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0))
     optionalDependencies:
       zone.js: 0.16.2
 
@@ -13696,7 +13743,7 @@ snapshots:
       postcss: 8.5.26
       rollup: 4.62.4
       tailwindcss: 4.3.3
-      vitest: 4.1.10(@types/node@25.9.5)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -14521,6 +14568,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 8.0.0
       '@babel/helper-validator-identifier': 8.0.4
+
+  '@blazediff/core@1.9.1': {}
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:
@@ -16306,6 +16355,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@polka/url@1.0.0-next.29': {}
 
   '@preact/preset-vite@2.10.6(@babel/core@8.0.1)(preact@10.29.8)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))':
     dependencies:
@@ -18438,7 +18489,7 @@ snapshots:
       svelte: 5.56.8(@typescript-eslint/types@8.66.0)
     optionalDependencies:
       vite: 8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0)
-      vitest: 4.1.10(@types/node@25.9.5)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))
 
   '@testing-library/user-event@14.6.3(@testing-library/dom@10.4.1)':
     dependencies:
@@ -18837,6 +18888,68 @@ snapshots:
       vite: 8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0)
       vue: 3.6.0-rc.2(typescript@6.0.3)
 
+  '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@vitest/browser': 4.1.10(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0))
+      playwright: 1.62.1
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@vitest/browser': 4.1.10(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))
+      playwright: 1.62.1
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.10(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0))
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0))
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser@4.1.10(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
   '@vitest/coverage-istanbul@4.1.10(vitest@4.1.10)':
     dependencies:
       '@babel/core': 7.29.7
@@ -18849,7 +18962,7 @@ snapshots:
       magicast: 0.5.4
       obug: 2.1.4
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@25.9.5)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -21912,6 +22025,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -24014,6 +24130,14 @@ snapshots:
     dependencies:
       find-up: 3.0.0
 
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   plist@3.1.1:
     dependencies:
       '@xmldom/xmldom': 0.9.10
@@ -24021,6 +24145,8 @@ snapshots:
       xmlbuilder: 15.1.1
 
   pngjs@3.4.0: {}
+
+  pngjs@7.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -25050,6 +25176,12 @@ snapshots:
     dependencies:
       is-arrayish: 0.3.4
 
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
@@ -25402,6 +25534,8 @@ snapshots:
   toidentifier@1.0.1: {}
 
   toqr@0.1.1: {}
+
+  totalist@3.0.1: {}
 
   tough-cookie@6.0.2:
     dependencies:
@@ -25912,7 +26046,7 @@ snapshots:
     optionalDependencies:
       vite: 8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0)
 
-  vitest@4.1.10(@types/node@25.9.5)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0))
@@ -25936,12 +26070,13 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.5
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/coverage-istanbul': 4.1.10(vitest@4.1.10)
       jsdom: 27.4.0
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@types/node@25.9.5)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))
@@ -25965,6 +26100,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.5
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/coverage-istanbul': 4.1.10(vitest@4.1.10)
       jsdom: 27.4.0
     transitivePeerDependencies:


### PR DESCRIPTION
## 🎯 Changes

The `lucide-solid` entrypoint is a rather large barrel file. This means
it is fairly expensive to import, particularly in the tests (vitest)
since it needs to analyse and transform each imported file.

This adds a new ESLint rule to disallow importing icons from
`lucide-solid` and require they be imported directly from
`lucide-solid/icons/{name}`. It also applies that rule to the current
usages.

Locally, the test run now takes ~4s instead of ~8s.

**This also switches from jsdom to real browser tests**. We may need to alter the CI workflow to `playwright install chromium` for this to work.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized icon loading across the form devtools interface.
  - Added linting guidance to encourage consistent icon imports.
  - No user-facing functionality or visual behavior changed.

- **Tests**
  - Updated component testing to run in a real headless Chromium browser.
  - Improved test environment compatibility by removing obsolete resize-observer setup.
  - Added browser testing support for more realistic validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->