### PR TITLE
chore: bump pnpm to v11.21.0 (#2327)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "git+https://github.com/TanStack/form.git"
   },
-  "packageManager": "pnpm@11.3.0+sha512.2c403d6594527287672b1f7056343a1f7c3634036a67ffabfcc2b3d7595d843768f8787148d1b57cf7956c90606bbd192857c363af19e96d2d0ec9ec5741d215",
+  "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "engines": {
     "pnpm": ">=11.0.0"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ cleanupUnusedCatalogs: true
 linkWorkspacePackages: true
 preferWorkspacePackages: true
 blockExoticSubdeps: true
+minimumReleaseAge: 1440
 trustPolicy: 'no-downgrade'
 trustPolicyExclude:
   - 'ua-parser-js@1.0.41 || 0.7.41' # React Native Web & Expo Devices; UAP v2 is not MIT


### PR DESCRIPTION
Predecessor of #2222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package manager tooling version.
  * Added a minimum release age for newly published packages to improve dependency stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->