### PR TITLE
[v2] Fix: Subscription selectors no longer need `as const` when destructuring result

### DIFF
--- a/.changeset/polite-planets-deny.md
+++ b/.changeset/polite-planets-deny.md
@@ -1,0 +1,12 @@
+---
+'@tanstack/angular-form': patch
+'@tanstack/preact-form': patch
+'@tanstack/svelte-form': patch
+'@tanstack/react-form': patch
+'@tanstack/solid-form': patch
+'@tanstack/form-core': patch
+'@tanstack/lit-form': patch
+'@tanstack/vue-form': patch
+---
+
+Fix: Subscription selectors now infer tuple return values without requiring `as const`.

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ stats.html
 .cursor
 .claude
 .codex
+AGENTS.md
+.agents
 
 *.log
 .cache

--- a/docs/config.json
+++ b/docs/config.json
@@ -250,94 +250,6 @@
       ]
     },
     {
-      "label": "Form creation",
-      "collapsible": true,
-      "defaultCollapsed": true,
-      "children": [
-        {
-          "label": "formOptions()",
-          "to": "reference/variables/formOptions"
-        },
-        {
-          "label": "formOptions.strictSchema()",
-          "to": "reference/type-aliases/FormOptionsStrictSchemaFn"
-        },
-        {
-          "label": "formOptions.looseSchema()",
-          "to": "reference/type-aliases/FormOptionsLooseSchemaFn"
-        },
-        {
-          "label": "FormOptions",
-          "to": "reference/interfaces/FormOptions"
-        }
-      ],
-      "frameworks": [
-        {
-          "label": "react",
-          "children": [
-            {
-              "label": "useForm()",
-              "to": "framework/react/reference/variables/useForm"
-            }
-          ]
-        },
-        {
-          "label": "preact",
-          "children": [
-            {
-              "label": "useForm()",
-              "to": "framework/preact/reference/variables/useForm"
-            }
-          ]
-        },
-        {
-          "label": "vue",
-          "children": [
-            {
-              "label": "useForm()",
-              "to": "framework/vue/reference/variables/useForm"
-            }
-          ]
-        },
-        {
-          "label": "angular",
-          "children": [
-            {
-              "label": "injectForm()",
-              "to": "framework/angular/reference/functions/injectForm"
-            }
-          ]
-        },
-        {
-          "label": "solid",
-          "children": [
-            {
-              "label": "createForm()",
-              "to": "framework/solid/reference/variables/createForm"
-            }
-          ]
-        },
-        {
-          "label": "lit",
-          "children": [
-            {
-              "label": "TanStackFormController",
-              "to": "framework/lit/reference/classes/TanStackFormController"
-            }
-          ]
-        },
-        {
-          "label": "svelte",
-          "children": [
-            {
-              "label": "createForm()",
-              "to": "framework/svelte/reference/variables/createForm"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "label": "Recommended Types",
       "collapsible": true,
       "defaultCollapsed": false,
@@ -445,6 +357,95 @@
         }
       ]
     },
+    {
+      "label": "Form creation",
+      "collapsible": true,
+      "defaultCollapsed": true,
+      "children": [
+        {
+          "label": "formOptions()",
+          "to": "reference/variables/formOptions"
+        },
+        {
+          "label": "formOptions.strictSchema()",
+          "to": "reference/type-aliases/FormOptionsStrictSchemaFn"
+        },
+        {
+          "label": "formOptions.looseSchema()",
+          "to": "reference/type-aliases/FormOptionsLooseSchemaFn"
+        },
+        {
+          "label": "FormOptions",
+          "to": "reference/interfaces/FormOptions"
+        }
+      ],
+      "frameworks": [
+        {
+          "label": "react",
+          "children": [
+            {
+              "label": "useForm()",
+              "to": "framework/react/reference/variables/useForm"
+            }
+          ]
+        },
+        {
+          "label": "preact",
+          "children": [
+            {
+              "label": "useForm()",
+              "to": "framework/preact/reference/variables/useForm"
+            }
+          ]
+        },
+        {
+          "label": "vue",
+          "children": [
+            {
+              "label": "useForm()",
+              "to": "framework/vue/reference/variables/useForm"
+            }
+          ]
+        },
+        {
+          "label": "angular",
+          "children": [
+            {
+              "label": "injectForm()",
+              "to": "framework/angular/reference/functions/injectForm"
+            }
+          ]
+        },
+        {
+          "label": "solid",
+          "children": [
+            {
+              "label": "createForm()",
+              "to": "framework/solid/reference/variables/createForm"
+            }
+          ]
+        },
+        {
+          "label": "lit",
+          "children": [
+            {
+              "label": "TanStackFormController",
+              "to": "framework/lit/reference/classes/TanStackFormController"
+            }
+          ]
+        },
+        {
+          "label": "svelte",
+          "children": [
+            {
+              "label": "createForm()",
+              "to": "framework/svelte/reference/variables/createForm"
+            }
+          ]
+        }
+      ]
+    },
+
     {
       "label": "Form Composition API Reference",
       "collapsible": true,

--- a/docs/config.json
+++ b/docs/config.json
@@ -250,6 +250,94 @@
       ]
     },
     {
+      "label": "Form creation",
+      "collapsible": true,
+      "defaultCollapsed": true,
+      "children": [
+        {
+          "label": "formOptions()",
+          "to": "reference/variables/formOptions"
+        },
+        {
+          "label": "formOptions.strictSchema()",
+          "to": "reference/type-aliases/FormOptionsStrictSchemaFn"
+        },
+        {
+          "label": "formOptions.looseSchema()",
+          "to": "reference/type-aliases/FormOptionsLooseSchemaFn"
+        },
+        {
+          "label": "FormOptions",
+          "to": "reference/interfaces/FormOptions"
+        }
+      ],
+      "frameworks": [
+        {
+          "label": "react",
+          "children": [
+            {
+              "label": "useForm()",
+              "to": "framework/react/reference/variables/useForm"
+            }
+          ]
+        },
+        {
+          "label": "preact",
+          "children": [
+            {
+              "label": "useForm()",
+              "to": "framework/preact/reference/variables/useForm"
+            }
+          ]
+        },
+        {
+          "label": "vue",
+          "children": [
+            {
+              "label": "useForm()",
+              "to": "framework/vue/reference/variables/useForm"
+            }
+          ]
+        },
+        {
+          "label": "angular",
+          "children": [
+            {
+              "label": "injectForm()",
+              "to": "framework/angular/reference/functions/injectForm"
+            }
+          ]
+        },
+        {
+          "label": "solid",
+          "children": [
+            {
+              "label": "createForm()",
+              "to": "framework/solid/reference/variables/createForm"
+            }
+          ]
+        },
+        {
+          "label": "lit",
+          "children": [
+            {
+              "label": "TanStackFormController",
+              "to": "framework/lit/reference/classes/TanStackFormController"
+            }
+          ]
+        },
+        {
+          "label": "svelte",
+          "children": [
+            {
+              "label": "createForm()",
+              "to": "framework/svelte/reference/variables/createForm"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "label": "Recommended Types",
       "collapsible": true,
       "defaultCollapsed": false,

--- a/docs/framework/angular/reference/functions/injectForm.md
+++ b/docs/framework/angular/reference/functions/injectForm.md
@@ -9,9 +9,17 @@ title: injectForm
 function injectForm<TFormData, TFormValidators, TSubmitReturn>(options): InternalFormApi<TFormData, TFormValidators, TSubmitReturn>;
 ```
 
-Defined in: [inject-form.ts:9](https://github.com/TanStack/form/blob/main/packages/angular-form/src/inject-form.ts#L9)
+Defined in: [inject-form.ts:38](https://github.com/TanStack/form/blob/main/packages/angular-form/src/inject-form.ts#L38)
 
-Creates and mounts a v2 form in the current Angular injection context.
+Creates and mounts a form in the current Angular injection context.
+
+`defaultValues` establish the initial state and inferred form value type.
+Form state changes notify Angular change detection, including OnPush
+components, and the form is cleaned up when the injection context is
+destroyed.
+
+Call this in a component field initializer, constructor, provider factory,
+or another active injection context.
 
 ## Type Parameters
 
@@ -19,13 +27,19 @@ Creates and mounts a v2 form in the current Angular injection context.
 
 `TFormData`
 
+Library-managed. Do not specify explicitly.
+
 ### TFormValidators
 
 `TFormValidators` *extends* `FormValidators`\<`TFormData`\>
 
+Library-managed. Do not specify explicitly.
+
 ### TSubmitReturn
 
 `TSubmitReturn`
+
+Library-managed. Do not specify explicitly.
 
 ## Parameters
 
@@ -33,6 +47,26 @@ Creates and mounts a v2 form in the current Angular injection context.
 
 `FormOptions`\<`TFormData`, `TFormValidators`, `TSubmitReturn`\>
 
+The initial form options. `defaultValues` drive form value
+inference.
+
 ## Returns
 
 `InternalFormApi`\<`TFormData`, `TFormValidators`, `TSubmitReturn`\>
+
+The mounted form API registered for injection-context cleanup.
+
+## Example
+
+```ts
+@Component({
+  selector: 'app-profile-form',
+  template: `<form></form>`,
+})
+class ProfileFormComponent {
+  form = injectForm({
+    defaultValues: { name: '' },
+    onSubmit: ({ value }) => saveProfile(value),
+  })
+}
+```

--- a/docs/framework/lit/reference/classes/TanStackFormController.md
+++ b/docs/framework/lit/reference/classes/TanStackFormController.md
@@ -5,7 +5,35 @@ title: TanStackFormController
 
 # Class: TanStackFormController\<TFormData, TFormValidators, TSubmitReturn\>
 
-Defined in: [tanstack-form-controller.ts:177](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L177)
+Defined in: [tanstack-form-controller.ts:209](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L209)
+
+Owns a form for a Lit reactive-controller host and provides Lit-specific
+field, form-group, and subscription render helpers.
+
+`defaultValues` establish the initial state and inferred form value type.
+The form mounts when its host connects and is cleaned up when the host
+disconnects. Call `update(...)` to apply later options without replacing the
+form instance, and access the framework-agnostic form API through `api`.
+
+## Example
+
+```ts
+class ProfileForm extends LitElement {
+  private form = new TanStackFormController(this, {
+    defaultValues: { name: '' },
+    onSubmit: ({ value }) => saveProfile(value),
+  })
+
+  render() {
+    return html`<form
+      @submit=${(event: SubmitEvent) => {
+        event.preventDefault()
+        void this.form.api.handleSubmit()
+      }}
+    ></form>`
+  }
+}
+```
 
 ## Type Parameters
 
@@ -13,13 +41,19 @@ Defined in: [tanstack-form-controller.ts:177](https://github.com/TanStack/form/b
 
 `TFormData`
 
+Library-managed. Do not specify explicitly.
+
 ### TFormValidators
 
 `TFormValidators` *extends* `FormValidators`\<`TFormData`\>
 
+Library-managed. Do not specify explicitly.
+
 ### TSubmitReturn
 
 `TSubmitReturn`
+
+Library-managed. Do not specify explicitly.
 
 ## Implements
 
@@ -35,7 +69,7 @@ Defined in: [tanstack-form-controller.ts:177](https://github.com/TanStack/form/b
 new TanStackFormController<TFormData, TFormValidators, TSubmitReturn>(host, options): TanStackFormController<TFormData, TFormValidators, TSubmitReturn>;
 ```
 
-Defined in: [tanstack-form-controller.ts:204](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L204)
+Defined in: [tanstack-form-controller.ts:241](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L241)
 
 #### Parameters
 
@@ -43,9 +77,14 @@ Defined in: [tanstack-form-controller.ts:204](https://github.com/TanStack/form/b
 
 `ReactiveControllerHost`
 
+The Lit host that owns the controller and form lifecycle.
+
 ##### options
 
 `FormOptions`\<`TFormData`, `TFormValidators`, `TSubmitReturn`\>
+
+The initial form options. `defaultValues` drive form value
+inference.
 
 #### Returns
 
@@ -61,7 +100,7 @@ Defined in: [tanstack-form-controller.ts:204](https://github.com/TanStack/form/b
 get api(): FormApi<TFormData, ToFormErrorTypes<TFormValidators, TSubmitReturn>>;
 ```
 
-Defined in: [tanstack-form-controller.ts:197](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L197)
+Defined in: [tanstack-form-controller.ts:229](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L229)
 
 ##### Returns
 
@@ -75,7 +114,7 @@ Defined in: [tanstack-form-controller.ts:197](https://github.com/TanStack/form/b
 arrayField<TFieldName, TFieldValidators>(options, render): unknown;
 ```
 
-Defined in: [tanstack-form-controller.ts:269](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L269)
+Defined in: [tanstack-form-controller.ts:306](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L306)
 
 #### Type Parameters
 
@@ -113,7 +152,7 @@ Defined in: [tanstack-form-controller.ts:269](https://github.com/TanStack/form/b
 field<TFieldName, TFieldValidators>(options, render): unknown;
 ```
 
-Defined in: [tanstack-form-controller.ts:232](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L232)
+Defined in: [tanstack-form-controller.ts:269](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L269)
 
 #### Type Parameters
 
@@ -151,7 +190,7 @@ Defined in: [tanstack-form-controller.ts:232](https://github.com/TanStack/form/b
 formGroup<TGroupName, TGroupValue, TGroupValidators>(options, render): unknown;
 ```
 
-Defined in: [tanstack-form-controller.ts:319](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L319)
+Defined in: [tanstack-form-controller.ts:356](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L356)
 
 #### Type Parameters
 
@@ -189,7 +228,7 @@ Defined in: [tanstack-form-controller.ts:319](https://github.com/TanStack/form/b
 hostConnected(): void;
 ```
 
-Defined in: [tanstack-form-controller.ts:213](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L213)
+Defined in: [tanstack-form-controller.ts:250](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L250)
 
 Called when the host is connected to the component tree. For custom
 element hosts, this corresponds to the `connectedCallback()` lifecycle,
@@ -213,7 +252,7 @@ ReactiveController.hostConnected
 hostDisconnected(): void;
 ```
 
-Defined in: [tanstack-form-controller.ts:218](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L218)
+Defined in: [tanstack-form-controller.ts:255](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L255)
 
 Called when the host is disconnected from the component tree. For custom
 element hosts, this corresponds to the `disconnectedCallback()` lifecycle,
@@ -241,7 +280,7 @@ subscribe<TSelected>(
    when?): unknown;
 ```
 
-Defined in: [tanstack-form-controller.ts:306](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L306)
+Defined in: [tanstack-form-controller.ts:343](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L343)
 
 #### Type Parameters
 
@@ -279,7 +318,7 @@ Defined in: [tanstack-form-controller.ts:306](https://github.com/TanStack/form/b
 update(options): void;
 ```
 
-Defined in: [tanstack-form-controller.ts:228](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L228)
+Defined in: [tanstack-form-controller.ts:265](https://github.com/TanStack/form/blob/main/packages/lit-form/src/tanstack-form-controller.ts#L265)
 
 Updates reactive form options without replacing the form instance.
 

--- a/docs/framework/preact/reference/variables/useForm.md
+++ b/docs/framework/preact/reference/variables/useForm.md
@@ -9,4 +9,38 @@ title: useForm
 const useForm: UseFormHook<DefaultPreactFormComponentMap>;
 ```
 
-Defined in: [packages/preact-form/src/PreactForm/useForm.public.ts:31](https://github.com/TanStack/form/blob/main/packages/preact-form/src/PreactForm/useForm.public.ts#L31)
+Defined in: [packages/preact-form/src/PreactForm/useForm.public.ts:63](https://github.com/TanStack/form/blob/main/packages/preact-form/src/PreactForm/useForm.public.ts#L63)
+
+Creates a Preact form whose instance and lifecycle are owned by the current
+component.
+
+`defaultValues` establish the initial state and inferred form value type.
+Later renders apply changed options to the same form instance, and unmounting
+the component cleans it up.
+
+Call this hook at the top level of a Preact component or custom hook.
+
+## Example
+
+```tsx
+function ProfileForm() {
+  const form = useForm({
+    defaultValues: { name: '' },
+    onSubmit: ({ value }) => saveProfile(value),
+  })
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault()
+        void form.handleSubmit()
+      }}
+    />
+  )
+}
+```
+
+## Returns
+
+The Preact form API with typed field, subscription, and form-group
+components attached.

--- a/docs/framework/react/reference/variables/useForm.md
+++ b/docs/framework/react/reference/variables/useForm.md
@@ -9,4 +9,38 @@ title: useForm
 const useForm: UseFormHook<DefaultReactFormComponentMap>;
 ```
 
-Defined in: [packages/react-form/src/ReactForm/useForm.public.ts:30](https://github.com/TanStack/form/blob/main/packages/react-form/src/ReactForm/useForm.public.ts#L30)
+Defined in: [packages/react-form/src/ReactForm/useForm.public.ts:62](https://github.com/TanStack/form/blob/main/packages/react-form/src/ReactForm/useForm.public.ts#L62)
+
+Creates a React form whose instance and lifecycle are owned by the current
+component.
+
+`defaultValues` establish the initial state and inferred form value type.
+Later renders apply changed options to the same form instance, and unmounting
+the component cleans it up.
+
+Call this hook at the top level of a React component or custom hook.
+
+## Example
+
+```tsx
+function ProfileForm() {
+  const form = useForm({
+    defaultValues: { name: '' },
+    onSubmit: ({ value }) => saveProfile(value),
+  })
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault()
+        void form.handleSubmit()
+      }}
+    />
+  )
+}
+```
+
+## Returns
+
+The React form API with typed field, subscription, and form-group
+components attached.

--- a/docs/framework/solid/reference/variables/createForm.md
+++ b/docs/framework/solid/reference/variables/createForm.md
@@ -9,4 +9,37 @@ title: createForm
 const createForm: CreateFormHook;
 ```
 
-Defined in: [packages/solid-form/src/createForm.public.ts:27](https://github.com/TanStack/form/blob/main/packages/solid-form/src/createForm.public.ts#L27)
+Defined in: [packages/solid-form/src/createForm.public.ts:58](https://github.com/TanStack/form/blob/main/packages/solid-form/src/createForm.public.ts#L58)
+
+Creates a Solid form whose instance and lifecycle are owned by the current
+reactive owner.
+
+Pass an options accessor. `defaultValues` establish the initial state and
+inferred form value type, while signals read by the accessor update the same
+form instance when they change. The form is cleaned up when its owner is
+disposed.
+
+## Example
+
+```tsx
+function ProfileForm() {
+  const form = createForm(() => ({
+    defaultValues: { name: '' },
+    onSubmit: ({ value }) => saveProfile(value),
+  }))
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault()
+        void form.handleSubmit()
+      }}
+    />
+  )
+}
+```
+
+## Returns
+
+The Solid form API with typed field, subscription, and form-group
+components attached.

--- a/docs/framework/svelte/reference/variables/createForm.md
+++ b/docs/framework/svelte/reference/variables/createForm.md
@@ -9,4 +9,28 @@ title: createForm
 const createForm: CreateForm;
 ```
 
-Defined in: [packages/svelte-form/src/createForm.public.ts:26](https://github.com/TanStack/form/blob/main/packages/svelte-form/src/createForm.public.ts#L26)
+Defined in: [packages/svelte-form/src/createForm.public.ts:48](https://github.com/TanStack/form/blob/main/packages/svelte-form/src/createForm.public.ts#L48)
+
+Creates a Svelte form whose instance and lifecycle are owned by the current
+component.
+
+Pass an options function. `defaultValues` establish the initial state and
+inferred form value type, while reactive values read by the function update
+the same form instance when they change.
+
+Call this during component initialization. The form mounts with the
+component and is cleaned up when the component unmounts.
+
+## Example
+
+```ts
+const form = createForm(() => ({
+  defaultValues: { name: '' },
+  onSubmit: ({ value }) => saveProfile(value),
+}))
+```
+
+## Returns
+
+The Svelte form API with typed field, subscription, and form-group
+components attached.

--- a/docs/framework/vue/reference/variables/useForm.md
+++ b/docs/framework/vue/reference/variables/useForm.md
@@ -9,4 +9,28 @@ title: useForm
 const useForm: UseFormHook<DefaultVueFormComponentMap>;
 ```
 
-Defined in: [packages/vue-form/src/VueForm/useForm.public.ts:29](https://github.com/TanStack/form/blob/main/packages/vue-form/src/VueForm/useForm.public.ts#L29)
+Defined in: [packages/vue-form/src/VueForm/useForm.public.ts:51](https://github.com/TanStack/form/blob/main/packages/vue-form/src/VueForm/useForm.public.ts#L51)
+
+Creates a Vue form whose instance and lifecycle are owned by the current
+component.
+
+`defaultValues` establish the initial state and inferred form value type. To
+update the existing form after creation, pass a reactive options object;
+tracked changes are applied without replacing the form instance.
+
+Call this during the component's setup phase. The form mounts with the
+component and is cleaned up when the component unmounts.
+
+## Example
+
+```ts
+const form = useForm({
+  defaultValues: { name: '' },
+  onSubmit: ({ value }) => saveProfile(value),
+})
+```
+
+## Returns
+
+The Vue form API with typed field, subscription, and form-group
+components attached.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -104,6 +104,8 @@ title: "@tanstack/form-core"
 - [FormListenerFn](type-aliases/FormListenerFn.md)
 - [FormListeners](type-aliases/FormListeners.md)
 - [FormListenerTriggers](type-aliases/FormListenerTriggers.md)
+- [FormOptionsLooseSchemaFn](type-aliases/FormOptionsLooseSchemaFn.md)
+- [FormOptionsStrictSchemaFn](type-aliases/FormOptionsStrictSchemaFn.md)
 - [FormValidateResult](type-aliases/FormValidateResult.md)
 - [FormValidateResultFromErrorTypes](type-aliases/FormValidateResultFromErrorTypes.md)
 - [FormValidationError](type-aliases/FormValidationError.md)

--- a/docs/reference/interfaces/FormOptionsApi.md
+++ b/docs/reference/interfaces/FormOptionsApi.md
@@ -5,13 +5,26 @@ title: FormOptionsApi
 
 # Interface: FormOptionsApi()
 
-Defined in: [utils.public.ts:53](https://github.com/TanStack/form/blob/main/packages/form-core/src/utils.public.ts#L53)
+Defined in: [utils.public.ts:169](https://github.com/TanStack/form/blob/main/packages/form-core/src/utils.public.ts#L169)
+
+The callable API exposed by `formOptions`, including its schema-driven
+inference modes.
+
+Use `formOptions` directly instead of naming this interface in application
+code.
 
 ```ts
 FormOptionsApi<TFormData, TFormValidators, TSubmitReturn>(options): FormOptions<TFormData, TFormValidators, TSubmitReturn>;
 ```
 
-Defined in: [utils.public.ts:54](https://github.com/TanStack/form/blob/main/packages/form-core/src/utils.public.ts#L54)
+Defined in: [utils.public.ts:190](https://github.com/TanStack/form/blob/main/packages/form-core/src/utils.public.ts#L190)
+
+Keeps types inferred from `defaultValues`, validators, and submission
+callbacks when form options are declared separately.
+
+`defaultValues` determine the form data shape in this mode. At runtime,
+this returns the original options object and does not create a form or run
+validation.
 
 ## Type Parameters
 
@@ -19,13 +32,19 @@ Defined in: [utils.public.ts:54](https://github.com/TanStack/form/blob/main/pack
 
 `TFormData`
 
+Library-managed. Do not specify explicitly.
+
 ### TFormValidators
 
 `TFormValidators` *extends* [`FormValidators`](../type-aliases/FormValidators.md)\<`TFormData`\>
 
+Library-managed. Do not specify explicitly.
+
 ### TSubmitReturn
 
 `TSubmitReturn`
+
+Library-managed. Do not specify explicitly.
 
 ## Parameters
 
@@ -37,70 +56,150 @@ Defined in: [utils.public.ts:54](https://github.com/TanStack/form/blob/main/pack
 
 [`FormOptions`](FormOptions.md)\<`TFormData`, `TFormValidators`, `TSubmitReturn`\>
 
+The original options object, normalized to `FormOptions` with its
+inferred form data, validator, and submission types.
+
+## Remarks
+
+**Important:** Although this returns the original object unchanged at
+runtime, its type is normalized to `FormOptions`. Optional properties such
+as `validators` therefore remain optional even when supplied. This
+tradeoff enables safer inference and reuse.
+
 ## Properties
 
 ### looseSchema
 
 ```ts
-looseSchema: <TFormValidators, TFormData, TSubmitReturn>(options) => FormOptions<InferUnion<TFormData, FormValidatorData<TFormValidators>>, TFormValidators, TSubmitReturn>;
+looseSchema: FormOptionsLooseSchemaFn;
 ```
 
-Defined in: [utils.public.ts:76](https://github.com/TanStack/form/blob/main/packages/form-core/src/utils.public.ts#L76)
+Defined in: [utils.public.ts:282](https://github.com/TanStack/form/blob/main/packages/form-core/src/utils.public.ts#L282)
 
-#### Type Parameters
+Infers the form data shape from a Standard Schema validator while allowing
+editable defaults to contain `null` or `undefined` values.
 
-##### TFormValidators
+Use this when the schema represents the final valid shape but the UI needs
+intermediate empty states, such as an unselected date. Raw form state
+remains available as `value`; read each validator's parsed output from the
+corresponding `schemaOutputs` entry during submission.
 
-`TFormValidators` *extends* [`FormValidators`](../type-aliases/FormValidators.md)\<`any`\>
+At runtime, this returns the original options object and does not run the
+schema.
 
-##### TFormData
+Include the schema in `validators` to provide the type inference and
+perform validation.
 
-`TFormData` *extends* `any`
+#### Remarks
 
-##### TSubmitReturn
+**Important:** Although this returns the original object unchanged at
+runtime, its type is normalized to `FormOptions`. Optional properties such
+as `validators` therefore remain optional even when supplied. This
+tradeoff enables safer inference and reuse.
 
-`TSubmitReturn`
+#### Example
 
-#### Parameters
-
-##### options
-
-[`FormOptions`](FormOptions.md)\<`TFormData`, `TFormValidators`, `TSubmitReturn`\>
+```ts
+const bookingOptions = formOptions.looseSchema({
+  defaultValues: { startDate: null },
+  validators: [
+    {
+      triggers: ['blur'],
+      run: z.object({ startDate: z.date() }),
+    },
+  ],
+  onSubmit: ({ schemaOutputs }) => saveBooking(schemaOutputs[0]),
+})
+```
 
 #### Returns
 
-[`FormOptions`](FormOptions.md)\<[`InferUnion`](../type-aliases/InferUnion.md)\<`TFormData`, [`FormValidatorData`](../type-aliases/FormValidatorData.md)\<`TFormValidators`\>\>, `TFormValidators`, `TSubmitReturn`\>
+The original options object, normalized to `FormOptions` with
+nullable and undefined editable states merged into the schema's input
+shape.
+
+#### Type Param
+
+**TFormValidators**
+
+Library-managed. Do not specify explicitly.
+
+#### Type Param
+
+**TFormData**
+
+Library-managed. Do not specify explicitly.
+
+#### Type Param
+
+**TSubmitReturn**
+
+Library-managed. Do not specify explicitly.
 
 ***
 
 ### strictSchema
 
 ```ts
-strictSchema: <TFormValidators, TFormData, TSubmitReturn>(options) => FormOptions<FormValidatorData<TFormValidators>, TFormValidators, TSubmitReturn>;
+strictSchema: FormOptionsStrictSchemaFn;
 ```
 
-Defined in: [utils.public.ts:62](https://github.com/TanStack/form/blob/main/packages/form-core/src/utils.public.ts#L62)
+Defined in: [utils.public.ts:238](https://github.com/TanStack/form/blob/main/packages/form-core/src/utils.public.ts#L238)
 
-#### Type Parameters
+Infers the form data type from a Standard Schema validator and requires
+`defaultValues` to match the schema input.
 
-##### TFormValidators
+Use this when the schema represents an input-to-output pipeline. Raw form
+state remains available as `value`; read each validator's parsed output
+from the corresponding `schemaOutputs` entry during submission.
 
-`TFormValidators` *extends* [`FormValidators`](../type-aliases/FormValidators.md)\<`any`\>
+At runtime, this returns the original options object and does not run the
+schema.
 
-##### TFormData
+Include the schema in `validators` to provide the type inference and
+perform validation.
 
-`TFormData` *extends* `any`
+#### Remarks
 
-##### TSubmitReturn
+**Important:** Although this returns the original object unchanged at
+runtime, its type is normalized to `FormOptions`. Optional properties such
+as `validators` therefore remain optional even when supplied. This
+tradeoff enables safer inference and reuse.
 
-`TSubmitReturn`
+#### Example
 
-#### Parameters
-
-##### options
-
-[`FormOptions`](FormOptions.md)\<`TFormData`, `TFormValidators`, `TSubmitReturn`\>
+```ts
+const profileOptions = formOptions.strictSchema({
+  defaultValues: { name: '' },
+  validators: [
+    {
+      triggers: ['change'],
+      run: z.object({ name: z.string().min(1) }),
+    },
+  ],
+  onSubmit: ({ schemaOutputs }) => saveProfile(schemaOutputs[0]),
+})
+```
 
 #### Returns
 
-[`FormOptions`](FormOptions.md)\<[`FormValidatorData`](../type-aliases/FormValidatorData.md)\<`TFormValidators`\>, `TFormValidators`, `TSubmitReturn`\>
+The original options object, normalized to `FormOptions` with the
+schema's input shape.
+
+#### Type Param
+
+**TFormValidators**
+
+Library-managed. Do not specify explicitly.
+
+#### Type Param
+
+**TFormData**
+
+Library-managed. Do not specify explicitly.
+
+#### Type Param
+
+**TSubmitReturn**
+
+Library-managed. Do not specify explicitly.

--- a/docs/reference/type-aliases/FormOptionsLooseSchemaFn.md
+++ b/docs/reference/type-aliases/FormOptionsLooseSchemaFn.md
@@ -1,0 +1,82 @@
+---
+id: FormOptionsLooseSchemaFn
+title: FormOptionsLooseSchemaFn
+---
+
+# Type Alias: FormOptionsLooseSchemaFn
+
+```ts
+type FormOptionsLooseSchemaFn = <TFormValidators, TFormData, TSubmitReturn>(options) => FormOptions<InferUnion<TFormData, FormValidatorData<TFormValidators>>, TFormValidators, TSubmitReturn>;
+```
+
+Defined in: [utils.public.ts:150](https://github.com/TanStack/form/blob/main/packages/form-core/src/utils.public.ts#L150)
+
+Infers the form data shape from a Standard Schema validator while allowing
+editable defaults to contain `null` or `undefined` values.
+
+Use this when the schema represents the final valid shape but the UI needs
+intermediate empty states, such as an unselected date. Raw form state
+remains available as `value`; read each validator's parsed output from the
+corresponding `schemaOutputs` entry during submission.
+
+At runtime, this returns the original options object and does not run the
+schema.
+
+Include the schema in `validators` to provide the type inference and
+perform validation.
+
+## Type Parameters
+
+### TFormValidators
+
+`TFormValidators` *extends* [`FormValidators`](FormValidators.md)\<`any`\>
+
+Library-managed. Do not specify explicitly.
+
+### TFormData
+
+`TFormData` *extends* [`NullableSchemaData`](NullableSchemaData.md)\<`TFormValidators`\>
+
+Library-managed. Do not specify explicitly.
+
+### TSubmitReturn
+
+`TSubmitReturn`
+
+Library-managed. Do not specify explicitly.
+
+## Parameters
+
+### options
+
+[`FormOptions`](../interfaces/FormOptions.md)\<`TFormData`, `TFormValidators`, `TSubmitReturn`\>
+
+## Returns
+
+[`FormOptions`](../interfaces/FormOptions.md)\<[`InferUnion`](InferUnion.md)\<`TFormData`, [`FormValidatorData`](FormValidatorData.md)\<`TFormValidators`\>\>, `TFormValidators`, `TSubmitReturn`\>
+
+The original options object, normalized to `FormOptions` with
+nullable and undefined editable states merged into the schema's input
+shape.
+
+## Remarks
+
+**Important:** Although this returns the original object unchanged at
+runtime, its type is normalized to `FormOptions`. Optional properties such
+as `validators` therefore remain optional even when supplied. This
+tradeoff enables safer inference and reuse.
+
+## Example
+
+```ts
+const bookingOptions = formOptions.looseSchema({
+  defaultValues: { startDate: null },
+  validators: [
+    {
+      triggers: ['blur'],
+      run: z.object({ startDate: z.date() }),
+    },
+  ],
+  onSubmit: ({ schemaOutputs }) => saveBooking(schemaOutputs[0]),
+})
+```

--- a/docs/reference/type-aliases/FormOptionsStrictSchemaFn.md
+++ b/docs/reference/type-aliases/FormOptionsStrictSchemaFn.md
@@ -1,0 +1,80 @@
+---
+id: FormOptionsStrictSchemaFn
+title: FormOptionsStrictSchemaFn
+---
+
+# Type Alias: FormOptionsStrictSchemaFn
+
+```ts
+type FormOptionsStrictSchemaFn = <TFormValidators, TFormData, TSubmitReturn>(options) => FormOptions<FormValidatorData<TFormValidators>, TFormValidators, TSubmitReturn>;
+```
+
+Defined in: [utils.public.ts:93](https://github.com/TanStack/form/blob/main/packages/form-core/src/utils.public.ts#L93)
+
+Infers the form data type from a Standard Schema validator and requires
+`defaultValues` to match the schema input.
+
+Use this when the schema represents an input-to-output pipeline. Raw form
+state remains available as `value`; read each validator's parsed output
+from the corresponding `schemaOutputs` entry during submission.
+
+At runtime, this returns the original options object and does not run the
+schema.
+
+Include the schema in `validators` to provide the type inference and
+perform validation.
+
+## Type Parameters
+
+### TFormValidators
+
+`TFormValidators` *extends* [`FormValidators`](FormValidators.md)\<`any`\>
+
+Library-managed. Do not specify explicitly.
+
+### TFormData
+
+`TFormData` *extends* [`FormValidatorData`](FormValidatorData.md)\<`TFormValidators`\>
+
+Library-managed. Do not specify explicitly.
+
+### TSubmitReturn
+
+`TSubmitReturn`
+
+Library-managed. Do not specify explicitly.
+
+## Parameters
+
+### options
+
+[`FormOptions`](../interfaces/FormOptions.md)\<`TFormData`, `TFormValidators`, `TSubmitReturn`\>
+
+## Returns
+
+[`FormOptions`](../interfaces/FormOptions.md)\<[`FormValidatorData`](FormValidatorData.md)\<`TFormValidators`\>, `TFormValidators`, `TSubmitReturn`\>
+
+The original options object, normalized to `FormOptions` with the
+schema's input shape.
+
+## Remarks
+
+**Important:** Although this returns the original object unchanged at
+runtime, its type is normalized to `FormOptions`. Optional properties such
+as `validators` therefore remain optional even when supplied. This
+tradeoff enables safer inference and reuse.
+
+## Example
+
+```ts
+const profileOptions = formOptions.strictSchema({
+  defaultValues: { name: '' },
+  validators: [
+    {
+      triggers: ['change'],
+      run: z.object({ name: z.string().min(1) }),
+    },
+  ],
+  onSubmit: ({ schemaOutputs }) => saveProfile(schemaOutputs[0]),
+})
+```

--- a/docs/reference/variables/formOptions.md
+++ b/docs/reference/variables/formOptions.md
@@ -9,4 +9,43 @@ title: formOptions
 const formOptions: FormOptionsApi;
 ```
 
-Defined in: [utils.public.ts:89](https://github.com/TanStack/form/blob/main/packages/form-core/src/utils.public.ts#L89)
+Defined in: [utils.public.ts:323](https://github.com/TanStack/form/blob/main/packages/form-core/src/utils.public.ts#L323)
+
+Keeps form data, validator, and submission types inferred when options are
+declared separately from a framework's form creation API.
+
+The regular helper takes `defaultValues` at face value as the form data
+shape. For schema-driven inference, use `formOptions.strictSchema` when the
+schema defines an input-to-output boundary, or `formOptions.looseSchema` when
+the schema defines the shape but editable defaults need `null` or
+`undefined` values.
+
+At runtime, this is an identity helper: it returns the original options
+object and does not create a form or run validation.
+
+## Remarks
+
+**Important:** Although this returns the original object unchanged at
+runtime, its type is normalized to `FormOptions`. Optional properties such
+as `validators` therefore remain optional even when supplied. This tradeoff
+enables safer inference and reuse.
+
+## Example
+
+```ts
+const profileOptions = formOptions({
+  defaultValues: { name: '' },
+  validators: [
+    {
+      triggers: ['change'],
+      run: ({ value }) =>
+        value.name.length === 0 ? 'Name is required' : undefined,
+    },
+  ],
+})
+
+const form = useForm({
+  ...profileOptions,
+  onSubmit: ({ value }) => saveProfile(value),
+})
+```

--- a/packages/angular-form/src/inject-form.ts
+++ b/packages/angular-form/src/inject-form.ts
@@ -4,7 +4,36 @@ import { InternalFormApi } from '@tanstack/form-core/internals'
 import type { FormOptions, FormValidators } from '@tanstack/form-core'
 
 /**
- * Creates and mounts a v2 form in the current Angular injection context.
+ * Creates and mounts a form in the current Angular injection context.
+ *
+ * `defaultValues` establish the initial state and inferred form value type.
+ * Form state changes notify Angular change detection, including OnPush
+ * components, and the form is cleaned up when the injection context is
+ * destroyed.
+ *
+ * Call this in a component field initializer, constructor, provider factory,
+ * or another active injection context.
+ *
+ * @example
+ * ```ts
+ * @Component({
+ *   selector: 'app-profile-form',
+ *   template: `<form></form>`,
+ * })
+ * class ProfileFormComponent {
+ *   form = injectForm({
+ *     defaultValues: { name: '' },
+ *     onSubmit: ({ value }) => saveProfile(value),
+ *   })
+ * }
+ * ```
+ *
+ * @param options - The initial form options. `defaultValues` drive form value
+ * inference.
+ * @returns The mounted form API registered for injection-context cleanup.
+ * @typeParam TFormData - Library-managed. Do not specify explicitly.
+ * @typeParam TFormValidators - Library-managed. Do not specify explicitly.
+ * @typeParam TSubmitReturn - Library-managed. Do not specify explicitly.
  */
 export function injectForm<
   TFormData,

--- a/packages/form-core/src/utils.public.ts
+++ b/packages/form-core/src/utils.public.ts
@@ -50,7 +50,143 @@ export type FormValidatorData<TFormValidators extends FormValidators<any>> =
 export type NullableSchemaData<TFormValidators extends FormValidators<any>> =
   Editable<FormValidatorData<TFormValidators>>
 
+/**
+ * Infers the form data type from a Standard Schema validator and requires
+ * `defaultValues` to match the schema input.
+ *
+ * Use this when the schema represents an input-to-output pipeline. Raw form
+ * state remains available as `value`; read each validator's parsed output
+ * from the corresponding `schemaOutputs` entry during submission.
+ *
+ * At runtime, this returns the original options object and does not run the
+ * schema.
+ *
+ * Include the schema in `validators` to provide the type inference and
+ * perform validation.
+ *
+ * @remarks
+ * **Important:** Although this returns the original object unchanged at
+ * runtime, its type is normalized to `FormOptions`. Optional properties such
+ * as `validators` therefore remain optional even when supplied. This
+ * tradeoff enables safer inference and reuse.
+ *
+ * @example
+ * ```ts
+ * const profileOptions = formOptions.strictSchema({
+ *   defaultValues: { name: '' },
+ *   validators: [
+ *     {
+ *       triggers: ['change'],
+ *       run: z.object({ name: z.string().min(1) }),
+ *     },
+ *   ],
+ *   onSubmit: ({ schemaOutputs }) => saveProfile(schemaOutputs[0]),
+ * })
+ * ```
+ *
+ * @returns The original options object, normalized to `FormOptions` with the
+ * schema's input shape.
+ * @typeParam TFormValidators - Library-managed. Do not specify explicitly.
+ * @typeParam TFormData - Library-managed. Do not specify explicitly.
+ * @typeParam TSubmitReturn - Library-managed. Do not specify explicitly.
+ */
+export type FormOptionsStrictSchemaFn = <
+  const TFormValidators extends FormValidators<any>,
+  // Not quite sure why, but using FormValidatorData directly in the generic breaks things.
+  // Probably something recursive going on that resolves it to `never`?
+  TFormData extends FormValidatorData<TFormValidators>,
+  TSubmitReturn,
+>(
+  options: FormOptions<TFormData, TFormValidators, TSubmitReturn>,
+) => FormOptions<
+  FormValidatorData<TFormValidators>,
+  TFormValidators,
+  TSubmitReturn
+>
+
+/**
+ * Infers the form data shape from a Standard Schema validator while allowing
+ * editable defaults to contain `null` or `undefined` values.
+ *
+ * Use this when the schema represents the final valid shape but the UI needs
+ * intermediate empty states, such as an unselected date. Raw form state
+ * remains available as `value`; read each validator's parsed output from the
+ * corresponding `schemaOutputs` entry during submission.
+ *
+ * At runtime, this returns the original options object and does not run the
+ * schema.
+ *
+ * Include the schema in `validators` to provide the type inference and
+ * perform validation.
+ *
+ * @remarks
+ * **Important:** Although this returns the original object unchanged at
+ * runtime, its type is normalized to `FormOptions`. Optional properties such
+ * as `validators` therefore remain optional even when supplied. This
+ * tradeoff enables safer inference and reuse.
+ *
+ * @example
+ * ```ts
+ * const bookingOptions = formOptions.looseSchema({
+ *   defaultValues: { startDate: null },
+ *   validators: [
+ *     {
+ *       triggers: ['blur'],
+ *       run: z.object({ startDate: z.date() }),
+ *     },
+ *   ],
+ *   onSubmit: ({ schemaOutputs }) => saveBooking(schemaOutputs[0]),
+ * })
+ * ```
+ *
+ * @returns The original options object, normalized to `FormOptions` with
+ * nullable and undefined editable states merged into the schema's input
+ * shape.
+ * @typeParam TFormValidators - Library-managed. Do not specify explicitly.
+ * @typeParam TFormData - Library-managed. Do not specify explicitly.
+ * @typeParam TSubmitReturn - Library-managed. Do not specify explicitly.
+ *
+ */
+export type FormOptionsLooseSchemaFn = <
+  const TFormValidators extends FormValidators<any>,
+  const TFormData extends NullableSchemaData<TFormValidators>,
+  TSubmitReturn,
+>(
+  options: FormOptions<TFormData, TFormValidators, TSubmitReturn>,
+) => FormOptions<
+  InferUnion<TFormData, FormValidatorData<TFormValidators>>,
+  TFormValidators,
+  TSubmitReturn
+>
+
+/**
+ * The callable API exposed by `formOptions`, including its schema-driven
+ * inference modes.
+ *
+ * Use `formOptions` directly instead of naming this interface in application
+ * code.
+ */
 export interface FormOptionsApi {
+  /**
+   * Keeps types inferred from `defaultValues`, validators, and submission
+   * callbacks when form options are declared separately.
+   *
+   * `defaultValues` determine the form data shape in this mode. At runtime,
+   * this returns the original options object and does not create a form or run
+   * validation.
+   *
+   * @remarks
+   * **Important:** Although this returns the original object unchanged at
+   * runtime, its type is normalized to `FormOptions`. Optional properties such
+   * as `validators` therefore remain optional even when supplied. This
+   * tradeoff enables safer inference and reuse.
+   *
+   * @returns The original options object, normalized to `FormOptions` with its
+   * inferred form data, validator, and submission types.
+   * @typeParam TFormData - Library-managed. Do not specify explicitly.
+   * @typeParam TFormValidators - Library-managed. Do not specify explicitly.
+   * @typeParam TSubmitReturn - Library-managed. Do not specify explicitly.
+   */
   <
     TFormData,
     const TFormValidators extends FormValidators<TFormData>,
@@ -59,33 +195,131 @@ export interface FormOptionsApi {
     options: FormOptions<TFormData, TFormValidators, TSubmitReturn>,
   ): FormOptions<TFormData, TFormValidators, TSubmitReturn>
 
-  strictSchema: <
-    const TFormValidators extends FormValidators<any>,
-    // Not quite sure why, but using FormValidatorData directly in the generic breaks things.
-    // Probably something recursive going on that resolves it to `never`?
-    TFormData extends FormValidatorData<TFormValidators>,
-    TSubmitReturn,
-  >(
-    options: FormOptions<TFormData, TFormValidators, TSubmitReturn>,
-  ) => FormOptions<
-    FormValidatorData<TFormValidators>,
-    TFormValidators,
-    TSubmitReturn
-  >
+  /**
+   * Infers the form data type from a Standard Schema validator and requires
+   * `defaultValues` to match the schema input.
+   *
+   * Use this when the schema represents an input-to-output pipeline. Raw form
+   * state remains available as `value`; read each validator's parsed output
+   * from the corresponding `schemaOutputs` entry during submission.
+   *
+   * At runtime, this returns the original options object and does not run the
+   * schema.
+   *
+   * Include the schema in `validators` to provide the type inference and
+   * perform validation.
+   *
+   * @remarks
+   * **Important:** Although this returns the original object unchanged at
+   * runtime, its type is normalized to `FormOptions`. Optional properties such
+   * as `validators` therefore remain optional even when supplied. This
+   * tradeoff enables safer inference and reuse.
+   *
+   * @example
+   * ```ts
+   * const profileOptions = formOptions.strictSchema({
+   *   defaultValues: { name: '' },
+   *   validators: [
+   *     {
+   *       triggers: ['change'],
+   *       run: z.object({ name: z.string().min(1) }),
+   *     },
+   *   ],
+   *   onSubmit: ({ schemaOutputs }) => saveProfile(schemaOutputs[0]),
+   * })
+   * ```
+   *
+   * @returns The original options object, normalized to `FormOptions` with the
+   * schema's input shape.
+   * @typeParam TFormValidators - Library-managed. Do not specify explicitly.
+   * @typeParam TFormData - Library-managed. Do not specify explicitly.
+   * @typeParam TSubmitReturn - Library-managed. Do not specify explicitly.
+   */
+  strictSchema: FormOptionsStrictSchemaFn
 
-  looseSchema: <
-    const TFormValidators extends FormValidators<any>,
-    const TFormData extends NullableSchemaData<TFormValidators>,
-    TSubmitReturn,
-  >(
-    options: FormOptions<TFormData, TFormValidators, TSubmitReturn>,
-  ) => FormOptions<
-    InferUnion<TFormData, FormValidatorData<TFormValidators>>,
-    TFormValidators,
-    TSubmitReturn
-  >
+  /**
+   * Infers the form data shape from a Standard Schema validator while allowing
+   * editable defaults to contain `null` or `undefined` values.
+   *
+   * Use this when the schema represents the final valid shape but the UI needs
+   * intermediate empty states, such as an unselected date. Raw form state
+   * remains available as `value`; read each validator's parsed output from the
+   * corresponding `schemaOutputs` entry during submission.
+   *
+   * At runtime, this returns the original options object and does not run the
+   * schema.
+   *
+   * Include the schema in `validators` to provide the type inference and
+   * perform validation.
+   *
+   * @remarks
+   * **Important:** Although this returns the original object unchanged at
+   * runtime, its type is normalized to `FormOptions`. Optional properties such
+   * as `validators` therefore remain optional even when supplied. This
+   * tradeoff enables safer inference and reuse.
+   *
+   * @example
+   * ```ts
+   * const bookingOptions = formOptions.looseSchema({
+   *   defaultValues: { startDate: null },
+   *   validators: [
+   *     {
+   *       triggers: ['blur'],
+   *       run: z.object({ startDate: z.date() }),
+   *     },
+   *   ],
+   *   onSubmit: ({ schemaOutputs }) => saveBooking(schemaOutputs[0]),
+   * })
+   * ```
+   *
+   * @returns The original options object, normalized to `FormOptions` with
+   * nullable and undefined editable states merged into the schema's input
+   * shape.
+   * @typeParam TFormValidators - Library-managed. Do not specify explicitly.
+   * @typeParam TFormData - Library-managed. Do not specify explicitly.
+   * @typeParam TSubmitReturn - Library-managed. Do not specify explicitly.
+   */
+  looseSchema: FormOptionsLooseSchemaFn
 }
 
+/**
+ * Keeps form data, validator, and submission types inferred when options are
+ * declared separately from a framework's form creation API.
+ *
+ * The regular helper takes `defaultValues` at face value as the form data
+ * shape. For schema-driven inference, use `formOptions.strictSchema` when the
+ * schema defines an input-to-output boundary, or `formOptions.looseSchema` when
+ * the schema defines the shape but editable defaults need `null` or
+ * `undefined` values.
+ *
+ * At runtime, this is an identity helper: it returns the original options
+ * object and does not create a form or run validation.
+ *
+ * @remarks
+ * **Important:** Although this returns the original object unchanged at
+ * runtime, its type is normalized to `FormOptions`. Optional properties such
+ * as `validators` therefore remain optional even when supplied. This tradeoff
+ * enables safer inference and reuse.
+ *
+ * @example
+ * ```ts
+ * const profileOptions = formOptions({
+ *   defaultValues: { name: '' },
+ *   validators: [
+ *     {
+ *       triggers: ['change'],
+ *       run: ({ value }) =>
+ *         value.name.length === 0 ? 'Name is required' : undefined,
+ *     },
+ *   ],
+ * })
+ *
+ * const form = useForm({
+ *   ...profileOptions,
+ *   onSubmit: ({ value }) => saveProfile(value),
+ * })
+ * ```
+ */
 const formOptions = ((opts) => {
   return opts
 }) as FormOptionsApi

--- a/packages/lit-form/src/tanstack-form-controller.ts
+++ b/packages/lit-form/src/tanstack-form-controller.ts
@@ -146,7 +146,7 @@ export interface LitFieldMethods<
 }
 
 export interface LitSubscribeMethod<TState> {
-  subscribe<TSelected>(
+  subscribe<const TSelected>(
     selector: (state: TState) => TSelected,
     render: RenderCallback<NoInfer<TSelected>>,
     when?: (selected: NoInfer<TSelected>) => boolean,
@@ -303,7 +303,7 @@ export class TanStackFormController<
     )
   }
 
-  subscribe<TSelected>(
+  subscribe<const TSelected>(
     selector: (
       state: FormState<
         TFormData,

--- a/packages/lit-form/src/tanstack-form-controller.ts
+++ b/packages/lit-form/src/tanstack-form-controller.ts
@@ -174,6 +174,38 @@ export type LitFormGroupApi<
   > &
   LitSubscribeMethod<FormGroupState<TGroupValue, TGroupErrorTypes>>
 
+/**
+ * Owns a form for a Lit reactive-controller host and provides Lit-specific
+ * field, form-group, and subscription render helpers.
+ *
+ * `defaultValues` establish the initial state and inferred form value type.
+ * The form mounts when its host connects and is cleaned up when the host
+ * disconnects. Call `update(...)` to apply later options without replacing the
+ * form instance, and access the framework-agnostic form API through `api`.
+ *
+ * @example
+ * ```ts
+ * class ProfileForm extends LitElement {
+ *   private form = new TanStackFormController(this, {
+ *     defaultValues: { name: '' },
+ *     onSubmit: ({ value }) => saveProfile(value),
+ *   })
+ *
+ *   render() {
+ *     return html`<form
+ *       @submit=${(event: SubmitEvent) => {
+ *         event.preventDefault()
+ *         void this.form.api.handleSubmit()
+ *       }}
+ *     ></form>`
+ *   }
+ * }
+ * ```
+ *
+ * @typeParam TFormData - Library-managed. Do not specify explicitly.
+ * @typeParam TFormValidators - Library-managed. Do not specify explicitly.
+ * @typeParam TSubmitReturn - Library-managed. Do not specify explicitly.
+ */
 export class TanStackFormController<
   TFormData,
   const TFormValidators extends FormValidators<TFormData>,
@@ -201,6 +233,11 @@ export class TanStackFormController<
     return this.#form
   }
 
+  /**
+   * @param host - The Lit host that owns the controller and form lifecycle.
+   * @param options - The initial form options. `defaultValues` drive form value
+   * inference.
+   */
   constructor(
     host: ReactiveControllerHost,
     options: FormOptions<TFormData, TFormValidators, TSubmitReturn>,

--- a/packages/lit-form/tests/types.spec.ts
+++ b/packages/lit-form/tests/types.spec.ts
@@ -17,6 +17,14 @@ const options = formOptions({
 type Form = LitFormType<typeof options>
 
 function assertControllerTypes(form: Form) {
+  form.subscribe(
+    (state) => [state.values.name, state.submissionAttempts],
+    (selected) => {
+      expectTypeOf(selected).toEqualTypeOf<readonly [string, number]>()
+      return null
+    },
+  )
+
   form.field({ name: 'name' }, (field) => {
     expectTypeOf(field.value).toEqualTypeOf<string>()
     expectTypeOf(field.errors).toEqualTypeOf<Array<ValidationIssue>>()

--- a/packages/preact-form/src/FieldGroup/FieldGroupApi.public.ts
+++ b/packages/preact-form/src/FieldGroup/FieldGroupApi.public.ts
@@ -67,7 +67,7 @@ export type FieldGroupSubscribeProps<TSelected> = PreactFormSubscribeProps<
   TSelected
 >
 
-export type FieldGroupSubscribeComponent = <TSelected>(
+export type FieldGroupSubscribeComponent = <const TSelected>(
   props: FieldGroupSubscribeProps<TSelected>,
 ) => CrossVersionPreactNode
 

--- a/packages/preact-form/src/PreactForm/Components.public.ts
+++ b/packages/preact-form/src/PreactForm/Components.public.ts
@@ -106,7 +106,7 @@ export type PreactFormSubscribeProps<
 export type PreactFormSubscribeComponent<
   in out TFormData,
   in out TFormErrorTypes extends FormErrorTypes,
-> = <TSelected>(
+> = <const TSelected>(
   props: PreactFormSubscribeProps<TFormData, TFormErrorTypes, TSelected>,
 ) => CrossVersionPreactNode
 
@@ -212,7 +212,7 @@ export type PreactFormGroupSubscribeProps<
 export type PreactFormGroupSubscribeComponent<
   in out TGroupValue,
   in out TGroupErrorTypes extends FormErrorTypes,
-> = <TSelected>(
+> = <const TSelected>(
   props: PreactFormGroupSubscribeProps<
     TGroupValue,
     TGroupErrorTypes,

--- a/packages/preact-form/src/PreactForm/useForm.public.ts
+++ b/packages/preact-form/src/PreactForm/useForm.public.ts
@@ -28,6 +28,38 @@ function useFormHook(options: FormOptions<any, any, any>) {
   return form
 }
 
+/**
+ * Creates a Preact form whose instance and lifecycle are owned by the current
+ * component.
+ *
+ * `defaultValues` establish the initial state and inferred form value type.
+ * Later renders apply changed options to the same form instance, and unmounting
+ * the component cleans it up.
+ *
+ * Call this hook at the top level of a Preact component or custom hook.
+ *
+ * @example
+ * ```tsx
+ * function ProfileForm() {
+ *   const form = useForm({
+ *     defaultValues: { name: '' },
+ *     onSubmit: ({ value }) => saveProfile(value),
+ *   })
+ *
+ *   return (
+ *     <form
+ *       onSubmit={(event) => {
+ *         event.preventDefault()
+ *         void form.handleSubmit()
+ *       }}
+ *     />
+ *   )
+ * }
+ * ```
+ *
+ * @returns The Preact form API with typed field, subscription, and form-group
+ * components attached.
+ */
 const useForm =
   useFormHook as never as UseFormHook<DefaultPreactFormComponentMap>
 

--- a/packages/preact-form/tests/FormGroup.test-d.tsx
+++ b/packages/preact-form/tests/FormGroup.test-d.tsx
@@ -399,9 +399,27 @@ function RootFieldTypes() {
   )
 }
 
+function RootSubscribeTypes() {
+  const form = useForm({
+    defaultValues: { name: '' },
+  })
+
+  return (
+    <form.Subscribe
+      selector={(state) => [state.values.name, state.submissionAttempts]}
+    >
+      {(selected) => {
+        expectTypeOf(selected).toEqualTypeOf<readonly [string, number]>()
+        return null
+      }}
+    </form.Subscribe>
+  )
+}
+
 void FormGroupTypes
 void FormGroupSubmitTypes
 void FormGroupSubscribeTypes
 void FormGroupSubscribeWithoutGroupErrorsTypes
 void FormGroupWithoutValidatorsTypes
 void RootFieldTypes
+void RootSubscribeTypes

--- a/packages/react-form/src/FieldGroup/FieldGroupApi.public.ts
+++ b/packages/react-form/src/FieldGroup/FieldGroupApi.public.ts
@@ -167,7 +167,7 @@ export type FieldGroupSubscribeProps<TSelected> = ReactFormSubscribeProps<
  * </fields.Subscribe>
  * ```
  */
-export type FieldGroupSubscribeComponent = <TSelected>(
+export type FieldGroupSubscribeComponent = <const TSelected>(
   props: FieldGroupSubscribeProps<TSelected>,
 ) => ReactNode
 

--- a/packages/react-form/src/ReactForm/Components.public.ts
+++ b/packages/react-form/src/ReactForm/Components.public.ts
@@ -110,7 +110,7 @@ export type ReactFormSubscribeProps<
 export type ReactFormSubscribeComponent<
   in out TFormData,
   in out TFormErrorTypes extends FormErrorTypes,
-> = <TSelected>(
+> = <const TSelected>(
   props: ReactFormSubscribeProps<TFormData, TFormErrorTypes, TSelected>,
 ) => ReactNode
 
@@ -216,7 +216,7 @@ export type ReactFormGroupSubscribeProps<
 export type ReactFormGroupSubscribeComponent<
   in out TGroupValue,
   in out TGroupErrorTypes extends FormErrorTypes,
-> = <TSelected>(
+> = <const TSelected>(
   props: ReactFormGroupSubscribeProps<TGroupValue, TGroupErrorTypes, TSelected>,
 ) => ReactNode
 

--- a/packages/react-form/src/ReactForm/useForm.public.ts
+++ b/packages/react-form/src/ReactForm/useForm.public.ts
@@ -27,6 +27,38 @@ function useFormHook(options: FormOptions<any, any, any>) {
   return form
 }
 
+/**
+ * Creates a React form whose instance and lifecycle are owned by the current
+ * component.
+ *
+ * `defaultValues` establish the initial state and inferred form value type.
+ * Later renders apply changed options to the same form instance, and unmounting
+ * the component cleans it up.
+ *
+ * Call this hook at the top level of a React component or custom hook.
+ *
+ * @example
+ * ```tsx
+ * function ProfileForm() {
+ *   const form = useForm({
+ *     defaultValues: { name: '' },
+ *     onSubmit: ({ value }) => saveProfile(value),
+ *   })
+ *
+ *   return (
+ *     <form
+ *       onSubmit={(event) => {
+ *         event.preventDefault()
+ *         void form.handleSubmit()
+ *       }}
+ *     />
+ *   )
+ * }
+ * ```
+ *
+ * @returns The React form API with typed field, subscription, and form-group
+ * components attached.
+ */
 const useForm =
   useFormHook as never as UseFormHook<DefaultReactFormComponentMap>
 

--- a/packages/react-form/tests/FormGroup.test-d.tsx
+++ b/packages/react-form/tests/FormGroup.test-d.tsx
@@ -399,9 +399,27 @@ function RootFieldTypes() {
   )
 }
 
+function RootSubscribeTypes() {
+  const form = useForm({
+    defaultValues: { name: '' },
+  })
+
+  return (
+    <form.Subscribe
+      selector={(state) => [state.values.name, state.submissionAttempts]}
+    >
+      {(selected) => {
+        expectTypeOf(selected).toEqualTypeOf<readonly [string, number]>()
+        return null
+      }}
+    </form.Subscribe>
+  )
+}
+
 void FormGroupTypes
 void FormGroupSubmitTypes
 void FormGroupSubscribeTypes
 void FormGroupSubscribeWithoutGroupErrorsTypes
 void FormGroupWithoutValidatorsTypes
 void RootFieldTypes
+void RootSubscribeTypes

--- a/packages/solid-form/src/Components.public.ts
+++ b/packages/solid-form/src/Components.public.ts
@@ -86,7 +86,7 @@ export type SolidFormSubscribeProps<
 export type SolidFormSubscribeComponent<
   TFormData,
   TFormErrorTypes extends FormErrorTypes,
-> = <TSelected>(
+> = <const TSelected>(
   props: SolidFormSubscribeProps<TFormData, TFormErrorTypes, TSelected>,
 ) => JSX.Element
 
@@ -205,7 +205,7 @@ export type SolidFormGroupSubscribeProps<
 export type SolidFormGroupSubscribeComponent<
   TGroupValue,
   TGroupErrorTypes extends FormErrorTypes,
-> = <TSelected>(
+> = <const TSelected>(
   props: SolidFormGroupSubscribeProps<TGroupValue, TGroupErrorTypes, TSelected>,
 ) => JSX.Element
 

--- a/packages/solid-form/src/FieldGroup/FieldGroupApi.public.ts
+++ b/packages/solid-form/src/FieldGroup/FieldGroupApi.public.ts
@@ -66,7 +66,7 @@ export type FieldGroupSubscribeProps<TSelected> = SolidFormSubscribeProps<
   TSelected
 >
 
-export type FieldGroupSubscribeComponent = <TSelected>(
+export type FieldGroupSubscribeComponent = <const TSelected>(
   props: FieldGroupSubscribeProps<TSelected>,
 ) => JSX.Element
 

--- a/packages/solid-form/src/createForm.public.ts
+++ b/packages/solid-form/src/createForm.public.ts
@@ -24,4 +24,35 @@ function createFormHook(options: Accessor<FormOptions<any, any, any>>) {
   return createInternalForm(options, initializeForm)
 }
 
+/**
+ * Creates a Solid form whose instance and lifecycle are owned by the current
+ * reactive owner.
+ *
+ * Pass an options accessor. `defaultValues` establish the initial state and
+ * inferred form value type, while signals read by the accessor update the same
+ * form instance when they change. The form is cleaned up when its owner is
+ * disposed.
+ *
+ * @example
+ * ```tsx
+ * function ProfileForm() {
+ *   const form = createForm(() => ({
+ *     defaultValues: { name: '' },
+ *     onSubmit: ({ value }) => saveProfile(value),
+ *   }))
+ *
+ *   return (
+ *     <form
+ *       onSubmit={(event) => {
+ *         event.preventDefault()
+ *         void form.handleSubmit()
+ *       }}
+ *     />
+ *   )
+ * }
+ * ```
+ *
+ * @returns The Solid form API with typed field, subscription, and form-group
+ * components attached.
+ */
 export const createForm = createFormHook as never as CreateFormHook

--- a/packages/solid-form/tests/adapter.test-d.tsx
+++ b/packages/solid-form/tests/adapter.test-d.tsx
@@ -9,6 +9,23 @@ import {
 import type { Accessor } from 'solid-js'
 import type { FieldWithValue, SolidFormType, ValidationIssue } from '../src'
 
+function SubscribeTypes() {
+  const form = createForm(() => ({
+    defaultValues: { name: '' },
+  }))
+
+  return (
+    <form.Subscribe
+      selector={(state) => [state.values.name, state.submissionAttempts]}
+    >
+      {(selected) => {
+        expectTypeOf(selected()).toEqualTypeOf<readonly [string, number]>()
+        return null
+      }}
+    </form.Subscribe>
+  )
+}
+
 function FormAndGroupTypes() {
   const form = createForm(() => ({
     defaultValues: {
@@ -199,6 +216,7 @@ function AppFields(props: { fields: typeof appFieldGroup.fields }) {
 const BoundAppFields = appFieldGroup.bindComponent(AppFields, 'fields')
 
 void FormAndGroupTypes
+void SubscribeTypes
 void SharedFormChild
 void AppFormTypes
 void FieldGroupBindingsTypes

--- a/packages/svelte-form/src/Components.public.ts
+++ b/packages/svelte-form/src/Components.public.ts
@@ -89,7 +89,7 @@ export type SvelteFormSubscribeProps<
 export type SvelteFormSubscribeComponent<
   TFormData,
   TFormErrorTypes extends FormErrorTypes,
-> = (new <TSelected>(
+> = (new <const TSelected>(
   options: ComponentConstructorOptions<
     SvelteFormSubscribeProps<TFormData, TFormErrorTypes, TSelected>
   >,
@@ -192,7 +192,7 @@ export type SvelteFormArrayFieldComponent<
 export type SvelteFormGroupSubscribeComponent<
   TGroupValue,
   TGroupErrorTypes extends FormErrorTypes,
-> = (new <TSelected>(
+> = (new <const TSelected>(
   options: ComponentConstructorOptions<
     SvelteSubscribeProps<
       FormGroupState<TGroupValue, TGroupErrorTypes>,

--- a/packages/svelte-form/src/FieldGroup/FieldGroupApi.public.ts
+++ b/packages/svelte-form/src/FieldGroup/FieldGroupApi.public.ts
@@ -71,7 +71,7 @@ export type FieldGroupArrayFieldComponent<
   Component<any> &
   WithoutFunction<Component>
 
-export type FieldGroupSubscribeComponent = (new <TSelected>(
+export type FieldGroupSubscribeComponent = (new <const TSelected>(
   options: ComponentConstructorOptions<
     SvelteFormSubscribeProps<unknown, FormErrorTypes, TSelected>
   >,

--- a/packages/svelte-form/src/createForm.public.ts
+++ b/packages/svelte-form/src/createForm.public.ts
@@ -23,4 +23,26 @@ function createFormImpl(options: () => FormOptions<any, any, any>) {
   return createInternalForm(options, initializeForm)
 }
 
+/**
+ * Creates a Svelte form whose instance and lifecycle are owned by the current
+ * component.
+ *
+ * Pass an options function. `defaultValues` establish the initial state and
+ * inferred form value type, while reactive values read by the function update
+ * the same form instance when they change.
+ *
+ * Call this during component initialization. The form mounts with the
+ * component and is cleaned up when the component unmounts.
+ *
+ * @example
+ * ```ts
+ * const form = createForm(() => ({
+ *   defaultValues: { name: '' },
+ *   onSubmit: ({ value }) => saveProfile(value),
+ * }))
+ * ```
+ *
+ * @returns The Svelte form API with typed field, subscription, and form-group
+ * components attached.
+ */
 export const createForm = createFormImpl as never as CreateForm

--- a/packages/svelte-form/tests/adapter/BaseForm.svelte
+++ b/packages/svelte-form/tests/adapter/BaseForm.svelte
@@ -64,11 +64,14 @@
   Show
 </button>
 
+{#snippet expectTuple(_value: readonly [boolean, number])}{/snippet}
+
 <form.Subscribe
-  selector={(state) => state.values.visible}
-  when={(visible) => visible}
+  selector={(state) => [state.values.visible, state.submissionAttempts]}
+  when={([visible]) => visible}
 >
-  {#snippet children()}
+  {#snippet children(selected)}
+    {@render expectTuple(selected)}
     <span data-testid="visible">Visible</span>
   {/snippet}
 </form.Subscribe>

--- a/packages/vue-form/src/FieldGroup/FieldGroupApi.public.ts
+++ b/packages/vue-form/src/FieldGroup/FieldGroupApi.public.ts
@@ -123,7 +123,7 @@ export type FieldGroupSubscribeProps<TSelected> = VueFormSubscribeProps<
   TSelected
 >
 
-export type FieldGroupSubscribeComponent = new <TSelected>(
+export type FieldGroupSubscribeComponent = new <const TSelected>(
   props: FieldGroupSubscribeProps<TSelected> & PublicProps,
 ) => VueComponentInstance<
   FieldGroupSubscribeProps<TSelected>,

--- a/packages/vue-form/src/VueForm/Components.public.ts
+++ b/packages/vue-form/src/VueForm/Components.public.ts
@@ -86,7 +86,7 @@ export type VueFormSubscribeProps<
 export type VueFormSubscribeComponent<
   in out TFormData,
   in out TFormErrorTypes extends FormErrorTypes,
-> = new <TSelected>(
+> = new <const TSelected>(
   props: VueFormSubscribeProps<TFormData, TFormErrorTypes, TSelected> &
     PublicProps,
 ) => VueComponentInstance<
@@ -224,7 +224,7 @@ export type VueFormGroupSubscribeProps<
 export type VueFormGroupSubscribeComponent<
   in out TGroupValue,
   in out TGroupErrorTypes extends FormErrorTypes,
-> = new <TSelected>(
+> = new <const TSelected>(
   props: VueFormGroupSubscribeProps<TGroupValue, TGroupErrorTypes, TSelected> &
     PublicProps,
 ) => VueComponentInstance<

--- a/packages/vue-form/src/VueForm/useForm.public.ts
+++ b/packages/vue-form/src/VueForm/useForm.public.ts
@@ -26,5 +26,27 @@ function useFormHook(options: FormOptions<any, any, any>) {
   return useInternalForm(options, initializeForm)
 }
 
+/**
+ * Creates a Vue form whose instance and lifecycle are owned by the current
+ * component.
+ *
+ * `defaultValues` establish the initial state and inferred form value type. To
+ * update the existing form after creation, pass a reactive options object;
+ * tracked changes are applied without replacing the form instance.
+ *
+ * Call this during the component's setup phase. The form mounts with the
+ * component and is cleaned up when the component unmounts.
+ *
+ * @example
+ * ```ts
+ * const form = useForm({
+ *   defaultValues: { name: '' },
+ *   onSubmit: ({ value }) => saveProfile(value),
+ * })
+ * ```
+ *
+ * @returns The Vue form API with typed field, subscription, and form-group
+ * components attached.
+ */
 export const useForm =
   useFormHook as never as UseFormHook<DefaultVueFormComponentMap>

--- a/packages/vue-form/tests/type-inference.vue
+++ b/packages/vue-form/tests/type-inference.vue
@@ -16,6 +16,13 @@ const form = useForm({
   },
 })
 
+const TupleConsumer = defineComponent<{
+  value: readonly [string, number]
+}>({
+  props: ['value'],
+  setup: () => () => null,
+})
+
 const TextField = defineComponent<{
   field: FieldWithValue<string>
   label: string
@@ -61,6 +68,13 @@ const Reusable = reusableFieldGroup.bindComponent(ReusableFields, 'fields')
 </script>
 
 <template>
+  <form.Subscribe
+    :selector="(state) => [state.values.name, state.submissionAttempts]"
+    v-slot="selected"
+  >
+    <TupleConsumer :value="selected" />
+  </form.Subscribe>
+
   <form.Field name="name" v-slot="{ field }">
     {{ field.value.toUpperCase() }}
     {{ field.meta.isTouched }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Subscription selectors across supported frameworks now preserve readonly tuple types automatically, without requiring `as const`.
  * Added clearer schema-based form option typing for improved form configuration inference.

* **Documentation**
  * Expanded form creation guidance and API documentation across Angular, React, Preact, Vue, Solid, Lit, and Svelte.

* **Tests**
  * Added type coverage validating tuple inference for form subscriptions across supported frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->