### PR TITLE
Feat(react): [v2] Allow nestable form and field components

### DIFF
--- a/.changeset/tender-keys-own.md
+++ b/.changeset/tender-keys-own.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-form': minor
+---
+
+Feat: Field and Form components can now be nested to create namespaces.

--- a/packages/react-form/src/AppForm/ReactAppFieldApi.lib.ts
+++ b/packages/react-form/src/AppForm/ReactAppFieldApi.lib.ts
@@ -1,10 +1,8 @@
 import { InternalFieldApi } from '@tanstack/form-core/internals'
-import type { FunctionComponent } from 'react'
-
-type FieldComponents = Record<string, FunctionComponent<any>>
+import type { ReactComponentTree } from './componentMap.public'
 
 export function createInternalReactAppFieldApiClass(
-  fieldComponents: FieldComponents,
+  fieldComponents: ReactComponentTree,
 ): typeof InternalFieldApi {
   class InternalReactAppFieldApi extends InternalFieldApi<any, any, any> {}
 

--- a/packages/react-form/src/AppForm/ReactAppFormApi.lib.ts
+++ b/packages/react-form/src/AppForm/ReactAppFormApi.lib.ts
@@ -9,25 +9,24 @@ import {
 import type { DefaultOptions, FormOptions } from '@tanstack/form-core'
 import type { FunctionComponent } from 'react'
 import type { AppFormComponent } from './ReactAppFormApi.public'
-
-type FormComponents = Record<string, FunctionComponent<any>>
+import type { ReactComponentTree } from './componentMap.public'
 
 interface InternalReactAppFormApiInstance extends InternalReactFormApi {
   AppForm: AppFormComponent
 }
 
 type InternalReactAppFormApiConstructor<
-  TFormComponents extends FormComponents,
+  TFormComponents extends ReactComponentTree,
 > = new (
   options: FormOptions<any, any, any, unknown>,
   defaultOptions?: DefaultOptions,
 ) => InternalReactAppFormApiInstance & TFormComponents
 
 export function createInternalReactAppFormApiClass<
-  const TFormComponents extends FormComponents,
+  const TFormComponents extends ReactComponentTree,
 >(
   formComponents: TFormComponents,
-  fieldComponents: FormComponents,
+  fieldComponents: ReactComponentTree,
 ): InternalReactAppFormApiConstructor<TFormComponents> {
   const InternalReactAppFieldApi =
     createInternalReactAppFieldApiClass(fieldComponents)

--- a/packages/react-form/src/AppForm/componentMap.public.ts
+++ b/packages/react-form/src/AppForm/componentMap.public.ts
@@ -1,16 +1,39 @@
 import type { FunctionComponent } from 'react'
 
+/**
+ * A recursively nested collection of components registered with
+ * `createFormHook`.
+ *
+ * Component trees are inferred from `fieldComponents` and `formComponents` in
+ * normal usage. This type is primarily useful when building wrappers around
+ * `createFormHook` or declaring reusable component registries.
+ *
+ * @example
+ * ```tsx
+ * const fields = {
+ *   inputs: {
+ *     TextField,
+ *   },
+ * } satisfies ReactComponentTree
+ * ```
+ */
+export type ReactComponentTree = {
+  readonly [name: string]: FunctionComponent<any> | ReactComponentTree
+}
+
 export interface ReactFormComponentMap<
-  in out TFormComponents extends Record<string, FunctionComponent<any>>,
-  in out TFieldComponents extends Record<string, FunctionComponent<any>>,
+  in out TFormComponents extends ReactComponentTree,
+  in out TFieldComponents extends ReactComponentTree,
 > {
+  /** Components and component namespaces exposed on each App Form API. */
   formComponents: TFormComponents
+  /** Components and component namespaces exposed on each App Field API. */
   fieldComponents: TFieldComponents
 }
 
 export type AnyReactFormComponentMap = ReactFormComponentMap<
-  Record<string, FunctionComponent<any>>,
-  Record<string, FunctionComponent<any>>
+  ReactComponentTree,
+  ReactComponentTree
 >
 
 export type DefaultReactFormComponentMap = ReactFormComponentMap<

--- a/packages/react-form/src/AppForm/createFormHook.public.ts
+++ b/packages/react-form/src/AppForm/createFormHook.public.ts
@@ -8,12 +8,12 @@ import type {
   CreateFormHookOptions,
   UseAppFormHook,
 } from './createFormHookTypes.public'
-import type { FunctionComponent } from 'react'
+import type { ReactComponentTree } from './componentMap.public'
 import type { FormOptions } from '@tanstack/form-core'
 
 export function createFormHook<
-  const TFormComponents extends Record<string, FunctionComponent<any>>,
-  const TFieldComponents extends Record<string, FunctionComponent<any>>,
+  const TFormComponents extends ReactComponentTree,
+  const TFieldComponents extends ReactComponentTree,
 >(
   createOptions: CreateFormHookOptions<TFormComponents, TFieldComponents>,
 ): AppFormHookResult<{

--- a/packages/react-form/src/AppForm/createFormHookTypes.public.ts
+++ b/packages/react-form/src/AppForm/createFormHookTypes.public.ts
@@ -1,10 +1,10 @@
 import type {
   AnyReactFormComponentMap,
+  ReactComponentTree,
   ReactFormComponentMap,
 } from './componentMap.public'
 import type { ReactAppFormApi } from './ReactAppFormApi.public'
 import type { DefineFieldGroupFn } from '../FieldGroup/withFields.public'
-import type { FunctionComponent } from 'react'
 import type {
   DefaultFieldOptions,
   DefaultFormGroupOptions,
@@ -27,9 +27,15 @@ import type {
  * @example
  * ```tsx
  * const { useAppForm } = createFormHook({
- *   formComponents: {},
+ *   formComponents: {
+ *     actions: {
+ *       SubmitButton,
+ *     },
+ *   },
  *   fieldComponents: {
- *     TextField,
+ *     inputs: {
+ *       TextField,
+ *     },
  *   },
  *   defaultFormOptions: {
  *     errorVisibility: ({ fieldState }) => fieldState.meta.isBlurred,
@@ -38,14 +44,18 @@ import type {
  *     errorBoundary: true,
  *   },
  * })
+ *
+ * // Registered namespaces retain their shape on the form and field APIs:
+ * // <form.actions.SubmitButton />
+ * // <field.inputs.TextField />
  * ```
  *
  * @typeParam TFormComponents - Library-managed. Do not specify explicitly.
  * @typeParam TFieldComponents - Library-managed. Do not specify explicitly.
  */
 export interface CreateFormHookOptions<
-  in out TFormComponents extends Record<string, FunctionComponent<any>>,
-  in out TFieldComponents extends Record<string, FunctionComponent<any>>,
+  in out TFormComponents extends ReactComponentTree,
+  in out TFieldComponents extends ReactComponentTree,
 > extends ReactFormComponentMap<TFormComponents, TFieldComponents> {
   /**
    * Defaults for every form created by `useAppForm`.

--- a/packages/react-form/src/AppForm/initializeAppForm.lib.ts
+++ b/packages/react-form/src/AppForm/initializeAppForm.lib.ts
@@ -1,5 +1,6 @@
 import { createInternalReactAppFormApiClass } from './ReactAppFormApi.lib'
 import type { InternalReactFormApi } from '../ReactForm/ReactFormApi.lib'
+import type { ReactComponentTree } from './componentMap.public'
 import type {
   DefaultFieldOptions,
   DefaultFormGroupOptions,
@@ -7,11 +8,10 @@ import type {
   DefaultOptions,
   FormOptions,
 } from '@tanstack/form-core'
-import type { FunctionComponent } from 'react'
 
 interface AnyCreateFormHookOptions {
-  formComponents: Record<string, FunctionComponent<any>>
-  fieldComponents: Record<string, FunctionComponent<any>>
+  formComponents: ReactComponentTree
+  fieldComponents: ReactComponentTree
   defaultFormOptions?: DefaultFormOptions
   defaultFieldOptions?: DefaultFieldOptions
   defaultFormGroupOptions?: DefaultFormGroupOptions

--- a/packages/react-form/src/FieldGroup/FieldGroupApi.public.ts
+++ b/packages/react-form/src/FieldGroup/FieldGroupApi.public.ts
@@ -14,11 +14,12 @@ import type {
   ReactFormFieldProps,
   ReactFormSubscribeProps,
 } from '../ReactForm/Components.public'
+import type { ReactComponentTree } from '../AppForm/componentMap.public'
 import type { ReadonlyAtom } from '@tanstack/react-store'
 
 export interface FieldGroupFieldComponent<
   in out TFieldData,
-  in out TFieldComponents extends Record<string, FunctionComponent<any>>,
+  in out TFieldComponents extends ReactComponentTree,
 > {
   /**
    * Renders a field from this field group.
@@ -83,7 +84,7 @@ export interface FieldGroupFieldComponent<
 
 export interface FieldGroupArrayFieldComponent<
   in out TFieldData,
-  in out TFieldComponents extends Record<string, FunctionComponent<any>>,
+  in out TFieldComponents extends ReactComponentTree,
 > {
   /**
    * Renders an array field from this field group.
@@ -173,8 +174,7 @@ export type FieldGroupSubscribeComponent = <const TSelected>(
 
 export interface FieldGroupApi<
   in out TFieldData,
-  in out TFieldComponents extends Record<string, FunctionComponent<any>> =
-    Record<never, never>,
+  in out TFieldComponents extends ReactComponentTree,
 >
   extends FormApiFieldMethods<TFieldData>, FormApiArrayMethods<TFieldData> {
   atom: ReadonlyAtom<TFieldData>

--- a/packages/react-form/src/FieldGroup/withFields.public.ts
+++ b/packages/react-form/src/FieldGroup/withFields.public.ts
@@ -8,9 +8,10 @@ import type {
   FieldGroupHelper,
   FormApi,
 } from '@tanstack/form-core'
-import type { FunctionComponent, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import type { ReactTanStackFormComponents } from '../ReactForm/Components.public'
 import type { FieldGroupApi } from './FieldGroupApi.public'
+import type { ReactComponentTree } from '../AppForm/componentMap.public'
 
 declare const fieldGroupFieldsSymbol: unique symbol
 
@@ -22,10 +23,7 @@ export type FieldGroupFieldsOf<TFieldGroup> = TFieldGroup extends {
 
 export type ReactFieldGroup<
   TFields extends FieldGroupFields,
-  TFieldComponents extends Record<string, FunctionComponent<any>> = Record<
-    never,
-    never
-  >,
+  TFieldComponents extends ReactComponentTree = Record<never, never>,
 > = FieldGroupApi<FieldGroupFieldData<TFields>, TFieldComponents> & {
   readonly [fieldGroupFieldsSymbol]: TFields
 }
@@ -36,10 +34,7 @@ export type FieldGroupFieldComponentsOf<TFieldGroup> =
     : never
 
 export type FieldGroupForm<
-  TFieldComponents extends Record<string, FunctionComponent<any>> = Record<
-    never,
-    never
-  >,
+  TFieldComponents extends ReactComponentTree = Record<never, never>,
   TFormData = any,
 > = FormApi<TFormData, any> &
   ReactTanStackFormComponents<TFormData, any, TFieldComponents>
@@ -122,7 +117,7 @@ export type FieldGroupWithFieldsFn<
 
 export interface FieldGroupDefinition<
   TFields extends FieldGroupFields,
-  TFieldComponents extends Record<string, FunctionComponent<any>>,
+  TFieldComponents extends ReactComponentTree,
 > {
   /**
    * The virtual field-group API injected into the component passed to
@@ -201,9 +196,9 @@ export interface FieldGroupDefinition<
 /**
  * Signature shared by `defineFieldGroup` and app-form field-group definers.
  */
-export type DefineFieldGroupFn<
-  TFieldComponents extends Record<string, FunctionComponent<any>>,
-> = <const TFields extends FieldGroupFields>(
+export type DefineFieldGroupFn<TFieldComponents extends ReactComponentTree> = <
+  const TFields extends FieldGroupFields,
+>(
   defineFn: (helper: FieldGroupHelper) => TFields,
 ) => FieldGroupDefinition<TFields, TFieldComponents>
 

--- a/packages/react-form/src/ReactForm/Components.public.ts
+++ b/packages/react-form/src/ReactForm/Components.public.ts
@@ -20,6 +20,7 @@ import type {
   MemoExoticComponent,
   ReactNode,
 } from 'react'
+import type { ReactComponentTree } from '../AppForm/componentMap.public'
 
 type ExactFieldBrand<out TValue> = {
   readonly __tanstackFieldExactType: TValue
@@ -50,30 +51,27 @@ type UnwrapComponent<TComponent> =
       ? UnwrapComponent<TInner>
       : TComponent
 
-type UnwrappedFieldComponents<
-  in out TFieldComponents extends Record<string, FunctionComponent<any>>,
-> = {
-  [K in keyof TFieldComponents]: UnwrapComponent<TFieldComponents[K]>
-}
-
 type FilteredFieldComponents<
-  in out TFieldComponents extends Record<string, FunctionComponent<any>>,
+  in out TFieldComponents extends ReactComponentTree,
   in out TTargetValue,
-  in out TUnwrappedFieldComponents extends {
-    [K in keyof TFieldComponents]: any
-  } = UnwrappedFieldComponents<TFieldComponents>,
 > = {
   [
-    K in keyof TFieldComponents as CompatibleFieldKey<
-      K,
-      TUnwrappedFieldComponents[K],
-      TTargetValue
-    >
-  ]: TFieldComponents[K]
+    K in keyof TFieldComponents as TFieldComponents[K] extends FunctionComponent<any>
+      ? CompatibleFieldKey<
+          K,
+          UnwrapComponent<TFieldComponents[K]>,
+          TTargetValue
+        >
+      : K
+  ]: TFieldComponents[K] extends infer TComp extends FunctionComponent<any>
+    ? TComp
+    : TFieldComponents[K] extends ReactComponentTree
+      ? FieldComponentsMatchingType<TFieldComponents[K], TTargetValue>
+      : never
 }
 
 type FieldComponentsMatchingType<
-  TFieldComponents extends Record<string, FunctionComponent<any>>,
+  TFieldComponents extends ReactComponentTree,
   TTargetValue,
 > = unknown extends TTargetValue
   ? TFieldComponents
@@ -87,7 +85,7 @@ export type ReactFieldApi<
   TFieldError,
   TFormData,
   TFormErrorTypes extends FormErrorTypes,
-  TFieldComponents extends Record<string, FunctionComponent<any>>,
+  TFieldComponents extends ReactComponentTree,
 > = FieldApi<TFieldName, TFieldValue, TFieldError, TFormData, TFormErrorTypes> &
   FieldComponentsMatchingType<TFieldComponents, TFieldValue>
 
@@ -126,7 +124,7 @@ export interface ReactFormFieldProps<
   in out TGroupFieldError,
   in out TFormData,
   in out TFormErrorTypes extends FormErrorTypes,
-  in out TFieldComponents extends Record<string, FunctionComponent<any>>,
+  in out TFieldComponents extends ReactComponentTree,
 > extends FieldApiOptions<
   TFieldData,
   TFieldName,
@@ -155,7 +153,7 @@ export interface ReactFormFieldProps<
 export type ReactFormFieldComponent<
   in out TFormData,
   in out TFormErrorTypes extends FormErrorTypes,
-  in out TFieldComponents extends Record<string, FunctionComponent<any>>,
+  in out TFieldComponents extends ReactComponentTree,
 > = {
   <
     TFieldName extends DeepKeys<TFormData>,
@@ -181,7 +179,7 @@ export type ReactFormFieldComponent<
 export type ReactFormArrayFieldComponent<
   in out TFormData,
   in out TFormErrorTypes extends FormErrorTypes,
-  in out TFieldComponents extends Record<string, FunctionComponent<any>>,
+  in out TFieldComponents extends ReactComponentTree,
 > = {
   <
     TFieldName extends DeepKeysWhereValueIncludes<TFormData, Array<any>>,
@@ -225,7 +223,7 @@ export interface ReactFormGroupFieldComponent<
   in out TGroupValue,
   in out TGroupErrorTypes extends FormErrorTypes,
   in out TFormErrorTypes extends FormErrorTypes,
-  in out TFieldComponents extends Record<string, FunctionComponent<any>>,
+  in out TFieldComponents extends ReactComponentTree,
 > {
   <
     TFieldName extends DeepKeys<TGroupValue>,
@@ -253,7 +251,7 @@ export type ReactFormGroupArrayFieldComponent<
   in out TGroupValue,
   in out TGroupErrorTypes extends FormErrorTypes,
   in out TFormErrorTypes extends FormErrorTypes,
-  in out TFieldComponents extends Record<string, FunctionComponent<any>>,
+  in out TFieldComponents extends ReactComponentTree,
 > = {
   <
     TFieldName extends DeepKeysWhereValueIncludes<TGroupValue, Array<any>>,
@@ -282,7 +280,7 @@ export interface ReactFormGroupApi<
   in out TGroupValue,
   in out TGroupErrorTypes extends FormErrorTypes,
   in out TFormErrorTypes extends FormErrorTypes,
-  in out TFieldComponents extends Record<string, FunctionComponent<any>>,
+  in out TFieldComponents extends ReactComponentTree,
 > extends FormGroupApi<
   TFormData,
   TGroupName,
@@ -313,7 +311,7 @@ export interface ReactFormGroupProps<
   in out TGroupValue,
   in out TGroupValidators extends FormGroupValidators<TGroupValue>,
   in out TFormErrorTypes extends FormErrorTypes,
-  in out TFieldComponents extends Record<string, FunctionComponent<any>>,
+  in out TFieldComponents extends ReactComponentTree,
 > extends Omit<
   FormGroupOptions<
     TFormData,
@@ -339,7 +337,7 @@ export interface ReactFormGroupProps<
 export interface ReactFormGroupComponent<
   in out TFormData,
   in out TFormErrorTypes extends FormErrorTypes,
-  in out TFieldComponents extends Record<string, FunctionComponent<any>>,
+  in out TFieldComponents extends ReactComponentTree,
 > {
   <
     TGroupName extends DeepKeys<TFormData>,
@@ -360,7 +358,7 @@ export interface ReactFormGroupComponent<
 export interface ReactTanStackFormComponents<
   in out TFormData,
   in out TFormErrorTypes extends FormErrorTypes,
-  in out TFieldComponents extends Record<string, FunctionComponent<any>>,
+  in out TFieldComponents extends ReactComponentTree,
 > {
   /**
    * TODO docs

--- a/packages/react-form/src/ReactForm/formApiTypes.public.ts
+++ b/packages/react-form/src/ReactForm/formApiTypes.public.ts
@@ -1,12 +1,14 @@
 import type { AnyFormApi, FormApi, FormErrorTypes } from '@tanstack/form-core'
-import type { FunctionComponent } from 'react'
 import type { ReactTanStackFormComponents } from './Components.public'
-import type { AnyReactFormComponentMap } from '../AppForm/componentMap.public'
+import type {
+  AnyReactFormComponentMap,
+  ReactComponentTree,
+} from '../AppForm/componentMap.public'
 
 type ExtendedFormApi<
   TFormData,
   TFormErrorTypes extends FormErrorTypes,
-  TFieldComponents extends Record<string, FunctionComponent<any>>,
+  TFieldComponents extends ReactComponentTree,
 > = FormApi<TFormData, TFormErrorTypes> &
   ReactTanStackFormComponents<TFormData, TFormErrorTypes, TFieldComponents>
 

--- a/packages/react-form/tests/FieldGroupApi.test-d.tsx
+++ b/packages/react-form/tests/FieldGroupApi.test-d.tsx
@@ -409,11 +409,14 @@ function DefineFieldGroupTypes() {
   }>()
 
   expectTypeOf(definedFields).toExtend<
-    FieldGroupApi<{
-      name: string
-      age: number
-      emails: Array<{ value: string }>
-    }>
+    FieldGroupApi<
+      {
+        name: string
+        age: number
+        emails: Array<{ value: string }>
+      },
+      Record<never, never>
+    >
   >()
   expectTypeOf<DefinedFieldsSpec>().toEqualTypeOf<{
     readonly name: typeof stringSlot

--- a/packages/react-form/tests/createFormHook.spec.tsx
+++ b/packages/react-form/tests/createFormHook.spec.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
-import { createFormHook } from '../src'
+import { createFormHook, getFormHookHelpers } from '../src'
 import type {
   AnyInternalFieldApi,
   AnyInternalFormApi,
 } from '@tanstack/form-core/internals'
+import type { FieldWithValue } from '../src'
 
 describe('createFormHook', () => {
   it('provides registered components to fields created during mount validation', () => {
@@ -40,6 +41,53 @@ describe('createFormHook', () => {
     const { getByText } = render(<Component />)
 
     expect(getByText('Shared field component')).toBeInTheDocument()
+  })
+
+  it('supports nested field and form component trees', () => {
+    function FieldValue({ field }: { field: FieldWithValue<string> }) {
+      return <span>Field value: {field.value}</span>
+    }
+
+    function FormHeading() {
+      return <h1>Nested form component</h1>
+    }
+
+    const { fieldComponent } = getFormHookHelpers()
+    const FieldValueWithContext = fieldComponent.strict(FieldValue, 'field')
+    const { useAppForm } = createFormHook({
+      fieldComponents: {
+        display: {
+          values: {
+            FieldValue: FieldValueWithContext,
+          },
+        },
+      },
+      formComponents: {
+        layout: {
+          headings: {
+            FormHeading,
+          },
+        },
+      },
+    })
+
+    function Component() {
+      const form = useAppForm({ defaultValues: { name: 'Tony' } })
+
+      return (
+        <form.AppForm>
+          <form.layout.headings.FormHeading />
+          <form.Field name="name">
+            {(field) => <field.display.values.FieldValue />}
+          </form.Field>
+        </form.AppForm>
+      )
+    }
+
+    const { getByText } = render(<Component />)
+
+    expect(getByText('Nested form component')).toBeInTheDocument()
+    expect(getByText('Field value: Tony')).toBeInTheDocument()
   })
 
   it('supports destructuring registered form components', () => {

--- a/packages/react-form/tests/createFormHook.test-d.tsx
+++ b/packages/react-form/tests/createFormHook.test-d.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import { expectTypeOf } from 'vitest'
-import { createFormHook } from '../src'
+import { createFormHook, getFormHookHelpers } from '../src'
 import type {
   DefaultFieldOptions,
   DefaultFormGroupOptions,
   DefaultFormOptions,
+  FieldWithValue,
+  ReactComponentTree,
 } from '../src'
 
 const { useAppForm } = createFormHook({
@@ -99,6 +101,155 @@ function InferenceRemainsLocal() {
 }
 
 void InferenceRemainsLocal
+
+function TextFieldComponent(props: {
+  field: FieldWithValue<string>
+  label: string
+}) {
+  return props.label
+}
+
+function NumberFieldComponent(props: { field: FieldWithValue<number> }) {
+  return String(props.field.value)
+}
+
+function FieldInfoComponent(props: { field: FieldWithValue<unknown> }) {
+  return String(props.field.value)
+}
+
+const { fieldComponent } = getFormHookHelpers()
+const TextField = fieldComponent.strict(TextFieldComponent, 'field')
+const NumberField = fieldComponent.strict(NumberFieldComponent, 'field')
+const FieldInfo = fieldComponent.loose(FieldInfoComponent, 'field')
+const MemoTextField = React.memo(TextField)
+const LazyTextField = React.lazy(() => Promise.resolve({ default: TextField }))
+
+const reusableFields = {
+  inputs: {
+    text: {
+      TextField,
+      MemoTextField,
+      LazyTextField,
+    },
+    numbers: {
+      NumberField,
+    },
+  },
+  feedback: {
+    FieldInfo,
+  },
+} satisfies ReactComponentTree
+
+function SubmitButton() {
+  return null
+}
+
+function FormStatus() {
+  return null
+}
+
+const {
+  useAppForm: useNestedAppForm,
+  defineAppFieldGroup: defineNestedAppFieldGroup,
+} = createFormHook({
+  fieldComponents: reusableFields,
+  formComponents: {
+    actions: {
+      SubmitButton,
+    },
+    layout: {
+      status: {
+        FormStatus,
+      },
+    },
+  },
+})
+
+const nestedAppFieldGroup = defineNestedAppFieldGroup(({ strict }) => ({
+  name: strict<string>(),
+  age: strict<number>(),
+}))
+
+function NestedComponentTrees() {
+  const form = useNestedAppForm({
+    defaultValues: {
+      name: '',
+      age: 0,
+      tags: [''],
+    },
+  })
+
+  return (
+    <>
+      <form.actions.SubmitButton />
+      <form.layout.status.FormStatus />
+      <form.Field name="name">
+        {(field) => {
+          expectTypeOf<keyof typeof field.inputs.numbers>().toBeNever()
+          return (
+            <>
+              <field.inputs.text.TextField label="Name" />
+              <field.inputs.text.MemoTextField label="Name" />
+              <field.inputs.text.LazyTextField label="Name" />
+              <field.feedback.FieldInfo />
+              {/* @ts-expect-error number-only leaves are filtered from string fields */}
+              <field.inputs.numbers.NumberField />
+            </>
+          )
+        }}
+      </form.Field>
+      <form.Field name="age">
+        {(field) => {
+          expectTypeOf<keyof typeof field.inputs.text>().toBeNever()
+          return (
+            <>
+              <field.inputs.numbers.NumberField />
+              {/* @ts-expect-error string-only leaves are filtered from number fields */}
+              <field.inputs.text.TextField label="Age" />
+            </>
+          )
+        }}
+      </form.Field>
+      <form.ArrayField name="tags">
+        {(field) => {
+          expectTypeOf<keyof typeof field.inputs.text>().toBeNever()
+          return <field.feedback.FieldInfo />
+        }}
+      </form.ArrayField>
+      <nestedAppFieldGroup.fields.Field name="name">
+        {(field) => (
+          <>
+            <field.inputs.text.TextField label="Name" />
+            {/* @ts-expect-error nested filtering is preserved by app field groups */}
+            <field.inputs.numbers.NumberField />
+          </>
+        )}
+      </nestedAppFieldGroup.fields.Field>
+    </>
+  )
+}
+
+void NestedComponentTrees
+
+createFormHook({
+  fieldComponents: {
+    invalid: {
+      // @ts-expect-error component-tree leaves must be React components
+      value: 'not a component',
+    },
+  },
+  formComponents: {},
+})
+
+createFormHook({
+  fieldComponents: {},
+  formComponents: {
+    invalid: {
+      // @ts-expect-error component-tree leaves must be React components
+      value: 123,
+    },
+  },
+})
 
 expectTypeOf<
   Extract<


### PR DESCRIPTION
Closes #2360 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for nesting form and field components in component trees, enabling organized namespaces such as `layout.headings` or `display.values`.
  * Nested components remain accessible through the form and field APIs while preserving type-safe component selection.
  * Added support for nested component structures across field groups and reusable form components.

* **Documentation**
  * Updated usage guidance and examples to demonstrate namespaced form and field components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->