### PR TITLE
fix(vue-form): run the cleanup returned by FormApi.mount() on unmount

### DIFF
--- a/packages/vue-form/src/useForm.tsx
+++ b/packages/vue-form/src/useForm.tsx
@@ -1,6 +1,6 @@
 import { FormApi } from '@tanstack/form-core'
 import { useSelector } from '@tanstack/vue-store'
-import { defineComponent, h, onMounted } from 'vue'
+import { defineComponent, h, onMounted, onUnmounted } from 'vue'
 import { Field } from './useField'
 import { FormGroup } from './useFormGroup'
 import { useFormId } from './useFormId'
@@ -351,7 +351,20 @@ export function useForm<
     return extendedApi
   })()
 
-  onMounted(formApi.mount)
+  // `mount()` returns a teardown function. Vue, unlike React's `useEffect`,
+  // ignores a value returned from `onMounted`, so it has to be held and invoked
+  // from `onUnmounted` — otherwise the devtools event listeners and store
+  // subscription registered by `mount()` are never released.
+  let cleanupMount: (() => void) | undefined
+
+  onMounted(() => {
+    cleanupMount = formApi.mount()
+  })
+
+  onUnmounted(() => {
+    cleanupMount?.()
+    cleanupMount = undefined
+  })
 
   // formApi.useStore((state) => state.isSubmitting)
   formApi.update(opts)

--- a/packages/vue-form/tests/useFormMountCleanup.test.tsx
+++ b/packages/vue-form/tests/useFormMountCleanup.test.tsx
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/vue'
+import { defineComponent } from 'vue'
+import { useForm } from '../src'
+
+/**
+ * `FormApi.mount()` registers listeners on `window` through the devtools event
+ * client and returns a teardown function. Vue ignores a value returned from
+ * `onMounted`, so the adapter has to hold that teardown and call it from
+ * `onUnmounted` — otherwise every mounted form leaks its listeners for the
+ * lifetime of the document.
+ */
+describe('useForm mount cleanup', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('removes the listeners registered by mount() when the form unmounts', async () => {
+    const added: Array<string> = []
+    const removed: Array<string> = []
+
+    vi.spyOn(window, 'addEventListener').mockImplementation(((
+      type: string,
+    ) => {
+      added.push(type)
+    }) as never)
+    vi.spyOn(window, 'removeEventListener').mockImplementation(((
+      type: string,
+    ) => {
+      removed.push(type)
+    }) as never)
+
+    const Comp = defineComponent(() => {
+      useForm({ defaultValues: { firstName: '' } })
+      return () => <div>form</div>
+    })
+
+    const { unmount } = render(<Comp />)
+    expect(added.length).toBeGreaterThan(0)
+
+    unmount()
+
+    // Every listener type registered on mount must be taken back off.
+    for (const type of new Set(added)) {
+      expect(removed).toContain(type)
+    }
+  })
+
+  it('does not accumulate listeners across repeated mounts', async () => {
+    const live = new Map<string, number>()
+
+    vi.spyOn(window, 'addEventListener').mockImplementation(((
+      type: string,
+    ) => {
+      live.set(type, (live.get(type) ?? 0) + 1)
+    }) as never)
+    vi.spyOn(window, 'removeEventListener').mockImplementation(((
+      type: string,
+    ) => {
+      live.set(type, (live.get(type) ?? 0) - 1)
+    }) as never)
+
+    const Comp = defineComponent(() => {
+      useForm({ defaultValues: { firstName: '' } })
+      return () => <div>form</div>
+    })
+
+    for (let i = 0; i < 3; i++) {
+      const { unmount } = render(<Comp />)
+      unmount()
+    }
+
+    for (const [, count] of live) {
+      expect(count).toBe(0)
+    }
+  })
+})


### PR DESCRIPTION
## Problem

`packages/vue-form/src/useForm.tsx` does:

```ts
onMounted(formApi.mount)
```

`FormApi.mount()` returns a teardown function. Unlike React's `useEffect`, **Vue ignores a value returned from `onMounted`**, so that teardown is never invoked.

`mount()` registers three listeners on the shared `formEventClient` plus a store subscription:

```ts
// packages/form-core/src/FormApi.ts
this.mount = () => {
  const cleanupDevtoolBroadcast = this.store.subscribe(...)
  const cleanupFormStateListener = formEventClient.on('request-form-state', ...)
  const cleanupFormResetListener = formEventClient.on('request-form-reset', ...)
  const cleanupFormForceSubmitListener = formEventClient.on('request-form-force-submit', ...)
  const cleanup = () => { /* releases all four + emits 'form-unmounted' */ }
  ...
  return cleanup
}
```

Because `formEventClient` is a module-level singleton, those listeners live for the lifetime of the document. Every mounted form leaks three `window` listeners and a store subscription, and the listener closures capture the `FormApi` — and through `this.options`, the options object supplied by the component — so the component's scope is retained too. `form-unmounted` is also never emitted, so devtools never learns the form went away.

In an SPA that mounts a form on more than one route, this accumulates on every navigation.

## Fix

Hold the teardown and call it from `onUnmounted`:

```ts
let cleanupMount: (() => void) | undefined

onMounted(() => {
  cleanupMount = formApi.mount()
})

onUnmounted(() => {
  cleanupMount?.()
  cleanupMount = undefined
})
```

`react-form` already gets this right — `useIsomorphicLayoutEffect(formApi.mount, [])` does honour the returned cleanup. This brings the Vue adapter in line with the same contract.

## Tests

Added `packages/vue-form/tests/useFormMountCleanup.test.tsx` with two cases:

- every `window` listener type registered during mount is removed on unmount
- listeners do not accumulate across repeated mount/unmount cycles

Both fail on `main` and pass with this change.

## How this was found

Profiling a Vue 3 SPA for a memory leak across route changes. Instrumenting `addEventListener`/`removeEventListener` and capturing construction stacks showed three `window:form-devtools:*` listeners accumulating per navigation, originating in `FormEventClient.on`. On the affected route this retained ~4,000 detached DOM nodes per navigation; applying this fix locally took that to 0.

Note the same discarded-cleanup pattern cannot be worked around by consumers: `useForm` captures `formApi.mount` by value when registering the hook, so wrapping `mount` on the returned instance afterwards has no effect. It has to be fixed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form lifecycle cleanup by removing event listeners and subscriptions when form components are unmounted.
  * Prevented listener accumulation across repeated component mounts and unmounts.

* **Tests**
  * Added coverage for cleanup after unmounting and repeated mount cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->