### PR TITLE
fix(form-core): prevent concurrent submissions

### DIFF
--- a/.changeset/quiet-submit-guard.md
+++ b/.changeset/quiet-submit-guard.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/form-core': patch
+---
+
+Prevent concurrent form submissions while an async submit is already in progress.

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -2418,6 +2418,8 @@ export class FormApi<
    * Handles the form submission, performs validation, and calls the appropriate onSubmit or onSubmitInvalid callbacks.
    */
   _handleSubmit = async (submitMeta?: TSubmitMeta): Promise<void> => {
+    if (this.state.isSubmitting) return
+
     this.baseStore.setState((old) => ({
       ...old,
       // Submission attempts mark the form as not submitted

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -3521,6 +3521,38 @@ describe('form api', () => {
     expect(form.state.isSubmitSuccessful).toBe(false)
   })
 
+  it('should not call onSubmit again while a submission is in progress', async () => {
+    vi.useFakeTimers()
+    try {
+      const submitDelayMs = 1000
+      const expectedSubmitCount = 1
+      const onSubmit = vi.fn(async () => {
+        await sleep(submitDelayMs)
+      })
+      const form = new FormApi({
+        defaultValues: {
+          name: 'test',
+        },
+        onSubmit,
+      })
+
+      form.mount()
+
+      const firstSubmit = form.handleSubmit()
+      await vi.advanceTimersByTimeAsync(0)
+
+      const secondSubmit = form.handleSubmit()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(onSubmit).toHaveBeenCalledTimes(expectedSubmitCount)
+
+      await vi.runAllTimersAsync()
+      await Promise.all([firstSubmit, secondSubmit])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('should reset the fields value and meta to default state', async () => {
     const form = new FormApi({
       defaultValues: {


### PR DESCRIPTION
## 🎯 Changes
Fix #2279

- Prevent duplicate `handleSubmit()` calls from starting another submit while `isSubmitting` is true.
- Add a regression test covering repeated submit during a pending async `onSubmit`.

## Test verification (RED → GREEN)
- RED (unmodified main + new test): targeted form-core test failed with `expected "spy" to be called 1 times, but got 2 times`.
- GREEN (patched branch): targeted form-core test passed (`1 passed | 149 skipped`).
- Full form-core suite: `18 passed`; `506 passed | 3 todo`.

## Full local suite
- Baseline `main`: `./run-ci.sh` passed.
- Final branch: `./run-ci.sh` passed; diff coverage `1/1`.

## ✅ Checklist
- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact
- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented concurrent form submissions while an asynchronous submission is still in progress.
  - Repeated submission attempts are ignored until the current submission completes.
- **Tests**
  - Added coverage to verify that an in-progress submission does not trigger duplicate submit handlers.
- **Release**
  - Patch release prepared for the form core package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->