### PR TITLE
docs: add Valibot examples to validation guide

### DIFF
--- a/docs/framework/react/guides/validation.md
+++ b/docs/framework/react/guides/validation.md
@@ -513,10 +513,7 @@ Here is the same example with Valibot:
 import * as v from 'valibot'
 
 const userSchema = v.object({
-  age: v.pipe(
-    v.number(),
-    v.minValue(13, 'You must be 13 to make an account'),
-  ),
+  age: v.pipe(v.number(), v.minValue(13, 'You must be 13 to make an account')),
 })
 
 function App() {

--- a/docs/framework/react/guides/validation.md
+++ b/docs/framework/react/guides/validation.md
@@ -507,6 +507,40 @@ function App() {
 }
 ```
 
+Here is the same example with Valibot:
+
+```tsx
+import * as v from 'valibot'
+
+const userSchema = v.object({
+  age: v.pipe(
+    v.number(),
+    v.minValue(13, 'You must be 13 to make an account'),
+  ),
+})
+
+function App() {
+  const form = useForm({
+    defaultValues: {
+      age: 0,
+    },
+    validators: {
+      onChange: userSchema,
+    },
+  })
+  return (
+    <div>
+      <form.Field
+        name="age"
+        children={(field) => {
+          return <>{/* ... */}</>
+        }}
+      />
+    </div>
+  )
+}
+```
+
 Async validators at the form- and field-level are supported as well:
 
 ```tsx


### PR DESCRIPTION
The validation guide names Valibot as a supported Standard Schema library but there are no code examples for it. This adds a Valibot example based on the existing Zod one. The snippet is type-checked against the latest @tanstack/react-form and valibot. I'm the author of Valibot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a React guide example showing how to validate an age field with Valibot.
  * Demonstrated integrating Standard Schema validation with form fields and form state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->