### PR TITLE
fix(form-core): clear errorSourceMap.onMount alongside errorMap.onMount

### DIFF
--- a/.changeset/olive-forms-clear.md
+++ b/.changeset/olive-forms-clear.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/form-core': patch
+---
+
+Clear a field's `errorSourceMap.onMount` alongside `errorMap.onMount` when its value is set.

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -2668,6 +2668,11 @@ export class FormApi<
             ...prev?.errorMap,
             onMount: undefined,
           },
+          errorSourceMap: {
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+            ...prev?.errorSourceMap,
+            onMount: undefined,
+          },
         }))
       }
 

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -3233,6 +3233,70 @@ describe('form api', () => {
     expect(firstNameField.state.meta.errors).toEqual(['first name is required'])
   })
 
+  it("clears the onMount error source when a field's value is set", () => {
+    const form = new FormApi({
+      defaultValues: {
+        firstName: '',
+      },
+    })
+
+    form.mount()
+
+    const firstNameField = new FieldApi({
+      form,
+      name: 'firstName',
+      validators: {
+        onMount: () => 'first name is required',
+      },
+    })
+
+    firstNameField.mount()
+
+    expect(firstNameField.state.meta.errorMap.onMount).toBe(
+      'first name is required',
+    )
+    expect(firstNameField.state.meta.errorSourceMap.onMount).toBe('field')
+
+    form.setFieldValue('firstName', 'firstName')
+
+    expect(firstNameField.state.meta.errorMap.onMount).toBeUndefined()
+    expect(firstNameField.state.meta.errorSourceMap.onMount).toBeUndefined()
+  })
+
+  it("clears the form-sourced onMount error source when a field's value is set", () => {
+    const form = new FormApi({
+      defaultValues: {
+        firstName: '',
+      },
+      validators: {
+        onMount: () => ({
+          fields: {
+            firstName: 'first name is required',
+          },
+        }),
+      },
+    })
+
+    form.mount()
+
+    const firstNameField = new FieldApi({
+      form,
+      name: 'firstName',
+    })
+
+    firstNameField.mount()
+
+    expect(firstNameField.state.meta.errorMap.onMount).toBe(
+      'first name is required',
+    )
+    expect(firstNameField.state.meta.errorSourceMap.onMount).toBe('form')
+
+    form.setFieldValue('firstName', 'firstName')
+
+    expect(firstNameField.state.meta.errorMap.onMount).toBeUndefined()
+    expect(firstNameField.state.meta.errorSourceMap.onMount).toBeUndefined()
+  })
+
   it('clears errors on all fields affected by form validation when condition resolves', () => {
     const form = new FormApi({
       defaultValues: {


### PR DESCRIPTION
## 🎯 Changes

Fixes #2294.

`FormApi.setFieldValue` clears `errorMap.onMount` on the field's meta but leaves `errorSourceMap.onMount` untouched, so `field.state.meta.errorSourceMap.onMount` keeps reporting a source (`'field'` or `'form'`) for an error that no longer exists in `errorMap`. Every other field-meta write in `FormApi.ts` updates the two maps together, so this reads as an omission rather than intent.

This adds the matching `errorSourceMap` update inside the same `setFieldMeta` call, and two regression tests in `FormApi.spec.ts` covering the `'field'` source (field-level `onMount` validator) and the `'form'` source (form-level `onMount` validator emitting a field error).

`alpha` is not affected: `errorSourceMap` does not appear in any package on that branch, so there is nothing to port to v2.

Note that #2245 edits the same block for an unrelated reason. There is no functional overlap; happy to rebase if it lands first.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing a field value now consistently removes its initial validation errors, including errors originating from field- or form-level validation.
  * Updated field state now stays synchronized after values are changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->