### PR TITLE
[v2] Perf: Use one atom subscription per Field

### DIFF
--- a/packages/react-form/src/ReactForm/fieldSubscriptions.lib.ts
+++ b/packages/react-form/src/ReactForm/fieldSubscriptions.lib.ts
@@ -5,7 +5,7 @@ import type { AnyInternalFieldApi } from '@tanstack/form-core/internals'
 export function useValueFieldSubscription(
   fieldApi: AnyInternalFieldApi,
 ): AnyInternalFieldApi {
-  const state = useSelector(fieldApi.atom)
+  const state = useSelector(fieldApi.atom, state => state)
 
   return useMemo(() => {
     void state

--- a/packages/react-form/src/ReactForm/fieldSubscriptions.lib.ts
+++ b/packages/react-form/src/ReactForm/fieldSubscriptions.lib.ts
@@ -5,7 +5,7 @@ import type { AnyInternalFieldApi } from '@tanstack/form-core/internals'
 export function useValueFieldSubscription(
   fieldApi: AnyInternalFieldApi,
 ): AnyInternalFieldApi {
-  const state = useSelector(fieldApi.atom, state => state)
+  const state = useSelector(fieldApi.atom, (state) => state)
 
   return useMemo(() => {
     void state

--- a/packages/react-form/src/ReactForm/fieldSubscriptions.lib.ts
+++ b/packages/react-form/src/ReactForm/fieldSubscriptions.lib.ts
@@ -5,14 +5,12 @@ import type { AnyInternalFieldApi } from '@tanstack/form-core/internals'
 export function useValueFieldSubscription(
   fieldApi: AnyInternalFieldApi,
 ): AnyInternalFieldApi {
-  const value = useSelector(fieldApi.atom, (state) => state.value)
-  const meta = useSelector(fieldApi.atom, (state) => state.meta)
+  const state = useSelector(fieldApi.atom)
 
   return useMemo(() => {
-    void meta
-    void value
+    void state
     return Object.create(fieldApi)
-  }, [fieldApi, meta, value])
+  }, [fieldApi, state])
 }
 
 export function useArrayFieldSubscription(

--- a/packages/react-form/tests/FormGroup.spec.tsx
+++ b/packages/react-form/tests/FormGroup.spec.tsx
@@ -118,7 +118,7 @@ describe('FormGroup', () => {
     expect(getByTestId('app-field-name')).toHaveTextContent('guestDetails.name')
   })
 
-  it('uses the AppForm field provider subscription for field context', async () => {
+  it('uses one AppForm field provider subscription for field context', async () => {
     const subscribe = vi.fn()
     const unsubscribe = vi.fn()
     const instrumentedAtoms = new WeakSet<object>()
@@ -169,7 +169,7 @@ describe('FormGroup', () => {
 
     await vi.waitFor(() => {
       expect(subscribe.mock.calls.length - unsubscribe.mock.calls.length).toBe(
-        2,
+        1,
       )
     })
 


### PR DESCRIPTION
Each React `Field` subscribed to the same atom twice, once for value and once for meta. The field atom already preserves state identity when neither changes, so use one whole-state subscription instead.

This cuts active subscriptions from two to one per field with the same render behavior. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form field subscription handling so updates are tracked consistently.
  * Reduced redundant subscriptions while preserving existing field API behavior.
  * Improved subscription efficiency for more predictable form updates.

* **Tests**
  * Updated coverage to verify that each field uses a single active subscription.
  * Clarified subscription behavior in field-context tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->