### PR TITLE
fix(form-core): shift the array's own index when shifting nested array meta

### DIFF
--- a/.changeset/fix-nested-array-meta-shift.md
+++ b/.changeset/fix-nested-array-meta-shift.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/form-core': patch
+---
+
+Shift the correct index when an array field is nested inside another array field.

--- a/packages/form-core/src/metaHelper.ts
+++ b/packages/form-core/src/metaHelper.ts
@@ -97,7 +97,7 @@ export function metaHelper<
       new Map<DeepKeys<TFormData>, AnyFieldLikeMeta | undefined>(),
     )
 
-    shiftMeta(affectedFields, fromIndex < toIndex ? 'up' : 'down')
+    shiftMeta(field, affectedFields, fromIndex < toIndex ? 'up' : 'down')
 
     // Reapply the stored field meta at the destination index
     Object.keys(formApi.fieldInfo)
@@ -122,7 +122,7 @@ export function metaHelper<
     bumpArrayVersion(field)
     const affectedFields = getAffectedFields(field, index, 'remove')
 
-    shiftMeta(affectedFields, 'up')
+    shiftMeta(field, affectedFields, 'up')
   }
 
   /**
@@ -165,7 +165,7 @@ export function metaHelper<
     bumpArrayVersion(field)
     const affectedFields = getAffectedFields(field, insertIndex, 'insert')
 
-    shiftMeta(affectedFields, 'down')
+    shiftMeta(field, affectedFields, 'down')
 
     affectedFields.forEach((fieldKey) => {
       if (fieldKey.toString().startsWith(getFieldPath(field, insertIndex))) {
@@ -221,22 +221,34 @@ export function metaHelper<
   }
 
   function updateIndex(
+    field: DeepKeys<TFormData>,
     fieldKey: string,
     direction: 'up' | 'down',
   ): DeepKeys<TFormData> {
-    return fieldKey.replace(/\[(\d+)\]/, (_, num) => {
-      const currIndex = parseInt(num, 10)
-      const newIndex =
-        direction === 'up' ? currIndex + 1 : Math.max(0, currIndex - 1)
-      return `[${newIndex}]`
-    }) as DeepKeys<TFormData>
+    // Only the index belonging to `field` may move; a nested array field such
+    // as `teams[0].members` carries indices of its own that must stay put.
+    const prefix = `${field}[`
+    const closing = fieldKey.indexOf(']', prefix.length)
+    if (!fieldKey.startsWith(prefix) || closing === -1) {
+      return fieldKey as DeepKeys<TFormData>
+    }
+
+    const currIndex = parseInt(fieldKey.slice(prefix.length, closing), 10)
+    const newIndex =
+      direction === 'up' ? currIndex + 1 : Math.max(0, currIndex - 1)
+
+    return `${prefix}${newIndex}${fieldKey.slice(closing)}` as DeepKeys<TFormData>
   }
 
-  function shiftMeta(fields: DeepKeys<TFormData>[], direction: 'up' | 'down') {
+  function shiftMeta(
+    field: DeepKeys<TFormData>,
+    fields: DeepKeys<TFormData>[],
+    direction: 'up' | 'down',
+  ) {
     const sortedFields = direction === 'up' ? fields : [...fields].reverse()
 
     sortedFields.forEach((fieldKey) => {
-      const nextFieldKey = updateIndex(fieldKey.toString(), direction)
+      const nextFieldKey = updateIndex(field, fieldKey.toString(), direction)
       const nextFieldMeta = formApi.getFieldMeta(nextFieldKey)
       if (nextFieldMeta) {
         formApi.setFieldMeta(fieldKey, nextFieldMeta)

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -566,6 +566,37 @@ describe('form api', () => {
     expect(field1.state.meta.isBlurred).toBe(true)
   })
 
+  it('should shift meta of an array nested inside another array when inserting values', async () => {
+    const form = new FormApi({
+      defaultValues: {
+        teams: [{ members: ['a', 'b'] }],
+      },
+    })
+    form.mount()
+    new FieldApi({ form, name: 'teams' }).mount()
+    new FieldApi({ form, name: 'teams[0].members' }).mount()
+    const member0 = new FieldApi({ form, name: 'teams[0].members[0]' })
+    member0.mount()
+    const member1 = new FieldApi({ form, name: 'teams[0].members[1]' })
+    member1.mount()
+
+    member0.handleBlur()
+
+    expect(member0.state.meta.isBlurred).toBe(true)
+    expect(member1.state.meta.isBlurred).toBe(false)
+
+    await form.insertFieldValue('teams[0].members', 0, 'x')
+
+    expect(form.getFieldValue('teams[0].members')).toStrictEqual([
+      'x',
+      'a',
+      'b',
+    ])
+    // member0's meta moved onto member1 now
+    expect(member0.state.meta.isBlurred).toBe(false)
+    expect(member1.state.meta.isBlurred).toBe(true)
+  })
+
   it("should validate all shifted fields when inserting an array field's value", async () => {
     const form = new FormApi({
       defaultValues: {
@@ -732,6 +763,36 @@ describe('form api', () => {
     // field2's meta moved on field1 now
     expect(field1Name.state.meta.isBlurred).toBe(true)
     expect(field1Surname.state.meta.isBlurred).toBe(true)
+  })
+
+  it('should shift meta of an array nested inside another array when removing values', async () => {
+    const form = new FormApi({
+      defaultValues: {
+        teams: [{ members: ['a', 'b', 'c'] }],
+      },
+    })
+    form.mount()
+    new FieldApi({ form, name: 'teams' }).mount()
+    new FieldApi({ form, name: 'teams[0].members' }).mount()
+    const member0 = new FieldApi({ form, name: 'teams[0].members[0]' })
+    member0.mount()
+    const member1 = new FieldApi({ form, name: 'teams[0].members[1]' })
+    member1.mount()
+    const member2 = new FieldApi({ form, name: 'teams[0].members[2]' })
+    member2.mount()
+
+    member2.handleBlur()
+
+    expect(member0.state.meta.isBlurred).toBe(false)
+    expect(member1.state.meta.isBlurred).toBe(false)
+    expect(member2.state.meta.isBlurred).toBe(true)
+
+    await form.removeFieldValue('teams[0].members', 0)
+
+    expect(form.getFieldValue('teams[0].members')).toStrictEqual(['b', 'c'])
+    // member2's meta moved onto member1 now
+    expect(member0.state.meta.isBlurred).toBe(false)
+    expect(member1.state.meta.isBlurred).toBe(true)
   })
 
   it("should swap an array field's value", () => {


### PR DESCRIPTION
## Changes

Inserting into or removing from an array nested inside another array wipes the following rows' field meta instead of shifting it. A flat array behaves correctly, so the two disagree.

`updateIndex` (`metaHelper.ts:227`) rewrites the first bracketed index it finds: `fieldKey.replace(/\[(\d+)\]/, ...)`. For `users[1].name` that is the right one. For `teams[0].members[1]` it rewrites `teams`'s index, producing `teams[1].members[1]` - a key that does not exist - so the read returns `undefined` and the shifted row is reset to default meta. Touched, blurred, dirty and errors are all lost.

The fix anchors the rewrite on the array being mutated, so only the index directly after `${field}[` moves. `handleArraySwap` already does exactly this via `getFieldPath(field, index)` (`metaHelper.ts:147`), so this brings the other three helpers into line with it rather than introducing a new approach.

It reaches users through `removeFieldValue`, `insertFieldValue` and `moveFieldValues`; `getAffectedFields` narrows it to array paths that themselves contain an index, which is why only the nested case is affected.

Targeting `main` deliberately: on `alpha` the array subsystem was rewritten to a trie and `updateIndex` no longer exists, so this is v1-only.

Two regression tests next to the existing flat-array meta-shift tests. `form-core` is 507 passing with no type errors, eslint and prettier clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed form metadata shifting for nested array fields.
  - Inserting, removing, or moving items in nested arrays now preserves metadata on the correct fields.
  - Corrected related stored values when nested array entries change.

- **Tests**
  - Added coverage for nested-array insert and remove scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->