### PR TITLE
fix(form-core): only clear form-level onSubmit error on value change

### DIFF
--- a/.changeset/form-clear-onsubmit-error-on-change.md
+++ b/.changeset/form-clear-onsubmit-error-on-change.md
@@ -1,0 +1,12 @@
+---
+'@tanstack/form-core': patch
+---
+
+fix(form-core): only clear a form-level onSubmit error on value change
+
+`FormApi` cleared a stale form-level `onSubmit` error on any non-`submit`
+validation cause (`cause !== 'submit'`), so a `blur`, `mount`, or `dynamic`
+revalidation dropped the error even though the user never edited the field. The
+clear now only happens on `cause === 'change'`, matching the documented intent
+("clear the error as soon as the user enters a valid value") and the field-level
+fix in #2211.

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -2106,13 +2106,16 @@ export class FormApi<
 
       /**
        *  when we have an error for onSubmit in the state, we want
-       *  to clear the error as soon as the user enters a valid value in the field
+       *  to clear the error as soon as the user enters a valid value in the field.
+       *  This must only happen on a value `change` - clearing it on `blur` (or any
+       *  other non-value cause like `mount`, `server` or `dynamic`) would wrongly
+       *  drop the submit error when the field is revalidated without being edited.
        */
       const submitErrKey = getErrorMapKey('submit')
       if (
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         this.state.errorMap?.[submitErrKey] &&
-        cause !== 'submit' &&
+        cause === 'change' &&
         !hasErrored
       ) {
         this.baseStore.setState((prev) => ({

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -2162,6 +2162,63 @@ describe('form api', () => {
     expect(form.state.errors).toStrictEqual(['first name is required'])
   })
 
+  it('should not clear the form-level onSubmit error on blur when the value did not change', async () => {
+    const form = new FormApi({
+      defaultValues: {
+        firstName: '',
+      },
+      validators: {
+        onSubmit: ({ value }) =>
+          value.firstName.length > 0 ? undefined : 'first name is required',
+      },
+    })
+
+    form.mount()
+
+    const field = new FieldApi({
+      form,
+      name: 'firstName',
+    })
+
+    field.mount()
+
+    await form.handleSubmit()
+    expect(form.state.errorMap.onSubmit).toBe('first name is required')
+
+    // Blurring the field without changing its value must keep the submit error:
+    // `blur` is not a value change, so the stale onSubmit error should remain.
+    field.handleBlur()
+    expect(form.state.errorMap.onSubmit).toBe('first name is required')
+  })
+
+  it('should clear the form-level onSubmit error once a valid value is entered', async () => {
+    const form = new FormApi({
+      defaultValues: {
+        firstName: '',
+      },
+      validators: {
+        onSubmit: ({ value }) =>
+          value.firstName.length > 0 ? undefined : 'first name is required',
+      },
+    })
+
+    form.mount()
+
+    const field = new FieldApi({
+      form,
+      name: 'firstName',
+    })
+
+    field.mount()
+
+    await form.handleSubmit()
+    expect(form.state.errorMap.onSubmit).toBe('first name is required')
+
+    // Entering a valid value clears the stale submit error.
+    field.handleChange('John')
+    expect(form.state.errorMap.onSubmit).toBeUndefined()
+  })
+
   it('should run onChange validation during submit', async () => {
     const form = new FormApi({
       defaultValues: {


### PR DESCRIPTION
## 🎯 Changes

Fixes #2295.

A stale **form-level** `onSubmit` error was being cleared on any validation
cause other than `submit`. In `packages/form-core/src/FormApi.ts` the block that
is meant to "clear the error as soon as the user enters a valid value" gated on
`cause !== 'submit'`:

```ts
if (this.state.errorMap?.[submitErrKey] && cause !== 'submit' && !hasErrored) {
  // clear errorMap.onSubmit
}
```

`ValidationCause` is `'change' | 'blur' | 'submit' | 'mount' | 'server' | 'dynamic'`,
so this also cleared the error on `blur`, `mount`, and `dynamic` revalidations —
not just when the user actually changed a value. Because a field blur runs the
form's validators (`FieldApi.validate` → `form.validateSync(cause)`), simply
focusing and leaving an invalid field wiped the submit error while the underlying
problem was still unfixed.

The fix narrows the condition to `cause === 'change'`, matching the comment's
stated intent. This is the form-level counterpart of the field-level fix in
#2211 (which applies the identical change in `FieldApi.ts`).

### Scope note

Issue #2295 also mentions the neighbouring `onServer` clearing block. I left it
untouched on purpose: for `onServer`, the effective clearing is driven by
`defaultValidationLogic`, which injects a dedicated server-clearing validator
(`{ fn: () => undefined, cause: 'server' }`) into the `blur`/`change`/`submit`
runs whenever the form has validators. That path clears `onServer` regardless of
this guard, so flipping this condition would not actually change the reported
`onServer`-on-blur behaviour and would only add a misleading half-fix. That
belongs in a separate change to the injected validator and is a design call for
the maintainers.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Test verification (RED → GREEN)

Two tests were added to `packages/form-core/tests/FormApi.spec.ts`. Run on the
unmodified `main` production code (bug present) and again with the fix.

**RED** — production code reverted to `cause !== 'submit'`:

```
× form api > should not clear the form-level onSubmit error on blur when the value did not change
  → expected undefined to be 'first name is required'
✓ form api > should clear the form-level onSubmit error once a valid value is entered
Tests  1 failed | 1 passed
```

**GREEN** — with the fix:

```
✓ form api > should not clear the form-level onSubmit error on blur when the value did not change
✓ form api > should clear the form-level onSubmit error once a valid value is entered
Tests  2 passed
```

Full `@tanstack/form-core` suite: **507 passed / 3 todo** (2 new tests, no
regressions vs the 505-passing baseline). The `@tanstack/react-form` suite
(126 passed) is green against the rebuilt `form-core` dist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Form-level submission errors now remain visible when fields are revalidated without changes, such as on blur or mount.
  - Submission errors are cleared after the user edits the relevant field, including when entering a valid value.

- **Tests**
  - Added coverage for preserving errors during unchanged-field validation and clearing them after edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->