### PR TITLE
fix(form-core): ignore aborted async form-level validation results

### DIFF
--- a/.changeset/quiet-forms-ignore-stale.md
+++ b/.changeset/quiet-forms-ignore-stale.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/form-core": patch
+---
+
+Ignore aborted async form-level validation results so a slower previous run cannot overwrite newer form state.

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -2232,6 +2232,7 @@ export class FormApi<
           } catch (e: unknown) {
             rawError = e as ValidationError
           }
+          if (controller.signal.aborted) return resolve(undefined)
           const { formError, fieldErrors: fieldErrorsFromNormalizeError } =
             normalizeError<TFormData>(rawError)
 

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -1420,6 +1420,44 @@ describe('form api', () => {
     })
   })
 
+  it('should ignore aborted async form-level validation results', async () => {
+    vi.useFakeTimers()
+
+    const form = new FormApi({
+      defaultValues: {
+        name: 'valid',
+      },
+      validators: {
+        onChangeAsyncDebounceMs: 0,
+        onChangeAsync: async ({ value }) => {
+          if (value.name === 'slow-invalid') {
+            await sleep(2000)
+            return 'Stale validation result'
+          }
+          await sleep(50)
+          return undefined
+        },
+      },
+    })
+    const field = new FieldApi({
+      form,
+      name: 'name',
+    })
+    form.mount()
+    field.mount()
+
+    field.setValue('slow-invalid')
+    await vi.advanceTimersByTimeAsync(0)
+    field.setValue('valid')
+    await vi.advanceTimersByTimeAsync(50)
+    expect(form.state.errors).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(form.state.errors).toEqual([])
+    expect(form.state.errorMap.onChange).toBeUndefined()
+    vi.useRealTimers()
+  })
+
   it('should run validation onBlur', () => {
     const form = new FormApi({
       defaultValues: {


### PR DESCRIPTION
## Changes

Fixes #2346

`FieldApi` and `FormGroupApi` already drop in-flight async validation after a newer run aborts the previous `AbortController`. `FormApi` only checked the signal before starting the validator, not after it resolved.

That matters for form-level `onChangeAsync` validators that cannot observe the signal (including Standard Schema / Zod async refinements). A slower previous run can still apply its result and restore an error after a newer validation has already accepted the current value.

The check is the same one those sibling APIs already use: if `controller.signal.aborted` after the validator settles, resolve without writing `errorMap`.

Reproduced with a form-level async validator: `slow-invalid` sleeps 2000ms and returns an error, then the value becomes `valid` (50ms). After the slow run finishes, the form was left with `Stale validation result`. With this change it stays valid.

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

Local verification: `vitest` for `packages/form-core/tests/FormApi.spec.ts` (150/150 passing), including a new regression that fails on `main` and passes with this change.

## Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
