### PR TITLE
fix(form-core): restrict form group membership to delimited field paths

### DIFF
--- a/.changeset/wild-donkeys-shave.md
+++ b/.changeset/wild-donkeys-shave.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/form-core': patch
+---
+
+Restrict form group membership to dot- and bracket-delimited field paths so fields that merely share a name prefix with a group are no longer treated as part of it.

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -1628,7 +1628,7 @@ export class FieldApi<
     const encompassingGroups = opts?.skipGroupValidation
       ? []
       : Array.from(this.form.formGroupApis).filter((group) =>
-          this.name.startsWith(group.name),
+          isFieldInGroup(group.name, this.name),
         )
 
     // Attempt to sync validate first

--- a/packages/form-core/src/FormGroupApi.ts
+++ b/packages/form-core/src/FormGroupApi.ts
@@ -1646,7 +1646,7 @@ export class FormGroupApi<
       if (!field.instance) continue
       // TODO: How to handle FormGroups?
       if (!(field.instance instanceof FieldApi)) continue
-      if (field.instance.name.startsWith(this.name)) {
+      if (isFieldInGroup(this.name, field.instance.name)) {
         relatedFields.push(field.instance)
       }
     }

--- a/packages/form-core/tests/FormGroupApi.spec.ts
+++ b/packages/form-core/tests/FormGroupApi.spec.ts
@@ -1189,6 +1189,78 @@ describe('form group api', () => {
     expect(step1NameField.state.meta.errors).toEqual([])
   })
 
+  it('should not treat a field whose name merely shares a prefix as related', async () => {
+    const form = new FormApi({
+      defaultValues: {
+        step1: { name: 'test' },
+        step1Extra: '',
+      },
+    })
+
+    const step1Group = new FormGroupApi({
+      name: 'step1',
+      form,
+    })
+
+    const step1NameField = new FieldApi({
+      name: 'step1.name',
+      form,
+    })
+
+    const step1ExtraField = new FieldApi({
+      name: 'step1Extra',
+      form,
+      validators: {
+        onSubmit: () => 'Extra is invalid',
+      },
+    })
+
+    form.mount()
+    step1Group.mount()
+    step1NameField.mount()
+    step1ExtraField.mount()
+
+    await step1Group.handleSubmit()
+
+    expect(step1NameField.state.meta.isTouched).toBe(true)
+    expect(step1ExtraField.state.meta.isTouched).toBe(false)
+    expect(step1ExtraField.state.meta.errors).toEqual([])
+    expect(step1Group.areRelatedFieldsValid()).toBe(true)
+  })
+
+  it('should not cascade field validation into a group whose name merely shares a prefix', () => {
+    const form = new FormApi({
+      defaultValues: {
+        step1: { name: 'test' },
+        step1Extra: '',
+      },
+    })
+
+    const onChange = vi.fn(() => undefined)
+
+    const step1Group = new FormGroupApi({
+      name: 'step1',
+      form,
+      validators: {
+        onChange,
+      },
+    })
+
+    const step1ExtraField = new FieldApi({
+      name: 'step1Extra',
+      form,
+    })
+
+    form.mount()
+    step1Group.mount()
+    step1ExtraField.mount()
+
+    step1ExtraField.setMeta((prev) => ({ ...prev, isTouched: true }))
+    step1ExtraField.handleChange('changed')
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
   describe('isFieldsValid / isGroupValid / isValid', () => {
     it('should be true on a pristine, valid group', () => {
       const form = new FormApi({


### PR DESCRIPTION
## 🎯 Changes

`FormGroupApi.getRelatedFields()` and the group filter in `FieldApi.validate()` match members with a bare `startsWith`, so top-level `step1Extra` joins group `step1`: touched by the group's submit, counted by `areRelatedFieldsValid()`, and re-running its validators. Both now use `isFieldInGroup`, which requires a `.` or `[` boundary, as #2318 did for `deleteField`. Added tests fail on `main`.

Fixes #2337

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a changeset.
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected form-group field matching to recognize only dot- or bracket-delimited paths.
  - Prevented similarly prefixed fields from being incorrectly validated, touched, marked invalid, or triggering group-level change validation.

- **Tests**
  - Added regression coverage for fields with shared name prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->