### PR TITLE
fix: type serverValidate decoded values

### DIFF
--- a/.changeset/quiet-lamps-warn.md
+++ b/.changeset/quiet-lamps-warn.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/react-form-nextjs': patch
+'@tanstack/react-form-remix': patch
+---
+
+Fix `createServerValidate` return types to reflect decoded `FormData` values instead of inferred form values.

--- a/packages/react-form-nextjs/src/createServerValidate.ts
+++ b/packages/react-form-nextjs/src/createServerValidate.ts
@@ -99,12 +99,11 @@ export const createServerValidate =
       })
     }
 
-    const values = (info
-      ? decode(formData, info)
-      : decode(formData)) as never as TFormData
+    const values = info ? decode(formData, info) : decode(formData)
+    const validationValues = values as never as TFormData
 
     const onServerError = (await runValidator({
-      value: values,
+      value: validationValues,
       validationSource: 'form',
     })) as UnwrapFormAsyncValidateOrFn<TOnServer> | undefined
 
@@ -120,7 +119,7 @@ export const createServerValidate =
       errorMap: {
         onServer: onServerError,
       },
-      values,
+      values: validationValues,
       errors: onServerErrorVal ? [onServerErrorVal] : [],
     }
 

--- a/packages/react-form-nextjs/tests/createServerValidate.test-d.ts
+++ b/packages/react-form-nextjs/tests/createServerValidate.test-d.ts
@@ -1,0 +1,19 @@
+import { expectTypeOf, it } from 'vitest'
+import { createServerValidate, formOptions } from '../src'
+
+it('types serverValidate return values as decoded form data', () => {
+  const serverValidate = createServerValidate({
+    ...formOptions({
+      defaultValues: {
+        firstName: '',
+        age: 0,
+      },
+    }),
+    onServerValidate: async () => undefined,
+  })
+
+  type ServerValidateResult = Awaited<ReturnType<typeof serverValidate>>
+
+  expectTypeOf<ServerValidateResult>().toEqualTypeOf<Record<string, unknown>>()
+  expectTypeOf<ServerValidateResult['age']>().toEqualTypeOf<unknown>()
+})

--- a/packages/react-form-remix/src/createServerValidate.ts
+++ b/packages/react-form-remix/src/createServerValidate.ts
@@ -99,12 +99,11 @@ export const createServerValidate =
       })
     }
 
-    const values = (info
-      ? decode(formData, info)
-      : decode(formData)) as never as TFormData
+    const values = info ? decode(formData, info) : decode(formData)
+    const validationValues = values as never as TFormData
 
     const onServerError = (await runValidator({
-      value: values,
+      value: validationValues,
       validationSource: 'form',
     })) as UnwrapFormAsyncValidateOrFn<TOnServer> | undefined
 
@@ -120,7 +119,7 @@ export const createServerValidate =
       errorMap: {
         onServer: onServerError,
       },
-      values,
+      values: validationValues,
       errors: onServerErrorVal ? [onServerErrorVal] : [],
     }
 

--- a/packages/react-form-remix/tests/createServerValidate.test-d.ts
+++ b/packages/react-form-remix/tests/createServerValidate.test-d.ts
@@ -1,0 +1,19 @@
+import { expectTypeOf, it } from 'vitest'
+import { createServerValidate, formOptions } from '../src'
+
+it('types serverValidate return values as decoded form data', () => {
+  const serverValidate = createServerValidate({
+    ...formOptions({
+      defaultValues: {
+        firstName: '',
+        age: 0,
+      },
+    }),
+    onServerValidate: async () => undefined,
+  })
+
+  type ServerValidateResult = Awaited<ReturnType<typeof serverValidate>>
+
+  expectTypeOf<ServerValidateResult>().toEqualTypeOf<Record<string, unknown>>()
+  expectTypeOf<ServerValidateResult['age']>().toEqualTypeOf<unknown>()
+})


### PR DESCRIPTION
## 🎯 Changes

Fixes #1438. `createServerValidate` exposed form-value types instead of decoded form data.

Fix: Return decoded `decode-formdata` value types from the public adapter API, and keep form-shaped casts only for validator and `ServerFormState` internals.

Test: Added Next.js and Remix adapter type regression coverage.

## ✅ Checklist

- [x] I have followed the steps in the Contributing guide.
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a changeset.
- [ ] This change is docs/CI/dev-only (no release).
