### PR TITLE
fix(form-core): allow optional arrays in helpers

### DIFF
--- a/.changeset/silver-arrays-collect.md
+++ b/.changeset/silver-arrays-collect.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/form-core': patch
+---
+
+Allow optional array fields to use the form array helper methods.

--- a/packages/form-core/src/FieldApi.ts
+++ b/packages/form-core/src/FieldApi.ts
@@ -31,7 +31,12 @@ import type {
   ValidationErrorMap,
 } from './types'
 import type { ReadonlyStore } from '@tanstack/store'
-import type { DeepKeys, DeepValue, RejectPromiseValidator } from './util-types'
+import type {
+  ArrayElement,
+  DeepKeys,
+  DeepValue,
+  RejectPromiseValidator,
+} from './util-types'
 import type {
   StandardSchemaV1,
   TStandardSchemaValidatorValue,
@@ -1102,12 +1107,9 @@ export class FieldApi<
   /**
    * Pushes a new value to the field.
    */
-  pushValue = (
-    value: TData extends any[] ? TData[number] : never,
-    options?: UpdateMetaOptions,
-  ) => {
+  pushValue = (value: ArrayElement<TData>, options?: UpdateMetaOptions) => {
     this.form.pushFieldValue(
-      this.name,
+      this.name as never,
       value as any,
       mergeOpts(options, { dontRunListeners: true }),
     )
@@ -1122,11 +1124,11 @@ export class FieldApi<
    */
   insertValue = (
     index: number,
-    value: TData extends any[] ? TData[number] : never,
+    value: ArrayElement<TData>,
     options?: UpdateMetaOptions,
   ) => {
     this.form.insertFieldValue(
-      this.name,
+      this.name as never,
       index,
       value as any,
       mergeOpts(options, { dontRunListeners: true }),
@@ -1142,11 +1144,11 @@ export class FieldApi<
    */
   replaceValue = (
     index: number,
-    value: TData extends any[] ? TData[number] : never,
+    value: ArrayElement<TData>,
     options?: UpdateMetaOptions,
   ) => {
     this.form.replaceFieldValue(
-      this.name,
+      this.name as never,
       index,
       value as any,
       mergeOpts(options, { dontRunListeners: true }),
@@ -1162,7 +1164,7 @@ export class FieldApi<
    */
   removeValue = (index: number, options?: UpdateMetaOptions) => {
     this.form.removeFieldValue(
-      this.name,
+      this.name as never,
       index,
       mergeOpts(options, { dontRunListeners: true }),
     )
@@ -1181,7 +1183,7 @@ export class FieldApi<
     options?: UpdateMetaOptions,
   ) => {
     this.form.swapFieldValues(
-      this.name,
+      this.name as never,
       aIndex,
       bIndex,
       mergeOpts(options, { dontRunListeners: true }),
@@ -1197,7 +1199,7 @@ export class FieldApi<
    */
   moveValue = (aIndex: number, bIndex: number, options?: UpdateMetaOptions) => {
     this.form.moveFieldValues(
-      this.name,
+      this.name as never,
       aIndex,
       bIndex,
       mergeOpts(options, { dontRunListeners: true }),
@@ -1213,7 +1215,7 @@ export class FieldApi<
    */
   clearValues = (options?: UpdateMetaOptions) => {
     this.form.clearFieldValues(
-      this.name,
+      this.name as never,
       mergeOpts(options, { dontRunListeners: true }),
     )
 

--- a/packages/form-core/src/FieldGroupApi.ts
+++ b/packages/form-core/src/FieldGroupApi.ts
@@ -15,7 +15,9 @@ import type {
 } from './FormApi'
 import type { FieldOptions } from './FieldApi'
 import type {
+  ArrayElement,
   DeepKeys,
+  DeepKeysOfArray,
   DeepKeysOfType,
   DeepValue,
   FieldsMap,
@@ -312,14 +314,14 @@ export class FieldGroupApi<
    * Validates the children of a specified array in the form starting from a given index until the end using the correct handlers for a given validation type.
    */
   validateArrayFieldsStartingFrom = async <
-    TField extends DeepKeysOfType<TFieldGroupData, any[]>,
+    TField extends DeepKeysOfArray<TFieldGroupData>,
   >(
     field: TField,
     index: number,
     cause: ValidationCause,
   ) => {
     return this.form.validateArrayFieldsStartingFrom(
-      this.getFormFieldName(field),
+      this.getFormFieldName(field) as never,
       index,
       cause,
     )
@@ -399,15 +401,13 @@ export class FieldGroupApi<
   /**
    * Pushes a value into an array field.
    */
-  pushFieldValue = <TField extends DeepKeysOfType<TFieldGroupData, any[]>>(
+  pushFieldValue = <TField extends DeepKeysOfArray<TFieldGroupData>>(
     field: TField,
-    value: DeepValue<TFieldGroupData, TField> extends any[]
-      ? DeepValue<TFieldGroupData, TField>[number]
-      : never,
+    value: ArrayElement<DeepValue<TFieldGroupData, TField>>,
     opts?: UpdateMetaOptions,
   ) => {
     return this.form.pushFieldValue(
-      this.getFormFieldName(field),
+      this.getFormFieldName(field) as never,
       // since unknown doesn't extend an array, it types `value` as never.
       value as never,
       opts,
@@ -417,18 +417,14 @@ export class FieldGroupApi<
   /**
    * Insert a value into an array field at the specified index.
    */
-  insertFieldValue = async <
-    TField extends DeepKeysOfType<TFieldGroupData, any[]>,
-  >(
+  insertFieldValue = async <TField extends DeepKeysOfArray<TFieldGroupData>>(
     field: TField,
     index: number,
-    value: DeepValue<TFieldGroupData, TField> extends any[]
-      ? DeepValue<TFieldGroupData, TField>[number]
-      : never,
+    value: ArrayElement<DeepValue<TFieldGroupData, TField>>,
     opts?: UpdateMetaOptions,
   ) => {
     return this.form.insertFieldValue(
-      this.getFormFieldName(field),
+      this.getFormFieldName(field) as never,
       index,
       // since unknown doesn't extend an array, it types `value` as never.
       value as never,
@@ -439,18 +435,14 @@ export class FieldGroupApi<
   /**
    * Replaces a value into an array field at the specified index.
    */
-  replaceFieldValue = async <
-    TField extends DeepKeysOfType<TFieldGroupData, any[]>,
-  >(
+  replaceFieldValue = async <TField extends DeepKeysOfArray<TFieldGroupData>>(
     field: TField,
     index: number,
-    value: DeepValue<TFieldGroupData, TField> extends any[]
-      ? DeepValue<TFieldGroupData, TField>[number]
-      : never,
+    value: ArrayElement<DeepValue<TFieldGroupData, TField>>,
     opts?: UpdateMetaOptions,
   ) => {
     return this.form.replaceFieldValue(
-      this.getFormFieldName(field),
+      this.getFormFieldName(field) as never,
       index,
       // since unknown doesn't extend an array, it types `value` as never.
       value as never,
@@ -461,27 +453,29 @@ export class FieldGroupApi<
   /**
    * Removes a value from an array field at the specified index.
    */
-  removeFieldValue = async <
-    TField extends DeepKeysOfType<TFieldGroupData, any[]>,
-  >(
+  removeFieldValue = async <TField extends DeepKeysOfArray<TFieldGroupData>>(
     field: TField,
     index: number,
     opts?: UpdateMetaOptions,
   ) => {
-    return this.form.removeFieldValue(this.getFormFieldName(field), index, opts)
+    return this.form.removeFieldValue(
+      this.getFormFieldName(field) as never,
+      index,
+      opts,
+    )
   }
 
   /**
    * Swaps the values at the specified indices within an array field.
    */
-  swapFieldValues = <TField extends DeepKeysOfType<TFieldGroupData, any[]>>(
+  swapFieldValues = <TField extends DeepKeysOfArray<TFieldGroupData>>(
     field: TField,
     index1: number,
     index2: number,
     opts?: UpdateMetaOptions,
   ) => {
     return this.form.swapFieldValues(
-      this.getFormFieldName(field),
+      this.getFormFieldName(field) as never,
       index1,
       index2,
       opts,
@@ -491,25 +485,28 @@ export class FieldGroupApi<
   /**
    * Moves the value at the first specified index to the second specified index within an array field.
    */
-  moveFieldValues = <TField extends DeepKeysOfType<TFieldGroupData, any[]>>(
+  moveFieldValues = <TField extends DeepKeysOfArray<TFieldGroupData>>(
     field: TField,
     index1: number,
     index2: number,
     opts?: UpdateMetaOptions,
   ) => {
     return this.form.moveFieldValues(
-      this.getFormFieldName(field),
+      this.getFormFieldName(field) as never,
       index1,
       index2,
       opts,
     )
   }
 
-  clearFieldValues = <TField extends DeepKeysOfType<TFieldGroupData, any[]>>(
+  clearFieldValues = <TField extends DeepKeysOfArray<TFieldGroupData>>(
     field: TField,
     opts?: UpdateMetaOptions,
   ) => {
-    return this.form.clearFieldValues(this.getFormFieldName(field), opts)
+    return this.form.clearFieldValues(
+      this.getFormFieldName(field) as never,
+      opts,
+    )
   }
 
   /**

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -63,6 +63,12 @@ import type {
 } from './util-types'
 import type { Updater } from './utils'
 
+function getArrayFieldValue<TValue>(
+  value: TValue,
+): Array<ArrayElement<TValue>> {
+  return Array.isArray(value) ? value : []
+}
+
 /**
  * @private
  */
@@ -2721,7 +2727,7 @@ export class FormApi<
   ) => {
     this.setFieldValue(
       field,
-      (prev) => [...(Array.isArray(prev) ? prev : []), value] as any,
+      (prev) => [...getArrayFieldValue(prev), value] as any,
       options,
     )
 
@@ -2737,10 +2743,11 @@ export class FormApi<
     this.setFieldValue(
       field,
       (prev) => {
+        const previousValue = getArrayFieldValue(prev)
         return [
-          ...(prev as DeepValue<TFormData, TField>[]).slice(0, index),
+          ...previousValue.slice(0, index),
           value,
-          ...(prev as DeepValue<TFormData, TField>[]).slice(index),
+          ...previousValue.slice(index),
         ] as any
       },
       mergeOpts(options, { dontValidate: true }),
@@ -2772,7 +2779,7 @@ export class FormApi<
     this.setFieldValue(
       field,
       (prev) => {
-        return (prev as DeepValue<TFormData, TField>[]).map((d, i) =>
+        return getArrayFieldValue(prev).map((d, i) =>
           i === index ? value : d,
         ) as any
       },
@@ -2806,9 +2813,7 @@ export class FormApi<
     this.setFieldValue(
       field,
       (prev) => {
-        return (prev as DeepValue<TFormData, TField>[]).filter(
-          (_d, i) => i !== index,
-        ) as any
+        return getArrayFieldValue(prev).filter((_d, i) => i !== index) as any
       },
       mergeOpts(options, { dontValidate: true }),
     )
@@ -2841,9 +2846,16 @@ export class FormApi<
     this.setFieldValue(
       field,
       (prev: any) => {
-        const prev1 = prev[index1]!
-        const prev2 = prev[index2]!
-        return setBy(setBy(prev, `${index1}`, prev2), `${index2}`, prev1)
+        const previousValue = getArrayFieldValue(prev)
+        if (!previousValue.length) return previousValue as any
+
+        const prev1 = previousValue[index1]!
+        const prev2 = previousValue[index2]!
+        return setBy(
+          setBy(previousValue, `${index1}`, prev2),
+          `${index2}`,
+          prev1,
+        )
       },
       mergeOpts(options, { dontValidate: true }),
     )
@@ -2873,7 +2885,10 @@ export class FormApi<
     this.setFieldValue(
       field,
       (prev: any) => {
-        const next: any = [...prev]
+        const previousValue = getArrayFieldValue(prev)
+        if (!previousValue.length) return previousValue as any
+
+        const next: any = [...previousValue]
         next.splice(index2, 0, next.splice(index1, 1)[0])
         return next
       },

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -63,6 +63,9 @@ import type {
 } from './util-types'
 import type { Updater } from './utils'
 
+/**
+ * Returns array field values as arrays so optional or nullable array helpers can operate safely.
+ */
 function getArrayFieldValue<TValue>(
   value: TValue,
 ): Array<ArrayElement<TValue>> {

--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -54,7 +54,9 @@ import type {
   FormGroupState,
 } from './FormGroupApi'
 import type {
+  ArrayElement,
   DeepKeys,
+  DeepKeysOfArray,
   DeepKeysOfType,
   DeepValue,
   RejectPromiseValidator,
@@ -1890,7 +1892,7 @@ export class FormApi<
    * Validates the children of a specified array in the form starting from a given index until the end using the correct handlers for a given validation type.
    */
   validateArrayFieldsStartingFrom = async <
-    TField extends DeepKeysOfType<TFormData, any[]>,
+    TField extends DeepKeysOfArray<TFormData>,
   >(
     field: TField,
     index: number,
@@ -2712,11 +2714,9 @@ export class FormApi<
   /**
    * Pushes a value into an array field.
    */
-  pushFieldValue = <TField extends DeepKeysOfType<TFormData, any[]>>(
+  pushFieldValue = <TField extends DeepKeysOfArray<TFormData>>(
     field: TField,
-    value: DeepValue<TFormData, TField> extends any[]
-      ? DeepValue<TFormData, TField>[number]
-      : never,
+    value: ArrayElement<DeepValue<TFormData, TField>>,
     options?: UpdateMetaOptions,
   ) => {
     this.setFieldValue(
@@ -2728,12 +2728,10 @@ export class FormApi<
     metaHelper(this).bumpArrayVersion(field)
   }
 
-  insertFieldValue = async <TField extends DeepKeysOfType<TFormData, any[]>>(
+  insertFieldValue = async <TField extends DeepKeysOfArray<TFormData>>(
     field: TField,
     index: number,
-    value: DeepValue<TFormData, TField> extends any[]
-      ? DeepValue<TFormData, TField>[number]
-      : never,
+    value: ArrayElement<DeepValue<TFormData, TField>>,
     options?: UpdateMetaOptions,
   ) => {
     this.setFieldValue(
@@ -2765,12 +2763,10 @@ export class FormApi<
   /**
    * Replaces a value into an array field at the specified index.
    */
-  replaceFieldValue = async <TField extends DeepKeysOfType<TFormData, any[]>>(
+  replaceFieldValue = async <TField extends DeepKeysOfArray<TFormData>>(
     field: TField,
     index: number,
-    value: DeepValue<TFormData, TField> extends any[]
-      ? DeepValue<TFormData, TField>[number]
-      : never,
+    value: ArrayElement<DeepValue<TFormData, TField>>,
     options?: UpdateMetaOptions,
   ) => {
     this.setFieldValue(
@@ -2796,7 +2792,7 @@ export class FormApi<
   /**
    * Removes a value from an array field at the specified index.
    */
-  removeFieldValue = async <TField extends DeepKeysOfType<TFormData, any[]>>(
+  removeFieldValue = async <TField extends DeepKeysOfArray<TFormData>>(
     field: TField,
     index: number,
     options?: UpdateMetaOptions,
@@ -2836,7 +2832,7 @@ export class FormApi<
   /**
    * Swaps the values at the specified indices within an array field.
    */
-  swapFieldValues = <TField extends DeepKeysOfType<TFormData, any[]>>(
+  swapFieldValues = <TField extends DeepKeysOfArray<TFormData>>(
     field: TField,
     index1: number,
     index2: number,
@@ -2868,7 +2864,7 @@ export class FormApi<
   /**
    * Moves the value at the first specified index to the second specified index within an array field.
    */
-  moveFieldValues = <TField extends DeepKeysOfType<TFormData, any[]>>(
+  moveFieldValues = <TField extends DeepKeysOfArray<TFormData>>(
     field: TField,
     index1: number,
     index2: number,
@@ -2900,7 +2896,7 @@ export class FormApi<
   /**
    * Clear all values within an array field.
    */
-  clearFieldValues = <TField extends DeepKeysOfType<TFormData, any[]>>(
+  clearFieldValues = <TField extends DeepKeysOfArray<TFormData>>(
     field: TField,
     options?: UpdateMetaOptions,
   ) => {

--- a/packages/form-core/src/FormGroupApi.ts
+++ b/packages/form-core/src/FormGroupApi.ts
@@ -49,6 +49,7 @@ import type {
 import type { AsyncValidator, SyncValidator, Updater } from './utils'
 import type { ReadonlyStore } from '@tanstack/store'
 import type {
+  ArrayElement,
   DeepKeys,
   DeepKeysOfArray,
   DeepKeysOfType,
@@ -2239,7 +2240,7 @@ export class FormGroupApi<
 
   pushFieldValue = <TField extends DeepKeysOfArray<TParentData>>(
     field: TField,
-    value: any,
+    value: ArrayElement<DeepValue<TParentData, TField>>,
   ) => {
     return this.form.pushFieldValue(field as never, value)
   }
@@ -2247,7 +2248,7 @@ export class FormGroupApi<
   insertFieldValue = <TField extends DeepKeysOfArray<TParentData>>(
     field: TField,
     index: number,
-    value: any,
+    value: ArrayElement<DeepValue<TParentData, TField>>,
   ) => {
     return this.form.insertFieldValue(field as never, index, value)
   }
@@ -2255,7 +2256,7 @@ export class FormGroupApi<
   replaceFieldValue = <TField extends DeepKeysOfArray<TParentData>>(
     field: TField,
     index: number,
-    value: any,
+    value: ArrayElement<DeepValue<TParentData, TField>>,
   ) => {
     return this.form.replaceFieldValue(field as never, index, value)
   }

--- a/packages/form-core/src/FormGroupApi.ts
+++ b/packages/form-core/src/FormGroupApi.ts
@@ -50,6 +50,7 @@ import type { AsyncValidator, SyncValidator, Updater } from './utils'
 import type { ReadonlyStore } from '@tanstack/store'
 import type {
   DeepKeys,
+  DeepKeysOfArray,
   DeepKeysOfType,
   DeepValue,
   UnwrapOneLevelOfArray,
@@ -2184,13 +2185,17 @@ export class FormGroupApi<
   }
 
   validateArrayFieldsStartingFrom = <
-    TField extends DeepKeysOfType<TParentData, any[]>,
+    TField extends DeepKeysOfArray<TParentData>,
   >(
     field: TField,
     index: number,
     cause: ValidationCause,
   ) => {
-    return this.form.validateArrayFieldsStartingFrom(field, index, cause)
+    return this.form.validateArrayFieldsStartingFrom(
+      field as never,
+      index,
+      cause,
+    )
   }
 
   validateField = <TField extends DeepKeysOfType<TParentData, any>>(
@@ -2232,49 +2237,49 @@ export class FormGroupApi<
     return this.form.deleteField(field)
   }
 
-  pushFieldValue = <TField extends DeepKeysOfType<TParentData, any[]>>(
+  pushFieldValue = <TField extends DeepKeysOfArray<TParentData>>(
     field: TField,
     value: any,
   ) => {
-    return this.form.pushFieldValue(field, value)
+    return this.form.pushFieldValue(field as never, value)
   }
 
-  insertFieldValue = <TField extends DeepKeysOfType<TParentData, any[]>>(
-    field: TField,
-    index: number,
-    value: any,
-  ) => {
-    return this.form.insertFieldValue(field, index, value)
-  }
-
-  replaceFieldValue = <TField extends DeepKeysOfType<TParentData, any[]>>(
+  insertFieldValue = <TField extends DeepKeysOfArray<TParentData>>(
     field: TField,
     index: number,
     value: any,
   ) => {
-    return this.form.replaceFieldValue(field, index, value)
+    return this.form.insertFieldValue(field as never, index, value)
   }
 
-  swapFieldValues = <TField extends DeepKeysOfType<TParentData, any[]>>(
+  replaceFieldValue = <TField extends DeepKeysOfArray<TParentData>>(
+    field: TField,
+    index: number,
+    value: any,
+  ) => {
+    return this.form.replaceFieldValue(field as never, index, value)
+  }
+
+  swapFieldValues = <TField extends DeepKeysOfArray<TParentData>>(
     field: TField,
     index1: number,
     index2: number,
   ) => {
-    return this.form.swapFieldValues(field, index1, index2)
+    return this.form.swapFieldValues(field as never, index1, index2)
   }
 
-  moveFieldValues = <TField extends DeepKeysOfType<TParentData, any[]>>(
+  moveFieldValues = <TField extends DeepKeysOfArray<TParentData>>(
     field: TField,
     fromIndex: number,
     toIndex: number,
   ) => {
-    return this.form.moveFieldValues(field, fromIndex, toIndex)
+    return this.form.moveFieldValues(field as never, fromIndex, toIndex)
   }
 
-  clearFieldValues = <TField extends DeepKeysOfType<TParentData, any[]>>(
+  clearFieldValues = <TField extends DeepKeysOfArray<TParentData>>(
     field: TField,
   ) => {
-    return this.form.clearFieldValues(field)
+    return this.form.clearFieldValues(field as never)
   }
 
   resetField = <TField extends DeepKeysOfType<TParentData, any>>(
@@ -2283,11 +2288,11 @@ export class FormGroupApi<
     return this.form.resetField(field)
   }
 
-  removeFieldValue = <TField extends DeepKeysOfType<TParentData, any[]>>(
+  removeFieldValue = <TField extends DeepKeysOfArray<TParentData>>(
     field: TField,
     index: number,
   ) => {
-    return this.form.removeFieldValue(field, index)
+    return this.form.removeFieldValue(field as never, index)
   }
 
   areRelatedFieldsValid = () => {

--- a/packages/form-core/src/types.ts
+++ b/packages/form-core/src/types.ts
@@ -5,7 +5,9 @@ import type {
   FieldValidateOrFn,
 } from './FieldApi'
 import type {
+  ArrayElement,
   DeepKeys,
+  DeepKeysOfArray,
   DeepKeysOfType,
   DeepValue,
   UnwrapOneLevelOfArray,
@@ -186,9 +188,7 @@ export interface FormLikeAPI<TFormData, TSubmitMeta> {
   /**
    * Validates the children of a specified array in the form starting from a given index until the end using the correct handlers for a given validation type.
    */
-  validateArrayFieldsStartingFrom: <
-    TField extends DeepKeysOfType<TFormData, any[]>,
-  >(
+  validateArrayFieldsStartingFrom: <TField extends DeepKeysOfArray<TFormData>>(
     field: TField,
     index: number,
     cause: ValidationCause,
@@ -247,42 +247,36 @@ export interface FormLikeAPI<TFormData, TSubmitMeta> {
   /**
    * Pushes a value into an array field.
    */
-  pushFieldValue: <TField extends DeepKeysOfType<TFormData, any[]>>(
+  pushFieldValue: <TField extends DeepKeysOfArray<TFormData>>(
     field: TField,
-    value: DeepValue<TFormData, TField> extends any[]
-      ? DeepValue<TFormData, TField>[number]
-      : never,
+    value: ArrayElement<DeepValue<TFormData, TField>>,
     opts?: UpdateMetaOptions,
   ) => void
 
   /**
    * Insert a value into an array field at the specified index.
    */
-  insertFieldValue: <TField extends DeepKeysOfType<TFormData, any[]>>(
+  insertFieldValue: <TField extends DeepKeysOfArray<TFormData>>(
     field: TField,
     index: number,
-    value: DeepValue<TFormData, TField> extends any[]
-      ? DeepValue<TFormData, TField>[number]
-      : never,
+    value: ArrayElement<DeepValue<TFormData, TField>>,
     opts?: UpdateMetaOptions,
   ) => Promise<void>
 
   /**
    * Replaces a value into an array field at the specified index.
    */
-  replaceFieldValue: <TField extends DeepKeysOfType<TFormData, any[]>>(
+  replaceFieldValue: <TField extends DeepKeysOfArray<TFormData>>(
     field: TField,
     index: number,
-    value: DeepValue<TFormData, TField> extends any[]
-      ? DeepValue<TFormData, TField>[number]
-      : never,
+    value: ArrayElement<DeepValue<TFormData, TField>>,
     opts?: UpdateMetaOptions,
   ) => Promise<void>
 
   /**
    * Removes a value from an array field at the specified index.
    */
-  removeFieldValue: <TField extends DeepKeysOfType<TFormData, any[]>>(
+  removeFieldValue: <TField extends DeepKeysOfArray<TFormData>>(
     field: TField,
     index: number,
     opts?: UpdateMetaOptions,
@@ -291,7 +285,7 @@ export interface FormLikeAPI<TFormData, TSubmitMeta> {
   /**
    * Swaps the values at the specified indices within an array field.
    */
-  swapFieldValues: <TField extends DeepKeysOfType<TFormData, any[]>>(
+  swapFieldValues: <TField extends DeepKeysOfArray<TFormData>>(
     field: TField,
     index1: number,
     index2: number,
@@ -301,7 +295,7 @@ export interface FormLikeAPI<TFormData, TSubmitMeta> {
   /**
    * Moves the value at the first specified index to the second specified index within an array field.
    */
-  moveFieldValues: <TField extends DeepKeysOfType<TFormData, any[]>>(
+  moveFieldValues: <TField extends DeepKeysOfArray<TFormData>>(
     field: TField,
     index1: number,
     index2: number,
@@ -311,7 +305,7 @@ export interface FormLikeAPI<TFormData, TSubmitMeta> {
   /**
    * Clear all values within an array field.
    */
-  clearFieldValues: <TField extends DeepKeysOfType<TFormData, any[]>>(
+  clearFieldValues: <TField extends DeepKeysOfArray<TFormData>>(
     field: TField,
     opts?: UpdateMetaOptions,
   ) => void

--- a/packages/form-core/src/util-types.ts
+++ b/packages/form-core/src/util-types.ts
@@ -197,6 +197,24 @@ export type DeepKeysOfType<TData, TValue> = Extract<
 >['key']
 
 /**
+ * The keys of an object or array, deeply nested and only with a nullable or optional array value.
+ */
+export type DeepKeysOfArray<TData> =
+  DeepKeysAndValues<TData> extends infer TKeyAndValue
+    ? TKeyAndValue extends AnyDeepKeyAndValue<string, any>
+      ? NonNullable<TKeyAndValue['value']> extends any[]
+        ? TKeyAndValue['key']
+        : never
+      : never
+    : never
+
+/**
+ * The item type of a nullable or optional array.
+ */
+export type ArrayElement<T> =
+  NonNullable<T> extends (infer TElement)[] ? TElement : never
+
+/**
  * Maps the deep keys of TFormData to the shallow keys of TFieldGroupData.
  *  Since using template strings as keys is impractical, it relies on shallow keys only.
  */

--- a/packages/form-core/tests/FieldApi.test-d.ts
+++ b/packages/form-core/tests/FieldApi.test-d.ts
@@ -149,6 +149,56 @@ it('should type an array sub-field properly', () => {
   expectTypeOf(field.state.value).toEqualTypeOf<string>()
 })
 
+it('should allow optional array fields to use array value methods', () => {
+  type FormValues = {
+    aliases?: string[]
+    relatives: { name: string }[] | undefined
+    tags: string[] | null
+    title: string | undefined
+  }
+
+  const form = new FormApi({
+    defaultValues: {
+      title: undefined,
+    } as FormValues,
+  })
+
+  const aliases = new FieldApi({
+    form,
+    name: 'aliases',
+  })
+  const relatives = new FieldApi({
+    form,
+    name: 'relatives',
+  })
+  const tags = new FieldApi({
+    form,
+    name: 'tags',
+  })
+  const title = new FieldApi({
+    form,
+    name: 'title',
+  })
+
+  aliases.pushValue('alias')
+  aliases.insertValue(0, 'alias')
+  aliases.replaceValue(0, 'alias')
+  aliases.removeValue(0)
+  aliases.swapValues(0, 1)
+  aliases.moveValue(0, 1)
+  aliases.clearValues()
+
+  relatives.pushValue({ name: 'relative' })
+  relatives.insertValue(0, { name: 'relative' })
+  relatives.replaceValue(0, { name: 'relative' })
+  tags.pushValue('tag')
+
+  // @ts-expect-error non-array fields are still rejected
+  title.pushValue('title')
+  // @ts-expect-error array values must still match the array element type
+  aliases.pushValue(1)
+})
+
 it('should have the correct types returned from form validators', () => {
   const form = new FormApi({
     defaultValues: {

--- a/packages/form-core/tests/FieldGroupApi.test-d.ts
+++ b/packages/form-core/tests/FieldGroupApi.test-d.ts
@@ -168,6 +168,49 @@ describe('fieldGroupApi', () => {
     })
   })
 
+  it('should allow optional array fields for array-specific methods', () => {
+    type FormValues = {
+      nested: {
+        aliases?: string[]
+        title: string | undefined
+      }
+    }
+
+    const form = new FormApi({
+      defaultValues: {
+        nested: {
+          title: undefined,
+        },
+      } as FormValues,
+    })
+
+    const group = new FieldGroupApi({
+      form,
+      defaultValues: {
+        aliases: undefined,
+        title: undefined,
+      } as {
+        aliases?: string[]
+        title: string | undefined
+      },
+      fields: 'nested',
+    })
+
+    group.pushFieldValue('aliases', 'alias')
+    group.insertFieldValue('aliases', 0, 'alias')
+    group.replaceFieldValue('aliases', 0, 'alias')
+    group.removeFieldValue('aliases', 0)
+    group.swapFieldValues('aliases', 0, 1)
+    group.moveFieldValues('aliases', 0, 1)
+    group.clearFieldValues('aliases')
+    group.validateArrayFieldsStartingFrom('aliases', 0, 'change')
+
+    // @ts-expect-error non-array fields are still rejected
+    group.removeFieldValue('title', 0)
+    // @ts-expect-error array values must still match the array element type
+    group.pushFieldValue('aliases', 1)
+  })
+
   it('should allow null and undefined for fields when string', () => {
     type FormValues = {
       foo:

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -328,6 +328,67 @@ describe('form api', () => {
     ])
   })
 
+  it('should handle array helpers when optional array field values are missing', async () => {
+    type FormValues = {
+      optionalNames?: string[]
+      nullableNames: string[] | null
+    }
+
+    const form = new FormApi({
+      defaultValues: {
+        optionalNames: undefined,
+        nullableNames: null,
+      } as FormValues,
+    })
+    form.mount()
+
+    await form.insertFieldValue('optionalNames', 0, 'insert', {
+      dontValidate: true,
+    })
+    expect(form.getFieldValue('optionalNames')).toStrictEqual(['insert'])
+
+    form.setFieldValue('optionalNames', undefined)
+    await form.replaceFieldValue('optionalNames', 0, 'replace', {
+      dontValidate: true,
+    })
+    expect(form.getFieldValue('optionalNames')).toStrictEqual([])
+
+    form.setFieldValue('optionalNames', undefined)
+    await form.removeFieldValue('optionalNames', 0, { dontValidate: true })
+    expect(form.getFieldValue('optionalNames')).toStrictEqual([])
+
+    form.setFieldValue('optionalNames', undefined)
+    form.swapFieldValues('optionalNames', 0, 1, { dontValidate: true })
+    expect(form.getFieldValue('optionalNames')).toStrictEqual([])
+
+    form.setFieldValue('optionalNames', undefined)
+    form.moveFieldValues('optionalNames', 0, 1, { dontValidate: true })
+    expect(form.getFieldValue('optionalNames')).toStrictEqual([])
+
+    await form.insertFieldValue('nullableNames', 0, 'insert', {
+      dontValidate: true,
+    })
+    expect(form.getFieldValue('nullableNames')).toStrictEqual(['insert'])
+
+    form.setFieldValue('nullableNames', null)
+    await form.replaceFieldValue('nullableNames', 0, 'replace', {
+      dontValidate: true,
+    })
+    expect(form.getFieldValue('nullableNames')).toStrictEqual([])
+
+    form.setFieldValue('nullableNames', null)
+    await form.removeFieldValue('nullableNames', 0, { dontValidate: true })
+    expect(form.getFieldValue('nullableNames')).toStrictEqual([])
+
+    form.setFieldValue('nullableNames', null)
+    form.swapFieldValues('nullableNames', 0, 1, { dontValidate: true })
+    expect(form.getFieldValue('nullableNames')).toStrictEqual([])
+
+    form.setFieldValue('nullableNames', null)
+    form.moveFieldValues('nullableNames', 0, 1, { dontValidate: true })
+    expect(form.getFieldValue('nullableNames')).toStrictEqual([])
+  })
+
   it("should run onChange validation when pushing an array field's value", () => {
     const form = new FormApi({
       defaultValues: {

--- a/packages/form-core/tests/FormApi.test-d.ts
+++ b/packages/form-core/tests/FormApi.test-d.ts
@@ -282,6 +282,46 @@ it('should only allow array fields for array-specific methods', () => {
   const validate3 = form.validateArrayFieldsStartingFrom<RandomKeys>
 })
 
+it('should allow optional array fields for array-specific methods', () => {
+  type FormValues = {
+    aliases?: string[]
+    relatives: { name: string }[] | undefined
+    tags: string[] | null
+    title: string | undefined
+    empty: null
+    missing: undefined
+  }
+
+  const form = new FormApi({
+    defaultValues: {
+      title: undefined,
+    } as FormValues,
+  })
+
+  form.pushFieldValue('aliases', 'alias')
+  form.insertFieldValue('aliases', 0, 'alias')
+  form.replaceFieldValue('aliases', 0, 'alias')
+  form.removeFieldValue('aliases', 0)
+  form.swapFieldValues('aliases', 0, 1)
+  form.moveFieldValues('aliases', 0, 1)
+  form.clearFieldValues('aliases')
+  form.validateArrayFieldsStartingFrom('aliases', 0, 'change')
+
+  form.pushFieldValue('relatives', { name: 'relative' })
+  form.insertFieldValue('relatives', 0, { name: 'relative' })
+  form.replaceFieldValue('relatives', 0, { name: 'relative' })
+  form.pushFieldValue('tags', 'tag')
+
+  // @ts-expect-error non-array fields are still rejected
+  form.removeFieldValue('title', 0)
+  // @ts-expect-error null-only fields are still rejected
+  form.removeFieldValue('empty', 0)
+  // @ts-expect-error undefined-only fields are still rejected
+  form.removeFieldValue('missing', 0)
+  // @ts-expect-error array values must still match the array element type
+  form.pushFieldValue('aliases', 1)
+})
+
 it('should infer full field name union for form.resetField parameters', () => {
   type FormData = {
     shallow: string

--- a/packages/form-core/tests/FormGroupApi.test-d.ts
+++ b/packages/form-core/tests/FormGroupApi.test-d.ts
@@ -279,3 +279,45 @@ it('should type setValue updater properly', () => {
     return { name: 'updated' }
   })
 })
+
+it('should allow optional array fields for array-specific methods', () => {
+  type FormValues = {
+    step1: {
+      aliases?: string[]
+      relatives: { name: string }[] | undefined
+      title: string | undefined
+    }
+  }
+
+  const form = new FormApi({
+    defaultValues: {
+      step1: {
+        title: undefined,
+      },
+    } as FormValues,
+  })
+
+  const group = new FormGroupApi({
+    name: 'step1',
+    form,
+    onGroupSubmit: () => {},
+  })
+
+  group.pushFieldValue('step1.aliases', 'alias')
+  group.insertFieldValue('step1.aliases', 0, 'alias')
+  group.replaceFieldValue('step1.aliases', 0, 'alias')
+  group.removeFieldValue('step1.aliases', 0)
+  group.swapFieldValues('step1.aliases', 0, 1)
+  group.moveFieldValues('step1.aliases', 0, 1)
+  group.clearFieldValues('step1.aliases')
+  group.validateArrayFieldsStartingFrom('step1.aliases', 0, 'change')
+
+  group.pushFieldValue('step1.relatives', { name: 'relative' })
+  group.insertFieldValue('step1.relatives', 0, { name: 'relative' })
+  group.replaceFieldValue('step1.relatives', 0, { name: 'relative' })
+
+  // @ts-expect-error non-array fields are still rejected
+  group.removeFieldValue('step1.title', 0)
+  // @ts-expect-error array values must still match the array element type
+  group.pushFieldValue('step1.aliases', 1)
+})


### PR DESCRIPTION
## 🎯 Changes

Allows optional, nullable, and undefined-union array fields to use the form array helper APIs while preserving rejection for non-array fields and incorrect array element values.

Fix #1588

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/form/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Test verification (RED -> GREEN)

- Baseline on upstream/main: `CI=1 NX_DAEMON=false NX_CLOUD_ACCESS_TOKEN='' pnpm --filter form-core run test:types` passed.
- Tests-only patch on upstream/main: same command failed as expected with optional array helper arguments inferred as `never`.
- Patched branch: same command passed across TypeScript 5.4, 5.5, 5.6, 5.7, 5.8, and 5.9.

## Full local suite

`./run-ci.sh` passed locally after the final changes. It ran:

- `pnpm install --frozen-lockfile`
- `pnpm nx run-many --targets="test:sherif,test:knip,test:docs,test:eslint,test:lib,test:types,test:build,build" --all --parallel=3 --outputStyle=stream --skipRemoteCache`
- package/example build replay with remote cache disabled
- `pnpm exec prettier --experimental-cli --ignore-unknown "**/*" --check`

Independent review gate: no blockers reported.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Array field helpers now support optional, nullable, and undefined array fields.
  * Missing array values are safely treated as empty arrays during array operations.
  * Improved type checking ensures operations accept only valid array fields and element types across form, field, and field-group APIs.

* **Tests**
  * Added coverage for optional array behavior and rejection of invalid fields and value types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->